### PR TITLE
chore: update flake.lock & sources (2024-07-27)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -101,7 +101,7 @@
     },
     "fastfetch": {
         "cargoLocks": null,
-        "date": "2024-07-22",
+        "date": "2024-07-28",
         "extract": null,
         "name": "fastfetch",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "fastfetch-cli",
             "repo": "fastfetch",
-            "rev": "b89eeaa95421c5c21e5927ab4ae8733cd03558e2",
-            "sha256": "sha256-LShS6JFTfWLK5WbJdOZucRBOCfShfQsc5PiSkstcnN8=",
+            "rev": "a102f0505c6ccf5522da03af0ce389b3eb6a91f2",
+            "sha256": "sha256-CY/8OgFQe2YlQ4jHOftVLnw+Fq63rLKS2R9OipHeDiA=",
             "type": "github"
         },
-        "version": "b89eeaa95421c5c21e5927ab4ae8733cd03558e2"
+        "version": "a102f0505c6ccf5522da03af0ce389b3eb6a91f2"
     },
     "filen": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -63,15 +63,15 @@
   };
   fastfetch = {
     pname = "fastfetch";
-    version = "b89eeaa95421c5c21e5927ab4ae8733cd03558e2";
+    version = "a102f0505c6ccf5522da03af0ce389b3eb6a91f2";
     src = fetchFromGitHub {
       owner = "fastfetch-cli";
       repo = "fastfetch";
-      rev = "b89eeaa95421c5c21e5927ab4ae8733cd03558e2";
+      rev = "a102f0505c6ccf5522da03af0ce389b3eb6a91f2";
       fetchSubmodules = false;
-      sha256 = "sha256-LShS6JFTfWLK5WbJdOZucRBOCfShfQsc5PiSkstcnN8=";
+      sha256 = "sha256-CY/8OgFQe2YlQ4jHOftVLnw+Fq63rLKS2R9OipHeDiA=";
     };
-    date = "2024-07-22";
+    date = "2024-07-28";
   };
   filen = {
     pname = "filen";

--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717408969,
-        "narHash": "sha256-Q0OEFqe35fZbbRPPRdrjTUUChKVhhWXz3T9ZSKmaoVY=",
+        "lastModified": 1721986491,
+        "narHash": "sha256-lVAlUOIPszv5HMYQGscskeGdRIYpTY6xrPfEok0hHgI=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "1ebbe68d57457c8cae98145410b164b5477761f4",
+        "rev": "cc8700135fb0740199ac248063f20c6b1a3c7e42",
         "type": "github"
       },
       "original": {
@@ -438,11 +438,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721534365,
-        "narHash": "sha256-XpZOkaSJKdOsz1wU6JfO59Rx2fqtcarQ0y6ndIOKNpI=",
+        "lastModified": 1722067813,
+        "narHash": "sha256-nxpzoKXwn+8RsxpxwD86mtEscOMw64ZD/vGSNWzGMlA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "635563f245309ef5320f80c7ebcb89b2398d2949",
+        "rev": "975b83ca560d17db51a66cb2b0dc0e44213eab27",
         "type": "github"
       },
       "original": {
@@ -604,11 +604,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1721611847,
-        "narHash": "sha256-3rbobc9ulSJD9qzICSpMccajd2BIMdPpfsounXr4ut4=",
+        "lastModified": 1722043670,
+        "narHash": "sha256-MiPeYwr+BjSlQqAhEWvZQGBCZFcKrPBaaobTTcEGMfU=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "b266f7f0ae30eda6c4fe0741aaf17076b9a9de5e",
+        "rev": "b435250a94728e8b07828570cb29fc5fc79b604f",
         "type": "github"
       },
       "original": {
@@ -662,11 +662,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1721667257,
-        "narHash": "sha256-6zcR7GUMB+8o1OAMmcUgNMztWBpCCl6y04nzHhk8vD4=",
+        "lastModified": 1722097510,
+        "narHash": "sha256-GUdWQKSk8EL1E3v1AnYqAF5Fo+WG7jdfHnS8X6M+QG0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8e8c87bc74c1e6413b0b44a3067937a4f6f91b27",
+        "rev": "f144faebf182043b121d06a5374599938a5f42b8",
         "type": "github"
       },
       "original": {
@@ -716,11 +716,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1721566265,
-        "narHash": "sha256-o1thi0iay9AfkqkopNsPfc70bfHD+NcsKOs3IYwRk/A=",
+        "lastModified": 1721990326,
+        "narHash": "sha256-AL/quEgRTlQ8OyLsbxlA6Q7jY2yxPJPvGvZRbAkhImY=",
         "owner": "nix-community",
         "repo": "nixpkgs-wayland",
-        "rev": "6d34f9c34bdab180fd15185c87a44b3bd11cb4c0",
+        "rev": "55a7d37710a2e19e56e18be6f7a3be305383ff69",
         "type": "github"
       },
       "original": {
@@ -779,11 +779,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1721379653,
-        "narHash": "sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0=",
+        "lastModified": 1721924956,
+        "narHash": "sha256-Sb1jlyRO+N8jBXEX9Pg9Z1Qb8Bw9QyOgLDNMEpmjZ2M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+        "rev": "5ad6a14c6bf098e98800b091668718c336effc95",
         "type": "github"
       },
       "original": {
@@ -811,11 +811,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1721379653,
-        "narHash": "sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0=",
+        "lastModified": 1721924956,
+        "narHash": "sha256-Sb1jlyRO+N8jBXEX9Pg9Z1Qb8Bw9QyOgLDNMEpmjZ2M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+        "rev": "5ad6a14c6bf098e98800b091668718c336effc95",
         "type": "github"
       },
       "original": {
@@ -827,11 +827,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721666469,
-        "narHash": "sha256-RSdiElnKDUFnHtiWzu5yMyXcyWBFxRjnyOVaObmawYQ=",
+        "lastModified": 1722095184,
+        "narHash": "sha256-SgPV4cR3UUczwzf+DOhMGoOWfnguy7/U6/JlCMZVvaw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "382e7f1785b5366449ccc971c471ebd271274580",
+        "rev": "2cee621f9f4a49361f929d914aa90ab645aeb704",
         "type": "github"
       },
       "original": {
@@ -924,11 +924,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721641566,
-        "narHash": "sha256-705wGFLkkU7C7/Gli/bNb+HBnj+c7j4a4s1nxgevJlQ=",
+        "lastModified": 1722053480,
+        "narHash": "sha256-DG1jdoSIcRLkQvCs63MSMJmssHTwm4zGOmP3hUtAzSY=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "410281d206ae22b250f868e8e2a427df6784b196",
+        "rev": "e954f700aeaeb1b4df261c68c2391089f655fac8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 30

Flakes Changelog:
```
• Updated input 'devshell':
    'github:numtide/devshell/1ebbe68d57457c8cae98145410b164b5477761f4' (2024-06-03)
  → 'github:numtide/devshell/cc8700135fb0740199ac248063f20c6b1a3c7e42' (2024-07-26)
• Updated input 'home-manager':
    'github:nix-community/home-manager/635563f245309ef5320f80c7ebcb89b2398d2949' (2024-07-21)
  → 'github:nix-community/home-manager/975b83ca560d17db51a66cb2b0dc0e44213eab27' (2024-07-27)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/b266f7f0ae30eda6c4fe0741aaf17076b9a9de5e' (2024-07-22)
  → 'github:nix-community/nix-vscode-extensions/b435250a94728e8b07828570cb29fc5fc79b604f' (2024-07-27)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/1d9c2c9b3e71b9ee663d11c5d298727dace8d374' (2024-07-19)
  → 'github:NixOS/nixpkgs/5ad6a14c6bf098e98800b091668718c336effc95' (2024-07-25)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/8e8c87bc74c1e6413b0b44a3067937a4f6f91b27' (2024-07-22)
  → 'github:NixOS/nixpkgs/f144faebf182043b121d06a5374599938a5f42b8' (2024-07-27)
• Updated input 'nixpkgs-wayland':
    'github:nix-community/nixpkgs-wayland/6d34f9c34bdab180fd15185c87a44b3bd11cb4c0' (2024-07-21)
  → 'github:nix-community/nixpkgs-wayland/55a7d37710a2e19e56e18be6f7a3be305383ff69' (2024-07-26)
• Updated input 'nixpkgs-wayland/nixpkgs':
    'github:nixos/nixpkgs/1d9c2c9b3e71b9ee663d11c5d298727dace8d374' (2024-07-19)
  → 'github:nixos/nixpkgs/5ad6a14c6bf098e98800b091668718c336effc95' (2024-07-25)
• Updated input 'nur':
    'github:nix-community/NUR/382e7f1785b5366449ccc971c471ebd271274580' (2024-07-22)
  → 'github:nix-community/NUR/2cee621f9f4a49361f929d914aa90ab645aeb704' (2024-07-27)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/410281d206ae22b250f868e8e2a427df6784b196' (2024-07-22)
  → 'github:Gerg-L/spicetify-nix/e954f700aeaeb1b4df261c68c2391089f655fac8' (2024-07-27)
```

Sources Changelog:
```
fastfetch: b89eeaa95421c5c21e5927ab4ae8733cd03558e2 → a102f0505c6ccf5522da03af0ce389b3eb6a91f2
```
