### PR TITLE
chore: update flake.lock & sources (2024-08-10)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "arr_scripts": {
         "cargoLocks": null,
-        "date": "2024-08-01",
+        "date": "2024-08-08",
         "extract": null,
         "name": "arr_scripts",
         "passthru": null,
@@ -13,15 +13,15 @@
             "name": null,
             "owner": "RandomNinjaAtk",
             "repo": "arr-scripts",
-            "rev": "193f168511117d34b4ac6c3e371b878dd8f3fda0",
-            "sha256": "sha256-NmjpCEgn4E3Bf9NSRDZOnWmlj8DmoMJUDNI0oxSxLbo=",
+            "rev": "8d9271f31d8282a3c7bbfc1eea008d631b5ce70e",
+            "sha256": "sha256-kUcmeeHoCHMQuRrtOrLPrpvpW0LmRf2smbzncQIIC9Y=",
             "type": "github"
         },
-        "version": "193f168511117d34b4ac6c3e371b878dd8f3fda0"
+        "version": "8d9271f31d8282a3c7bbfc1eea008d631b5ce70e"
     },
     "bottom_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-07-20",
+        "date": "2024-08-09",
         "extract": null,
         "name": "bottom_catppuccin",
         "passthru": null,
@@ -33,11 +33,11 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "bottom",
-            "rev": "bc8183af40ab06db07824dd37ec9a9cf8bd61616",
-            "sha256": "sha256-V2HnizZOaxyQRb/7nqXS/TyrGUbWZ0dwx0wo9xHJcgc=",
+            "rev": "f33104ec5be6cdde0559c2560f85130e48e10cff",
+            "sha256": "sha256-Ew2yryQFJRICy3RbtQnLMR5pphXPZp1PtaFVxAL2Eu4=",
             "type": "github"
         },
-        "version": "bc8183af40ab06db07824dd37ec9a9cf8bd61616"
+        "version": "f33104ec5be6cdde0559c2560f85130e48e10cff"
     },
     "calibre_catppuccin": {
         "cargoLocks": null,
@@ -101,7 +101,7 @@
     },
     "fastfetch": {
         "cargoLocks": null,
-        "date": "2024-08-03",
+        "date": "2024-08-10",
         "extract": null,
         "name": "fastfetch",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "fastfetch-cli",
             "repo": "fastfetch",
-            "rev": "6b0db6fa746c3d5e2273cf76b6f7544f3a6585fe",
-            "sha256": "sha256-UgVcFtrKKaxtZp7iPtCwqc0TIgOGsghbNfHjIE1uKwE=",
+            "rev": "55b1603b83bd7a8e84a863b98206fba8694c3922",
+            "sha256": "sha256-paExg3JVq0rCuJhiBQKqm7kIZzqEGCHboAgSkspnzeU=",
             "type": "github"
         },
-        "version": "6b0db6fa746c3d5e2273cf76b6f7544f3a6585fe"
+        "version": "55b1603b83bd7a8e84a863b98206fba8694c3922"
     },
     "filen": {
         "cargoLocks": null,
@@ -148,11 +148,11 @@
             "name": null,
             "owner": "rafaelmardojai",
             "repo": "firefox-gnome-theme",
-            "rev": "v128",
-            "sha256": "sha256-zB+Zd0V0ayKP/zg9n1MQ8J/Znwa49adylRftxuc694k=",
+            "rev": "v129",
+            "sha256": "sha256-MOE9NeU2i6Ws1GhGmppMnjOHkNLl2MQMJmGhaMzdoJM=",
             "type": "github"
         },
-        "version": "v128"
+        "version": "v129"
     },
     "foot_catppuccin": {
         "cargoLocks": null,
@@ -211,7 +211,7 @@
     },
     "hyprlock_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-06-17",
+        "date": "2024-08-06",
         "extract": null,
         "name": "hyprlock_catppuccin",
         "passthru": null,
@@ -223,11 +223,11 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "hyprlock",
-            "rev": "480c46f1f3fa9dd175f8f9611c0d4378324378a7",
-            "sha256": "sha256-Fisxyg5Q5C3dlZdIpgVDEpOUJYrqRMT6HJ+46XUVwI0=",
+            "rev": "958e70b1cd8799defd16dee070d07f977d4fd76b",
+            "sha256": "sha256-l4CbAUeb/Tg603QnZ/VWxuGqRBztpHN0HLX/h8ndc5w=",
             "type": "github"
         },
-        "version": "480c46f1f3fa9dd175f8f9611c0d4378324378a7"
+        "version": "958e70b1cd8799defd16dee070d07f977d4fd76b"
     },
     "nix-fast-build": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,27 +3,27 @@
 {
   arr_scripts = {
     pname = "arr_scripts";
-    version = "193f168511117d34b4ac6c3e371b878dd8f3fda0";
+    version = "8d9271f31d8282a3c7bbfc1eea008d631b5ce70e";
     src = fetchFromGitHub {
       owner = "RandomNinjaAtk";
       repo = "arr-scripts";
-      rev = "193f168511117d34b4ac6c3e371b878dd8f3fda0";
+      rev = "8d9271f31d8282a3c7bbfc1eea008d631b5ce70e";
       fetchSubmodules = false;
-      sha256 = "sha256-NmjpCEgn4E3Bf9NSRDZOnWmlj8DmoMJUDNI0oxSxLbo=";
+      sha256 = "sha256-kUcmeeHoCHMQuRrtOrLPrpvpW0LmRf2smbzncQIIC9Y=";
     };
-    date = "2024-08-01";
+    date = "2024-08-08";
   };
   bottom_catppuccin = {
     pname = "bottom_catppuccin";
-    version = "bc8183af40ab06db07824dd37ec9a9cf8bd61616";
+    version = "f33104ec5be6cdde0559c2560f85130e48e10cff";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "bottom";
-      rev = "bc8183af40ab06db07824dd37ec9a9cf8bd61616";
+      rev = "f33104ec5be6cdde0559c2560f85130e48e10cff";
       fetchSubmodules = false;
-      sha256 = "sha256-V2HnizZOaxyQRb/7nqXS/TyrGUbWZ0dwx0wo9xHJcgc=";
+      sha256 = "sha256-Ew2yryQFJRICy3RbtQnLMR5pphXPZp1PtaFVxAL2Eu4=";
     };
-    date = "2024-07-20";
+    date = "2024-08-09";
   };
   calibre_catppuccin = {
     pname = "calibre_catppuccin";
@@ -63,15 +63,15 @@
   };
   fastfetch = {
     pname = "fastfetch";
-    version = "6b0db6fa746c3d5e2273cf76b6f7544f3a6585fe";
+    version = "55b1603b83bd7a8e84a863b98206fba8694c3922";
     src = fetchFromGitHub {
       owner = "fastfetch-cli";
       repo = "fastfetch";
-      rev = "6b0db6fa746c3d5e2273cf76b6f7544f3a6585fe";
+      rev = "55b1603b83bd7a8e84a863b98206fba8694c3922";
       fetchSubmodules = false;
-      sha256 = "sha256-UgVcFtrKKaxtZp7iPtCwqc0TIgOGsghbNfHjIE1uKwE=";
+      sha256 = "sha256-paExg3JVq0rCuJhiBQKqm7kIZzqEGCHboAgSkspnzeU=";
     };
-    date = "2024-08-03";
+    date = "2024-08-10";
   };
   filen = {
     pname = "filen";
@@ -83,13 +83,13 @@
   };
   firefox-gnome-theme = {
     pname = "firefox-gnome-theme";
-    version = "v128";
+    version = "v129";
     src = fetchFromGitHub {
       owner = "rafaelmardojai";
       repo = "firefox-gnome-theme";
-      rev = "v128";
+      rev = "v129";
       fetchSubmodules = false;
-      sha256 = "sha256-zB+Zd0V0ayKP/zg9n1MQ8J/Znwa49adylRftxuc694k=";
+      sha256 = "sha256-MOE9NeU2i6Ws1GhGmppMnjOHkNLl2MQMJmGhaMzdoJM=";
     };
   };
   foot_catppuccin = {
@@ -126,15 +126,15 @@
   };
   hyprlock_catppuccin = {
     pname = "hyprlock_catppuccin";
-    version = "480c46f1f3fa9dd175f8f9611c0d4378324378a7";
+    version = "958e70b1cd8799defd16dee070d07f977d4fd76b";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "hyprlock";
-      rev = "480c46f1f3fa9dd175f8f9611c0d4378324378a7";
+      rev = "958e70b1cd8799defd16dee070d07f977d4fd76b";
       fetchSubmodules = false;
-      sha256 = "sha256-Fisxyg5Q5C3dlZdIpgVDEpOUJYrqRMT6HJ+46XUVwI0=";
+      sha256 = "sha256-l4CbAUeb/Tg603QnZ/VWxuGqRBztpHN0HLX/h8ndc5w=";
     };
-    date = "2024-06-17";
+    date = "2024-08-06";
   };
   nix-fast-build = {
     pname = "nix-fast-build";

--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1722339003,
-        "narHash": "sha256-ZeS51uJI30ehNkcZ4uKqT4ZDARPyqrHADSKAwv5vVCU=",
+        "lastModified": 1723293904,
+        "narHash": "sha256-b+uqzj+Wa6xgMS9aNbX4I+sXeb5biPDi39VgvSFqFvU=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "3f1dae074a12feb7327b4bf43cbac0d124488bb7",
+        "rev": "f6291c5935fdc4e0bef208cfc0dcab7e3f7a1c41",
         "type": "github"
       },
       "original": {
@@ -356,11 +356,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721042469,
-        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "lastModified": 1723202784,
+        "narHash": "sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "rev": "c7012d0c18567c889b948781bc74a501e92275d1",
         "type": "github"
       },
       "original": {
@@ -419,11 +419,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722630065,
-        "narHash": "sha256-QfM/9BMRkCmgWzrPDK+KbgJOUlSJnfX4OvsUupEUZvA=",
+        "lastModified": 1723015306,
+        "narHash": "sha256-jQnFEtH20/OsDPpx71ntZzGdRlpXhUENSQCGTjn//NA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afc892db74d65042031a093adb6010c4c3378422",
+        "rev": "b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1722168631,
-        "narHash": "sha256-16XBXW86ceQC+jRx7feCREZo696kvIzpKYmN2LnKfaE=",
+        "lastModified": 1722773431,
+        "narHash": "sha256-puSEio9yjWojIBDBts4BSGZ43rv1LzIevdYOKmW/Mjg=",
         "owner": "nix-community",
         "repo": "lib-aggregate",
-        "rev": "4ce8efe904950cd85bda9624ff1c2ec55fe2ab6f",
+        "rev": "04a4b4d84e02590715e753da3d35fb03cddc6425",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1722136042,
-        "narHash": "sha256-x3FmT4QSyK28itMiR5zfYhUrG5nY+2dv+AIcKfmSp5A=",
+        "lastModified": 1722740924,
+        "narHash": "sha256-UQPgA5d8azLZuDHZMPmvDszhuKF1Ek89SrTRtqsQ4Ss=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "c0ca47e8523b578464014961059999d8eddd4aae",
+        "rev": "97ca0a0fca0391de835f57e44f369a283e37890f",
         "type": "github"
       },
       "original": {
@@ -565,11 +565,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1722634972,
-        "narHash": "sha256-34OfOf0A0v0T4iWuZ2hI6YIZedwXkPsGtNfbac3fR0s=",
+        "lastModified": 1723041154,
+        "narHash": "sha256-xk2pmNz7rbwMQFi0QUVkqbe97VnAERJOMmJFY06rMFg=",
         "owner": "nix-community",
         "repo": "nix-ld-rs",
-        "rev": "ad90f105e8fbaa0b0c87f464b862008598a903ea",
+        "rev": "4ce415e564f9c606de91da58c391018e44166125",
         "type": "github"
       },
       "original": {
@@ -585,11 +585,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1722648499,
-        "narHash": "sha256-GRZDqWF+q3hFiVv4+B5uxAoxhyoGipagt8jiUOtJFkY=",
+        "lastModified": 1723253488,
+        "narHash": "sha256-VGwyu/8zoCYdB1e4zl0xjHdbp0LISMueC5rmzhD9Fws=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "a6df283f4762b079b4d09b25acb1d9bd95f6a472",
+        "rev": "cb5f0076c97bcdd4d0ecdb945f4816784fab4fa7",
         "type": "github"
       },
       "original": {
@@ -628,11 +628,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1722128034,
-        "narHash": "sha256-L8rwzYPsLo/TYtydPJoQyYOfetuiyQYnTWYcyB8UE/s=",
+        "lastModified": 1722732880,
+        "narHash": "sha256-do2Mfm3T6SR7a5A804RhjQ+JTsF5hk4JTPGjCTRM/m8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "d15f6f6021693898fcd2c6a9bb13707383da9bbc",
+        "rev": "8bebd4c74f368aacb047f0141db09ec6b339733c",
         "type": "github"
       },
       "original": {
@@ -643,11 +643,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1722702659,
-        "narHash": "sha256-kXk9KIWE0dKAp9TjiJcrfkY6JovQHg23P6ODozNJP90=",
+        "lastModified": 1723307941,
+        "narHash": "sha256-tC6zzSTLRgk9wNQzDYzVGrBjHUcfMDTWcf0WcQazEQU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a3a5c12964705412d8b6758901d4d65b03bac357",
+        "rev": "c4e73af4dd854035b481ac24bd1f2317cd5861d5",
         "type": "github"
       },
       "original": {
@@ -697,11 +697,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1722698332,
-        "narHash": "sha256-jEH9aEYo5aw+Ean+rWHkHgQsmKu5Dlx5Uj8ZShds7qw=",
+        "lastModified": 1723306957,
+        "narHash": "sha256-fuXCd2b3H+cnmkWSPc5VacpS+3QvZnU3fx2HOpAfH0g=",
         "owner": "nix-community",
         "repo": "nixpkgs-wayland",
-        "rev": "3b5cf5b3226f3e9b89eee7c3e3451acbaf1cc469",
+        "rev": "797dc6fb81746869b72537de50a2f3eee4d4a555",
         "type": "github"
       },
       "original": {
@@ -712,11 +712,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1722062969,
-        "narHash": "sha256-QOS0ykELUmPbrrUGmegAUlpmUFznDQeR4q7rFhl8eQg=",
+        "lastModified": 1722421184,
+        "narHash": "sha256-/DJBI6trCeVnasdjUo9pbnodCLZcFqnVZiLUfqLH4jA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b73c2221a46c13557b1b3be9c2070cc42cf01eb3",
+        "rev": "9f918d616c5321ad374ae6cb5ea89c9e04bf3e58",
         "type": "github"
       },
       "original": {
@@ -760,11 +760,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1722421184,
-        "narHash": "sha256-/DJBI6trCeVnasdjUo9pbnodCLZcFqnVZiLUfqLH4jA=",
+        "lastModified": 1723175592,
+        "narHash": "sha256-M0xJ3FbDUc4fRZ84dPGx5VvgFsOzds77KiBMW/mMTnI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9f918d616c5321ad374ae6cb5ea89c9e04bf3e58",
+        "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
         "type": "github"
       },
       "original": {
@@ -792,11 +792,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1722421184,
-        "narHash": "sha256-/DJBI6trCeVnasdjUo9pbnodCLZcFqnVZiLUfqLH4jA=",
+        "lastModified": 1723175592,
+        "narHash": "sha256-M0xJ3FbDUc4fRZ84dPGx5VvgFsOzds77KiBMW/mMTnI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f918d616c5321ad374ae6cb5ea89c9e04bf3e58",
+        "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
         "type": "github"
       },
       "original": {
@@ -808,11 +808,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722700024,
-        "narHash": "sha256-yjiLjm6vqcLZ2QPILQBhX/FNBwqDwqEK4uU+uwgOwZs=",
+        "lastModified": 1723307312,
+        "narHash": "sha256-UcvsWK+vM/Cc8lGlqDpSa+75hAQY0LWa6n06VpVZCGQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b4345d37c5d51a68e1faf7ad63b365e6d239b4ef",
+        "rev": "0572e827f7bde034f478125ea5a932ff32715616",
         "type": "github"
       },
       "original": {
@@ -905,11 +905,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722658348,
-        "narHash": "sha256-LUph10KC5Oc3q/htlCBb5/OgrPoOsR7XivohLROTJek=",
+        "lastModified": 1723263161,
+        "narHash": "sha256-jb9jGnfyacnUGm+8/En2md3Rc57OJH3M/84Ifwa39E8=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "28b70e64a53207a5382e8fe112a66fe8745b635a",
+        "rev": "4f16dafbf384eebe7b99d99fbdb04018eb2a5db4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 32

Flakes Changelog:
```
• Updated input 'agenix':
    'github:ryantm/agenix/3f1dae074a12feb7327b4bf43cbac0d124488bb7' (2024-07-30)
  → 'github:ryantm/agenix/f6291c5935fdc4e0bef208cfc0dcab7e3f7a1c41' (2024-08-10)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/f451c19376071a90d8c58ab1a953c6e9840527fd' (2024-07-15)
  → 'github:cachix/git-hooks.nix/c7012d0c18567c889b948781bc74a501e92275d1' (2024-08-09)
• Updated input 'home-manager':
    'github:nix-community/home-manager/afc892db74d65042031a093adb6010c4c3378422' (2024-08-02)
  → 'github:nix-community/home-manager/b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e' (2024-08-07)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/c0ca47e8523b578464014961059999d8eddd4aae' (2024-07-28)
  → 'github:nix-community/nix-index-database/97ca0a0fca0391de835f57e44f369a283e37890f' (2024-08-04)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/b73c2221a46c13557b1b3be9c2070cc42cf01eb3' (2024-07-27)
  → 'github:NixOS/nixpkgs/9f918d616c5321ad374ae6cb5ea89c9e04bf3e58' (2024-07-31)
• Updated input 'nix-ld-rs':
    'github:nix-community/nix-ld-rs/ad90f105e8fbaa0b0c87f464b862008598a903ea' (2024-08-02)
  → 'github:nix-community/nix-ld-rs/4ce415e564f9c606de91da58c391018e44166125' (2024-08-07)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/a6df283f4762b079b4d09b25acb1d9bd95f6a472' (2024-08-03)
  → 'github:nix-community/nix-vscode-extensions/cb5f0076c97bcdd4d0ecdb945f4816784fab4fa7' (2024-08-10)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/9f918d616c5321ad374ae6cb5ea89c9e04bf3e58' (2024-07-31)
  → 'github:NixOS/nixpkgs/5e0ca22929f3342b19569b21b2f3462f053e497b' (2024-08-09)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/a3a5c12964705412d8b6758901d4d65b03bac357' (2024-08-03)
  → 'github:NixOS/nixpkgs/c4e73af4dd854035b481ac24bd1f2317cd5861d5' (2024-08-10)
• Updated input 'nixpkgs-wayland':
    'github:nix-community/nixpkgs-wayland/3b5cf5b3226f3e9b89eee7c3e3451acbaf1cc469' (2024-08-03)
  → 'github:nix-community/nixpkgs-wayland/797dc6fb81746869b72537de50a2f3eee4d4a555' (2024-08-10)
• Updated input 'nixpkgs-wayland/lib-aggregate':
    'github:nix-community/lib-aggregate/4ce8efe904950cd85bda9624ff1c2ec55fe2ab6f' (2024-07-28)
  → 'github:nix-community/lib-aggregate/04a4b4d84e02590715e753da3d35fb03cddc6425' (2024-08-04)
• Updated input 'nixpkgs-wayland/lib-aggregate/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/d15f6f6021693898fcd2c6a9bb13707383da9bbc' (2024-07-28)
  → 'github:nix-community/nixpkgs.lib/8bebd4c74f368aacb047f0141db09ec6b339733c' (2024-08-04)
• Updated input 'nixpkgs-wayland/nixpkgs':
    'github:nixos/nixpkgs/9f918d616c5321ad374ae6cb5ea89c9e04bf3e58' (2024-07-31)
  → 'github:nixos/nixpkgs/5e0ca22929f3342b19569b21b2f3462f053e497b' (2024-08-09)
• Updated input 'nur':
    'github:nix-community/NUR/b4345d37c5d51a68e1faf7ad63b365e6d239b4ef' (2024-08-03)
  → 'github:nix-community/NUR/0572e827f7bde034f478125ea5a932ff32715616' (2024-08-10)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/28b70e64a53207a5382e8fe112a66fe8745b635a' (2024-08-03)
  → 'github:Gerg-L/spicetify-nix/4f16dafbf384eebe7b99d99fbdb04018eb2a5db4' (2024-08-10)
```

Sources Changelog:
```
arr_scripts: 193f168511117d34b4ac6c3e371b878dd8f3fda0 → 8d9271f31d8282a3c7bbfc1eea008d631b5ce70e
hyprlock_catppuccin: 480c46f1f3fa9dd175f8f9611c0d4378324378a7 → 958e70b1cd8799defd16dee070d07f977d4fd76b
bottom_catppuccin: bc8183af40ab06db07824dd37ec9a9cf8bd61616 → f33104ec5be6cdde0559c2560f85130e48e10cff
firefox-gnome-theme: v128 → v129
fastfetch: 6b0db6fa746c3d5e2273cf76b6f7544f3a6585fe → 55b1603b83bd7a8e84a863b98206fba8694c3922
```
