### PR TITLE
chore: update flake.lock & sources (2024-08-03)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "arr_scripts": {
         "cargoLocks": null,
-        "date": "2024-07-11",
+        "date": "2024-08-01",
         "extract": null,
         "name": "arr_scripts",
         "passthru": null,
@@ -13,11 +13,11 @@
             "name": null,
             "owner": "RandomNinjaAtk",
             "repo": "arr-scripts",
-            "rev": "0965f6b2c524582fbe726860762b1297da68b732",
-            "sha256": "sha256-EDvocGeA1/4QJnlARH2gWPbf74gMUA1UVZEjkf6JPZM=",
+            "rev": "193f168511117d34b4ac6c3e371b878dd8f3fda0",
+            "sha256": "sha256-NmjpCEgn4E3Bf9NSRDZOnWmlj8DmoMJUDNI0oxSxLbo=",
             "type": "github"
         },
-        "version": "0965f6b2c524582fbe726860762b1297da68b732"
+        "version": "193f168511117d34b4ac6c3e371b878dd8f3fda0"
     },
     "bottom_catppuccin": {
         "cargoLocks": null,
@@ -101,7 +101,7 @@
     },
     "fastfetch": {
         "cargoLocks": null,
-        "date": "2024-07-28",
+        "date": "2024-08-03",
         "extract": null,
         "name": "fastfetch",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "fastfetch-cli",
             "repo": "fastfetch",
-            "rev": "a102f0505c6ccf5522da03af0ce389b3eb6a91f2",
-            "sha256": "sha256-CY/8OgFQe2YlQ4jHOftVLnw+Fq63rLKS2R9OipHeDiA=",
+            "rev": "6b0db6fa746c3d5e2273cf76b6f7544f3a6585fe",
+            "sha256": "sha256-UgVcFtrKKaxtZp7iPtCwqc0TIgOGsghbNfHjIE1uKwE=",
             "type": "github"
         },
-        "version": "a102f0505c6ccf5522da03af0ce389b3eb6a91f2"
+        "version": "6b0db6fa746c3d5e2273cf76b6f7544f3a6585fe"
     },
     "filen": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,15 +3,15 @@
 {
   arr_scripts = {
     pname = "arr_scripts";
-    version = "0965f6b2c524582fbe726860762b1297da68b732";
+    version = "193f168511117d34b4ac6c3e371b878dd8f3fda0";
     src = fetchFromGitHub {
       owner = "RandomNinjaAtk";
       repo = "arr-scripts";
-      rev = "0965f6b2c524582fbe726860762b1297da68b732";
+      rev = "193f168511117d34b4ac6c3e371b878dd8f3fda0";
       fetchSubmodules = false;
-      sha256 = "sha256-EDvocGeA1/4QJnlARH2gWPbf74gMUA1UVZEjkf6JPZM=";
+      sha256 = "sha256-NmjpCEgn4E3Bf9NSRDZOnWmlj8DmoMJUDNI0oxSxLbo=";
     };
-    date = "2024-07-11";
+    date = "2024-08-01";
   };
   bottom_catppuccin = {
     pname = "bottom_catppuccin";
@@ -63,15 +63,15 @@
   };
   fastfetch = {
     pname = "fastfetch";
-    version = "a102f0505c6ccf5522da03af0ce389b3eb6a91f2";
+    version = "6b0db6fa746c3d5e2273cf76b6f7544f3a6585fe";
     src = fetchFromGitHub {
       owner = "fastfetch-cli";
       repo = "fastfetch";
-      rev = "a102f0505c6ccf5522da03af0ce389b3eb6a91f2";
+      rev = "6b0db6fa746c3d5e2273cf76b6f7544f3a6585fe";
       fetchSubmodules = false;
-      sha256 = "sha256-CY/8OgFQe2YlQ4jHOftVLnw+Fq63rLKS2R9OipHeDiA=";
+      sha256 = "sha256-UgVcFtrKKaxtZp7iPtCwqc0TIgOGsghbNfHjIE1uKwE=";
     };
-    date = "2024-07-28";
+    date = "2024-08-03";
   };
   filen = {
     pname = "filen";

--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1720546205,
-        "narHash": "sha256-boCXsjYVxDviyzoEyAk624600f3ZBo/DKtUdvMTpbGY=",
+        "lastModified": 1722339003,
+        "narHash": "sha256-ZeS51uJI30ehNkcZ4uKqT4ZDARPyqrHADSKAwv5vVCU=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "de96bd907d5fbc3b14fc33ad37d1b9a3cb15edc6",
+        "rev": "3f1dae074a12feb7327b4bf43cbac0d124488bb7",
         "type": "github"
       },
       "original": {
@@ -82,17 +82,16 @@
     },
     "devshell": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1721986491,
-        "narHash": "sha256-lVAlUOIPszv5HMYQGscskeGdRIYpTY6xrPfEok0hHgI=",
+        "lastModified": 1722113426,
+        "narHash": "sha256-Yo/3loq572A8Su6aY5GP56knpuKYRvM2a1meP9oJZCw=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "cc8700135fb0740199ac248063f20c6b1a3c7e42",
+        "rev": "67cce7359e4cd3c45296fb4aaf6a19e2a9c757ae",
         "type": "github"
       },
       "original": {
@@ -201,11 +200,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
         "type": "github"
       },
       "original": {
@@ -262,24 +261,6 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
         "lastModified": 1681202837,
         "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
@@ -293,9 +274,9 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
+    "flake-utils_2": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1701680307,
@@ -303,6 +284,24 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -332,24 +331,6 @@
     "flake-utils_5": {
       "inputs": {
         "systems": "systems_6"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_6": {
-      "inputs": {
-        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -438,11 +419,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722067813,
-        "narHash": "sha256-nxpzoKXwn+8RsxpxwD86mtEscOMw64ZD/vGSNWzGMlA=",
+        "lastModified": 1722630065,
+        "narHash": "sha256-QfM/9BMRkCmgWzrPDK+KbgJOUlSJnfX4OvsUupEUZvA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "975b83ca560d17db51a66cb2b0dc0e44213eab27",
+        "rev": "afc892db74d65042031a093adb6010c4c3378422",
         "type": "github"
       },
       "original": {
@@ -456,7 +437,7 @@
         "crane": "crane",
         "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts_2",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "rust-overlay": "rust-overlay"
@@ -478,15 +459,15 @@
     },
     "lib-aggregate": {
       "inputs": {
-        "flake-utils": "flake-utils_6",
+        "flake-utils": "flake-utils_5",
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1721563874,
-        "narHash": "sha256-xsiynNj2qUbssiD5m+8ftWrGQflyOo5C4lPbqragiMc=",
+        "lastModified": 1722168631,
+        "narHash": "sha256-16XBXW86ceQC+jRx7feCREZo696kvIzpKYmN2LnKfaE=",
         "owner": "nix-community",
         "repo": "lib-aggregate",
-        "rev": "e0ea775feda9f162a153ee1ca8d93367dd0ee028",
+        "rev": "4ce8efe904950cd85bda9624ff1c2ec55fe2ab6f",
         "type": "github"
       },
       "original": {
@@ -497,7 +478,7 @@
     },
     "menucalc": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -564,11 +545,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1721531260,
-        "narHash": "sha256-O72uxk4gYFQDwNkoBioyrR3GK9EReZmexCStBaORMW8=",
+        "lastModified": 1722136042,
+        "narHash": "sha256-x3FmT4QSyK28itMiR5zfYhUrG5nY+2dv+AIcKfmSp5A=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "b6db9fd8dc59bb2ccb403f76d16ba8bbc1d5263d",
+        "rev": "c0ca47e8523b578464014961059999d8eddd4aae",
         "type": "github"
       },
       "original": {
@@ -580,15 +561,15 @@
     "nix-ld-rs": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1721394956,
-        "narHash": "sha256-VnayJVKngasaNNiMlBhkeA//+V9EpEuT/mkOsFUbFDg=",
+        "lastModified": 1722634972,
+        "narHash": "sha256-34OfOf0A0v0T4iWuZ2hI6YIZedwXkPsGtNfbac3fR0s=",
         "owner": "nix-community",
         "repo": "nix-ld-rs",
-        "rev": "2f1fe38bc69d2400652e0848d9d2ce2955a39cf6",
+        "rev": "ad90f105e8fbaa0b0c87f464b862008598a903ea",
         "type": "github"
       },
       "original": {
@@ -600,15 +581,15 @@
     "nix-vscode-extensions": {
       "inputs": {
         "flake-compat": "flake-compat_4",
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1722043670,
-        "narHash": "sha256-MiPeYwr+BjSlQqAhEWvZQGBCZFcKrPBaaobTTcEGMfU=",
+        "lastModified": 1722648499,
+        "narHash": "sha256-GRZDqWF+q3hFiVv4+B5uxAoxhyoGipagt8jiUOtJFkY=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "b435250a94728e8b07828570cb29fc5fc79b604f",
+        "rev": "a6df283f4762b079b4d09b25acb1d9bd95f6a472",
         "type": "github"
       },
       "original": {
@@ -635,23 +616,23 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1719876945,
-        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "lastModified": 1722555339,
+        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
       }
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1721523216,
-        "narHash": "sha256-/NjnIKkBoqKdvOS8unooDg0HqMaRUwYLbyn0ntjEckQ=",
+        "lastModified": 1722128034,
+        "narHash": "sha256-L8rwzYPsLo/TYtydPJoQyYOfetuiyQYnTWYcyB8UE/s=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "31a99025ce3784c20dd11dafa5260e80e314f59e",
+        "rev": "d15f6f6021693898fcd2c6a9bb13707383da9bbc",
         "type": "github"
       },
       "original": {
@@ -662,11 +643,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1722097510,
-        "narHash": "sha256-GUdWQKSk8EL1E3v1AnYqAF5Fo+WG7jdfHnS8X6M+QG0=",
+        "lastModified": 1722702659,
+        "narHash": "sha256-kXk9KIWE0dKAp9TjiJcrfkY6JovQHg23P6ODozNJP90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f144faebf182043b121d06a5374599938a5f42b8",
+        "rev": "a3a5c12964705412d8b6758901d4d65b03bac357",
         "type": "github"
       },
       "original": {
@@ -716,11 +697,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1721990326,
-        "narHash": "sha256-AL/quEgRTlQ8OyLsbxlA6Q7jY2yxPJPvGvZRbAkhImY=",
+        "lastModified": 1722698332,
+        "narHash": "sha256-jEH9aEYo5aw+Ean+rWHkHgQsmKu5Dlx5Uj8ZShds7qw=",
         "owner": "nix-community",
         "repo": "nixpkgs-wayland",
-        "rev": "55a7d37710a2e19e56e18be6f7a3be305383ff69",
+        "rev": "3b5cf5b3226f3e9b89eee7c3e3451acbaf1cc469",
         "type": "github"
       },
       "original": {
@@ -731,11 +712,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1721379653,
-        "narHash": "sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0=",
+        "lastModified": 1722062969,
+        "narHash": "sha256-QOS0ykELUmPbrrUGmegAUlpmUFznDQeR4q7rFhl8eQg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+        "rev": "b73c2221a46c13557b1b3be9c2070cc42cf01eb3",
         "type": "github"
       },
       "original": {
@@ -779,11 +760,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1721924956,
-        "narHash": "sha256-Sb1jlyRO+N8jBXEX9Pg9Z1Qb8Bw9QyOgLDNMEpmjZ2M=",
+        "lastModified": 1722421184,
+        "narHash": "sha256-/DJBI6trCeVnasdjUo9pbnodCLZcFqnVZiLUfqLH4jA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ad6a14c6bf098e98800b091668718c336effc95",
+        "rev": "9f918d616c5321ad374ae6cb5ea89c9e04bf3e58",
         "type": "github"
       },
       "original": {
@@ -811,11 +792,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1721924956,
-        "narHash": "sha256-Sb1jlyRO+N8jBXEX9Pg9Z1Qb8Bw9QyOgLDNMEpmjZ2M=",
+        "lastModified": 1722421184,
+        "narHash": "sha256-/DJBI6trCeVnasdjUo9pbnodCLZcFqnVZiLUfqLH4jA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ad6a14c6bf098e98800b091668718c336effc95",
+        "rev": "9f918d616c5321ad374ae6cb5ea89c9e04bf3e58",
         "type": "github"
       },
       "original": {
@@ -827,11 +808,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722095184,
-        "narHash": "sha256-SgPV4cR3UUczwzf+DOhMGoOWfnguy7/U6/JlCMZVvaw=",
+        "lastModified": 1722700024,
+        "narHash": "sha256-yjiLjm6vqcLZ2QPILQBhX/FNBwqDwqEK4uU+uwgOwZs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2cee621f9f4a49361f929d914aa90ab645aeb704",
+        "rev": "b4345d37c5d51a68e1faf7ad63b365e6d239b4ef",
         "type": "github"
       },
       "original": {
@@ -888,7 +869,7 @@
         "nixpkgs-wayland": "nixpkgs-wayland",
         "nur": "nur",
         "spicetify-nix": "spicetify-nix",
-        "systems": "systems_8"
+        "systems": "systems_7"
       }
     },
     "rust-overlay": {
@@ -924,11 +905,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722053480,
-        "narHash": "sha256-DG1jdoSIcRLkQvCs63MSMJmssHTwm4zGOmP3hUtAzSY=",
+        "lastModified": 1722658348,
+        "narHash": "sha256-LUph10KC5Oc3q/htlCBb5/OgrPoOsR7XivohLROTJek=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "e954f700aeaeb1b4df261c68c2391089f655fac8",
+        "rev": "28b70e64a53207a5382e8fe112a66fe8745b635a",
         "type": "github"
       },
       "original": {
@@ -1028,21 +1009,6 @@
       }
     },
     "systems_7": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_8": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
Automated Pull Request for Week 31

Flakes Changelog:
```
• Updated input 'agenix':
    'github:ryantm/agenix/de96bd907d5fbc3b14fc33ad37d1b9a3cb15edc6' (2024-07-09)
  → 'github:ryantm/agenix/3f1dae074a12feb7327b4bf43cbac0d124488bb7' (2024-07-30)
• Updated input 'devshell':
    'github:numtide/devshell/cc8700135fb0740199ac248063f20c6b1a3c7e42' (2024-07-26)
  → 'github:numtide/devshell/67cce7359e4cd3c45296fb4aaf6a19e2a9c757ae' (2024-07-27)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/9227223f6d922fee3c7b190b2cc238a99527bbb7' (2024-07-03)
  → 'github:hercules-ci/flake-parts/8471fe90ad337a8074e957b69ca4d0089218391d' (2024-08-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz?narHash=sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI%3D' (2024-07-01)
  → 'https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz?narHash=sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q%3D' (2024-08-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/975b83ca560d17db51a66cb2b0dc0e44213eab27' (2024-07-27)
  → 'github:nix-community/home-manager/afc892db74d65042031a093adb6010c4c3378422' (2024-08-02)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/b6db9fd8dc59bb2ccb403f76d16ba8bbc1d5263d' (2024-07-21)
  → 'github:nix-community/nix-index-database/c0ca47e8523b578464014961059999d8eddd4aae' (2024-07-28)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/1d9c2c9b3e71b9ee663d11c5d298727dace8d374' (2024-07-19)
  → 'github:NixOS/nixpkgs/b73c2221a46c13557b1b3be9c2070cc42cf01eb3' (2024-07-27)
• Updated input 'nix-ld-rs':
    'github:nix-community/nix-ld-rs/2f1fe38bc69d2400652e0848d9d2ce2955a39cf6' (2024-07-19)
  → 'github:nix-community/nix-ld-rs/ad90f105e8fbaa0b0c87f464b862008598a903ea' (2024-08-02)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/b435250a94728e8b07828570cb29fc5fc79b604f' (2024-07-27)
  → 'github:nix-community/nix-vscode-extensions/a6df283f4762b079b4d09b25acb1d9bd95f6a472' (2024-08-03)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/5ad6a14c6bf098e98800b091668718c336effc95' (2024-07-25)
  → 'github:NixOS/nixpkgs/9f918d616c5321ad374ae6cb5ea89c9e04bf3e58' (2024-07-31)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/f144faebf182043b121d06a5374599938a5f42b8' (2024-07-27)
  → 'github:NixOS/nixpkgs/a3a5c12964705412d8b6758901d4d65b03bac357' (2024-08-03)
• Updated input 'nixpkgs-wayland':
    'github:nix-community/nixpkgs-wayland/55a7d37710a2e19e56e18be6f7a3be305383ff69' (2024-07-26)
  → 'github:nix-community/nixpkgs-wayland/3b5cf5b3226f3e9b89eee7c3e3451acbaf1cc469' (2024-08-03)
• Updated input 'nixpkgs-wayland/lib-aggregate':
    'github:nix-community/lib-aggregate/e0ea775feda9f162a153ee1ca8d93367dd0ee028' (2024-07-21)
  → 'github:nix-community/lib-aggregate/4ce8efe904950cd85bda9624ff1c2ec55fe2ab6f' (2024-07-28)
• Updated input 'nixpkgs-wayland/lib-aggregate/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/31a99025ce3784c20dd11dafa5260e80e314f59e' (2024-07-21)
  → 'github:nix-community/nixpkgs.lib/d15f6f6021693898fcd2c6a9bb13707383da9bbc' (2024-07-28)
• Updated input 'nixpkgs-wayland/nixpkgs':
    'github:nixos/nixpkgs/5ad6a14c6bf098e98800b091668718c336effc95' (2024-07-25)
  → 'github:nixos/nixpkgs/9f918d616c5321ad374ae6cb5ea89c9e04bf3e58' (2024-07-31)
• Updated input 'nur':
    'github:nix-community/NUR/2cee621f9f4a49361f929d914aa90ab645aeb704' (2024-07-27)
  → 'github:nix-community/NUR/b4345d37c5d51a68e1faf7ad63b365e6d239b4ef' (2024-08-03)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/e954f700aeaeb1b4df261c68c2391089f655fac8' (2024-07-27)
  → 'github:Gerg-L/spicetify-nix/28b70e64a53207a5382e8fe112a66fe8745b635a' (2024-08-03)
```

Sources Changelog:
```
arr_scripts: 0965f6b2c524582fbe726860762b1297da68b732 → 193f168511117d34b4ac6c3e371b878dd8f3fda0
fastfetch: a102f0505c6ccf5522da03af0ce389b3eb6a91f2 → 6b0db6fa746c3d5e2273cf76b6f7544f3a6585fe
```
