### PR TITLE
chore: update flake.lock & sources

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -61,7 +61,7 @@
     },
     "catppuccin_zsh_syntax_highlighting": {
         "cargoLocks": null,
-        "date": "2022-10-12",
+        "date": "2024-07-20",
         "extract": null,
         "name": "catppuccin_zsh_syntax_highlighting",
         "passthru": null,
@@ -73,15 +73,15 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "zsh-syntax-highlighting",
-            "rev": "06d519c20798f0ebe275fc3a8101841faaeee8ea",
-            "sha256": "sha256-Q7KmwUd9fblprL55W0Sf4g7lRcemnhjh4/v+TacJSfo=",
+            "rev": "7926c3d3e17d26b3779851a2255b95ee650bd928",
+            "sha256": "sha256-l6tztApzYpQ2/CiKuLBf8vI2imM6vPJuFdNDSEi7T/o=",
             "type": "github"
         },
-        "version": "06d519c20798f0ebe275fc3a8101841faaeee8ea"
+        "version": "7926c3d3e17d26b3779851a2255b95ee650bd928"
     },
     "dunst_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-04-07",
+        "date": "2024-07-20",
         "extract": null,
         "name": "dunst_catppuccin",
         "passthru": null,
@@ -93,15 +93,15 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "dunst",
-            "rev": "bfec91a5d0ab02a73a4615243feb5499d376831c",
-            "sha256": "sha256-xy99DpBrOKlP7DgKyPgbl4QGC+dnXnvkGlkIG0cmd2A=",
+            "rev": "f02cd2894411c9b4caa207cfd8ed6345f97c0455",
+            "sha256": "sha256-EadNqtF1m//blHkV660+d4YjDReVFU2Bzhs0Pb43jh4=",
             "type": "github"
         },
-        "version": "bfec91a5d0ab02a73a4615243feb5499d376831c"
+        "version": "f02cd2894411c9b4caa207cfd8ed6345f97c0455"
     },
     "fastfetch": {
         "cargoLocks": null,
-        "date": "2024-07-20",
+        "date": "2024-07-22",
         "extract": null,
         "name": "fastfetch",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "fastfetch-cli",
             "repo": "fastfetch",
-            "rev": "7a1b214ffee60e2a0e8e03f471bbdee9fc65589a",
-            "sha256": "sha256-UPJKRMPhFOlPdrtMpPUOWYXYCLGpdSWeOUcCBh1mYec=",
+            "rev": "b89eeaa95421c5c21e5927ab4ae8733cd03558e2",
+            "sha256": "sha256-LShS6JFTfWLK5WbJdOZucRBOCfShfQsc5PiSkstcnN8=",
             "type": "github"
         },
-        "version": "7a1b214ffee60e2a0e8e03f471bbdee9fc65589a"
+        "version": "b89eeaa95421c5c21e5927ab4ae8733cd03558e2"
     },
     "filen": {
         "cargoLocks": null,
@@ -156,7 +156,7 @@
     },
     "foot_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-06-06",
+        "date": "2024-07-20",
         "extract": null,
         "name": "foot_catppuccin",
         "passthru": null,
@@ -168,11 +168,11 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "foot",
-            "rev": "80756a4d63ea4fae4d0fdd793017370f8b8b12ac",
-            "sha256": "sha256-h6+7ln/i+FRSfWX2aSLhrxFO4mYJgH2pzzhe2Zz9Q4k=",
+            "rev": "17e2bdc8a8d854e8d390919579f87ab7d5f86e38",
+            "sha256": "sha256-L5/HvBe4jGTHNSCxFL+xRh8CKYO3NLJ0ksVJIQxjsZA=",
             "type": "github"
         },
-        "version": "80756a4d63ea4fae4d0fdd793017370f8b8b12ac"
+        "version": "17e2bdc8a8d854e8d390919579f87ab7d5f86e38"
     },
     "hyprland_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -39,39 +39,39 @@
   };
   catppuccin_zsh_syntax_highlighting = {
     pname = "catppuccin_zsh_syntax_highlighting";
-    version = "06d519c20798f0ebe275fc3a8101841faaeee8ea";
+    version = "7926c3d3e17d26b3779851a2255b95ee650bd928";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "zsh-syntax-highlighting";
-      rev = "06d519c20798f0ebe275fc3a8101841faaeee8ea";
+      rev = "7926c3d3e17d26b3779851a2255b95ee650bd928";
       fetchSubmodules = false;
-      sha256 = "sha256-Q7KmwUd9fblprL55W0Sf4g7lRcemnhjh4/v+TacJSfo=";
+      sha256 = "sha256-l6tztApzYpQ2/CiKuLBf8vI2imM6vPJuFdNDSEi7T/o=";
     };
-    date = "2022-10-12";
+    date = "2024-07-20";
   };
   dunst_catppuccin = {
     pname = "dunst_catppuccin";
-    version = "bfec91a5d0ab02a73a4615243feb5499d376831c";
+    version = "f02cd2894411c9b4caa207cfd8ed6345f97c0455";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "dunst";
-      rev = "bfec91a5d0ab02a73a4615243feb5499d376831c";
+      rev = "f02cd2894411c9b4caa207cfd8ed6345f97c0455";
       fetchSubmodules = false;
-      sha256 = "sha256-xy99DpBrOKlP7DgKyPgbl4QGC+dnXnvkGlkIG0cmd2A=";
+      sha256 = "sha256-EadNqtF1m//blHkV660+d4YjDReVFU2Bzhs0Pb43jh4=";
     };
-    date = "2024-04-07";
+    date = "2024-07-20";
   };
   fastfetch = {
     pname = "fastfetch";
-    version = "7a1b214ffee60e2a0e8e03f471bbdee9fc65589a";
+    version = "b89eeaa95421c5c21e5927ab4ae8733cd03558e2";
     src = fetchFromGitHub {
       owner = "fastfetch-cli";
       repo = "fastfetch";
-      rev = "7a1b214ffee60e2a0e8e03f471bbdee9fc65589a";
+      rev = "b89eeaa95421c5c21e5927ab4ae8733cd03558e2";
       fetchSubmodules = false;
-      sha256 = "sha256-UPJKRMPhFOlPdrtMpPUOWYXYCLGpdSWeOUcCBh1mYec=";
+      sha256 = "sha256-LShS6JFTfWLK5WbJdOZucRBOCfShfQsc5PiSkstcnN8=";
     };
-    date = "2024-07-20";
+    date = "2024-07-22";
   };
   filen = {
     pname = "filen";
@@ -94,15 +94,15 @@
   };
   foot_catppuccin = {
     pname = "foot_catppuccin";
-    version = "80756a4d63ea4fae4d0fdd793017370f8b8b12ac";
+    version = "17e2bdc8a8d854e8d390919579f87ab7d5f86e38";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "foot";
-      rev = "80756a4d63ea4fae4d0fdd793017370f8b8b12ac";
+      rev = "17e2bdc8a8d854e8d390919579f87ab7d5f86e38";
       fetchSubmodules = false;
-      sha256 = "sha256-h6+7ln/i+FRSfWX2aSLhrxFO4mYJgH2pzzhe2Zz9Q4k=";
+      sha256 = "sha256-L5/HvBe4jGTHNSCxFL+xRh8CKYO3NLJ0ksVJIQxjsZA=";
     };
-    date = "2024-06-06";
+    date = "2024-07-20";
   };
   hyprland_catppuccin = {
     pname = "hyprland_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -438,11 +438,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721135958,
-        "narHash": "sha256-H548rpPMsn25LDKn1PCFmPxmWlClJJGnvdzImHkqjuY=",
+        "lastModified": 1721534365,
+        "narHash": "sha256-XpZOkaSJKdOsz1wU6JfO59Rx2fqtcarQ0y6ndIOKNpI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afd2021bedff2de92dfce0e257a3d03ae65c603d",
+        "rev": "635563f245309ef5320f80c7ebcb89b2398d2949",
         "type": "github"
       },
       "original": {
@@ -482,11 +482,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1720958877,
-        "narHash": "sha256-ggCV3etL7W1X9kxhLPZP35+BBh1LgQybene+L/aeQaQ=",
+        "lastModified": 1721563874,
+        "narHash": "sha256-xsiynNj2qUbssiD5m+8ftWrGQflyOo5C4lPbqragiMc=",
         "owner": "nix-community",
         "repo": "lib-aggregate",
-        "rev": "6e56a6fd1d993eb02c991d449819f01340888e02",
+        "rev": "e0ea775feda9f162a153ee1ca8d93367dd0ee028",
         "type": "github"
       },
       "original": {
@@ -524,11 +524,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1720931326,
-        "narHash": "sha256-QHajV5BjfaMWbiOAJ/MGH+exXo+CjzUpkxxEtz0ZZ2k=",
+        "lastModified": 1721505437,
+        "narHash": "sha256-sZpyyf9EiRVyEA9vUVWNxu8yI9MU0nhlEuPBL3hvC60=",
         "owner": "nix-community",
         "repo": "nix-eval-jobs",
-        "rev": "c132534bc68eb48479a59a3116ee7ce0f16ce12b",
+        "rev": "2e522fb78d7613cecaf683875ab27b6c90e8a84f",
         "type": "github"
       },
       "original": {
@@ -564,11 +564,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1720926593,
-        "narHash": "sha256-fW6e27L6qY6s+TxInwrS2EXZZfhMAlaNqT0sWS49qMA=",
+        "lastModified": 1721531260,
+        "narHash": "sha256-O72uxk4gYFQDwNkoBioyrR3GK9EReZmexCStBaORMW8=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "5fe5b0cdf1268112dc96319388819b46dc051ef4",
+        "rev": "b6db9fd8dc59bb2ccb403f76d16ba8bbc1d5263d",
         "type": "github"
       },
       "original": {
@@ -604,11 +604,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1721438851,
-        "narHash": "sha256-IibYKORt9B5Ed7j10/hkpq5zoVy5+sRtg240C1uF84I=",
+        "lastModified": 1721611847,
+        "narHash": "sha256-3rbobc9ulSJD9qzICSpMccajd2BIMdPpfsounXr4ut4=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "6a3e362545f74d9ee3fc51628e2323ea8dc4c9be",
+        "rev": "b266f7f0ae30eda6c4fe0741aaf17076b9a9de5e",
         "type": "github"
       },
       "original": {
@@ -647,11 +647,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1720918433,
-        "narHash": "sha256-z3Lp++7k4l/3K4A+7v3cuHBNcm/vntGXgxElLH+INa4=",
+        "lastModified": 1721523216,
+        "narHash": "sha256-/NjnIKkBoqKdvOS8unooDg0HqMaRUwYLbyn0ntjEckQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "3b0b1763c0f0931deaa2980b7b146f8ae7a6a952",
+        "rev": "31a99025ce3784c20dd11dafa5260e80e314f59e",
         "type": "github"
       },
       "original": {
@@ -662,11 +662,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1721493195,
-        "narHash": "sha256-OYPp+wnFZGrKJZ/+CkUr4ch1FSzFMWRylvWHGTQvcb4=",
+        "lastModified": 1721667257,
+        "narHash": "sha256-6zcR7GUMB+8o1OAMmcUgNMztWBpCCl6y04nzHhk8vD4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30a7fb23bd2c7c6ed57d610d4cc856b8d6903f94",
+        "rev": "8e8c87bc74c1e6413b0b44a3067937a4f6f91b27",
         "type": "github"
       },
       "original": {
@@ -716,11 +716,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1721432204,
-        "narHash": "sha256-P+EcNbJfOAfSiTbgv0x3IDx+f0yZYRDAVOQvSeLNuBI=",
+        "lastModified": 1721566265,
+        "narHash": "sha256-o1thi0iay9AfkqkopNsPfc70bfHD+NcsKOs3IYwRk/A=",
         "owner": "nix-community",
         "repo": "nixpkgs-wayland",
-        "rev": "79fefa5cf958abe84266753de014126afbd33935",
+        "rev": "6d34f9c34bdab180fd15185c87a44b3bd11cb4c0",
         "type": "github"
       },
       "original": {
@@ -731,11 +731,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1720768451,
-        "narHash": "sha256-EYekUHJE2gxeo2pM/zM9Wlqw1Uw2XTJXOSAO79ksc4Y=",
+        "lastModified": 1721379653,
+        "narHash": "sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e7c39ea35c5cdd002cd4588b03a3fb9ece6fad9",
+        "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
         "type": "github"
       },
       "original": {
@@ -827,11 +827,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721490395,
-        "narHash": "sha256-+Dfesi/WXkFRi6isU6290Y4TC+fXX6WXzs/lpqW5wbc=",
+        "lastModified": 1721666469,
+        "narHash": "sha256-RSdiElnKDUFnHtiWzu5yMyXcyWBFxRjnyOVaObmawYQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c9927fe73cae0e1d11bd136a9e0e446af3623004",
+        "rev": "382e7f1785b5366449ccc971c471ebd271274580",
         "type": "github"
       },
       "original": {
@@ -924,11 +924,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721535083,
-        "narHash": "sha256-t50dw2gAU7WjAs9fxKiKGKPmZdOCWE0fR+g0S2lFd2c=",
+        "lastModified": 1721641566,
+        "narHash": "sha256-705wGFLkkU7C7/Gli/bNb+HBnj+c7j4a4s1nxgevJlQ=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "cc7056ff1b0a83b66abc130872e3d8fd88c3f30c",
+        "rev": "410281d206ae22b250f868e8e2a427df6784b196",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/afd2021bedff2de92dfce0e257a3d03ae65c603d?narHash=sha256-H548rpPMsn25LDKn1PCFmPxmWlClJJGnvdzImHkqjuY%3D' (2024-07-16)
  → 'github:nix-community/home-manager/635563f245309ef5320f80c7ebcb89b2398d2949?narHash=sha256-XpZOkaSJKdOsz1wU6JfO59Rx2fqtcarQ0y6ndIOKNpI%3D' (2024-07-21)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/5fe5b0cdf1268112dc96319388819b46dc051ef4?narHash=sha256-fW6e27L6qY6s%2BTxInwrS2EXZZfhMAlaNqT0sWS49qMA%3D' (2024-07-14)
  → 'github:nix-community/nix-index-database/b6db9fd8dc59bb2ccb403f76d16ba8bbc1d5263d?narHash=sha256-O72uxk4gYFQDwNkoBioyrR3GK9EReZmexCStBaORMW8%3D' (2024-07-21)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/7e7c39ea35c5cdd002cd4588b03a3fb9ece6fad9?narHash=sha256-EYekUHJE2gxeo2pM/zM9Wlqw1Uw2XTJXOSAO79ksc4Y%3D' (2024-07-12)
  → 'github:NixOS/nixpkgs/1d9c2c9b3e71b9ee663d11c5d298727dace8d374?narHash=sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0%3D' (2024-07-19)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/6a3e362545f74d9ee3fc51628e2323ea8dc4c9be?narHash=sha256-IibYKORt9B5Ed7j10/hkpq5zoVy5%2BsRtg240C1uF84I%3D' (2024-07-20)
  → 'github:nix-community/nix-vscode-extensions/b266f7f0ae30eda6c4fe0741aaf17076b9a9de5e?narHash=sha256-3rbobc9ulSJD9qzICSpMccajd2BIMdPpfsounXr4ut4%3D' (2024-07-22)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/30a7fb23bd2c7c6ed57d610d4cc856b8d6903f94?narHash=sha256-OYPp%2BwnFZGrKJZ/%2BCkUr4ch1FSzFMWRylvWHGTQvcb4%3D' (2024-07-20)
  → 'github:NixOS/nixpkgs/8e8c87bc74c1e6413b0b44a3067937a4f6f91b27?narHash=sha256-6zcR7GUMB%2B8o1OAMmcUgNMztWBpCCl6y04nzHhk8vD4%3D' (2024-07-22)
• Updated input 'nixpkgs-wayland':
    'github:nix-community/nixpkgs-wayland/79fefa5cf958abe84266753de014126afbd33935?narHash=sha256-P%2BEcNbJfOAfSiTbgv0x3IDx%2Bf0yZYRDAVOQvSeLNuBI%3D' (2024-07-19)
  → 'github:nix-community/nixpkgs-wayland/6d34f9c34bdab180fd15185c87a44b3bd11cb4c0?narHash=sha256-o1thi0iay9AfkqkopNsPfc70bfHD%2BNcsKOs3IYwRk/A%3D' (2024-07-21)
• Updated input 'nixpkgs-wayland/lib-aggregate':
    'github:nix-community/lib-aggregate/6e56a6fd1d993eb02c991d449819f01340888e02?narHash=sha256-ggCV3etL7W1X9kxhLPZP35%2BBBh1LgQybene%2BL/aeQaQ%3D' (2024-07-14)
  → 'github:nix-community/lib-aggregate/e0ea775feda9f162a153ee1ca8d93367dd0ee028?narHash=sha256-xsiynNj2qUbssiD5m%2B8ftWrGQflyOo5C4lPbqragiMc%3D' (2024-07-21)
• Updated input 'nixpkgs-wayland/lib-aggregate/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/3b0b1763c0f0931deaa2980b7b146f8ae7a6a952?narHash=sha256-z3Lp%2B%2B7k4l/3K4A%2B7v3cuHBNcm/vntGXgxElLH%2BINa4%3D' (2024-07-14)
  → 'github:nix-community/nixpkgs.lib/31a99025ce3784c20dd11dafa5260e80e314f59e?narHash=sha256-/NjnIKkBoqKdvOS8unooDg0HqMaRUwYLbyn0ntjEckQ%3D' (2024-07-21)
• Updated input 'nixpkgs-wayland/nix-eval-jobs':
    'github:nix-community/nix-eval-jobs/c132534bc68eb48479a59a3116ee7ce0f16ce12b?narHash=sha256-QHajV5BjfaMWbiOAJ/MGH%2BexXo%2BCjzUpkxxEtz0ZZ2k%3D' (2024-07-14)
  → 'github:nix-community/nix-eval-jobs/2e522fb78d7613cecaf683875ab27b6c90e8a84f?narHash=sha256-sZpyyf9EiRVyEA9vUVWNxu8yI9MU0nhlEuPBL3hvC60%3D' (2024-07-20)
• Updated input 'nur':
    'github:nix-community/NUR/c9927fe73cae0e1d11bd136a9e0e446af3623004?narHash=sha256-%2BDfesi/WXkFRi6isU6290Y4TC%2BfXX6WXzs/lpqW5wbc%3D' (2024-07-20)
  → 'github:nix-community/NUR/382e7f1785b5366449ccc971c471ebd271274580?narHash=sha256-RSdiElnKDUFnHtiWzu5yMyXcyWBFxRjnyOVaObmawYQ%3D' (2024-07-22)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/cc7056ff1b0a83b66abc130872e3d8fd88c3f30c?narHash=sha256-t50dw2gAU7WjAs9fxKiKGKPmZdOCWE0fR%2Bg0S2lFd2c%3D' (2024-07-21)
  → 'github:Gerg-L/spicetify-nix/410281d206ae22b250f868e8e2a427df6784b196?narHash=sha256-705wGFLkkU7C7/Gli/bNb%2BHBnj%2Bc7j4a4s1nxgevJlQ%3D
```

```
catppuccin_zsh_syntax_highlighting: 06d519c20798f0ebe275fc3a8101841faaeee8ea → 7926c3d3e17d26b3779851a2255b95ee650bd928
dunst_catppuccin: bfec91a5d0ab02a73a4615243feb5499d376831c → f02cd2894411c9b4caa207cfd8ed6345f97c0455
foot_catppuccin: 80756a4d63ea4fae4d0fdd793017370f8b8b12ac → 17e2bdc8a8d854e8d390919579f87ab7d5f86e38
fastfetch: 7a1b214ffee60e2a0e8e03f471bbdee9fc65589a → b89eeaa95421c5c21e5927ab4ae8733cd03558e2
```