### PR TITLE
chore: update flake.lock & sources (2024-08-17)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -101,7 +101,7 @@
     },
     "fastfetch": {
         "cargoLocks": null,
-        "date": "2024-08-10",
+        "date": "2024-08-17",
         "extract": null,
         "name": "fastfetch",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "fastfetch-cli",
             "repo": "fastfetch",
-            "rev": "55b1603b83bd7a8e84a863b98206fba8694c3922",
-            "sha256": "sha256-paExg3JVq0rCuJhiBQKqm7kIZzqEGCHboAgSkspnzeU=",
+            "rev": "f71c4f6d5a48bc16973dd18c954c6512c72587d4",
+            "sha256": "sha256-9XczKSoIEJo2yEfnEWMuF1HN8jUimlXPomCxGo+imP0=",
             "type": "github"
         },
-        "version": "55b1603b83bd7a8e84a863b98206fba8694c3922"
+        "version": "f71c4f6d5a48bc16973dd18c954c6512c72587d4"
     },
     "filen": {
         "cargoLocks": null,
@@ -331,7 +331,7 @@
     },
     "starship_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-05-24",
+        "date": "2024-08-16",
         "extract": null,
         "name": "starship_catppuccin",
         "passthru": null,
@@ -343,11 +343,11 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "starship",
-            "rev": "ca2fb0600730fd3958a2cb4d4ca97c401877b365",
-            "sha256": "sha256-KzXO4dqpufxTew064ZLp3zKIXBwbF8Bi+I0Xa63j/lI=",
+            "rev": "3c4749512e7d552adf48e75e5182a271392ab176",
+            "sha256": "sha256-t/Hmd2dzBn0AbLUlbL8CBt19/we8spY5nMP0Z+VPMXA=",
             "type": "github"
         },
-        "version": "ca2fb0600730fd3958a2cb4d4ca97c401877b365"
+        "version": "3c4749512e7d552adf48e75e5182a271392ab176"
     },
     "wickedwizard_picture": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -63,15 +63,15 @@
   };
   fastfetch = {
     pname = "fastfetch";
-    version = "55b1603b83bd7a8e84a863b98206fba8694c3922";
+    version = "f71c4f6d5a48bc16973dd18c954c6512c72587d4";
     src = fetchFromGitHub {
       owner = "fastfetch-cli";
       repo = "fastfetch";
-      rev = "55b1603b83bd7a8e84a863b98206fba8694c3922";
+      rev = "f71c4f6d5a48bc16973dd18c954c6512c72587d4";
       fetchSubmodules = false;
-      sha256 = "sha256-paExg3JVq0rCuJhiBQKqm7kIZzqEGCHboAgSkspnzeU=";
+      sha256 = "sha256-9XczKSoIEJo2yEfnEWMuF1HN8jUimlXPomCxGo+imP0=";
     };
-    date = "2024-08-10";
+    date = "2024-08-17";
   };
   filen = {
     pname = "filen";
@@ -198,15 +198,15 @@
   };
   starship_catppuccin = {
     pname = "starship_catppuccin";
-    version = "ca2fb0600730fd3958a2cb4d4ca97c401877b365";
+    version = "3c4749512e7d552adf48e75e5182a271392ab176";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "starship";
-      rev = "ca2fb0600730fd3958a2cb4d4ca97c401877b365";
+      rev = "3c4749512e7d552adf48e75e5182a271392ab176";
       fetchSubmodules = false;
-      sha256 = "sha256-KzXO4dqpufxTew064ZLp3zKIXBwbF8Bi+I0Xa63j/lI=";
+      sha256 = "sha256-t/Hmd2dzBn0AbLUlbL8CBt19/we8spY5nMP0Z+VPMXA=";
     };
-    date = "2024-05-24";
+    date = "2024-08-16";
   };
   wickedwizard_picture = {
     pname = "wickedwizard_picture";

--- a/flake.lock
+++ b/flake.lock
@@ -243,11 +243,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
         "type": "github"
       },
       "original": {
@@ -356,11 +356,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723202784,
-        "narHash": "sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q=",
+        "lastModified": 1723803910,
+        "narHash": "sha256-yezvUuFiEnCFbGuwj/bQcqg7RykIEqudOy/RBrId0pc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "c7012d0c18567c889b948781bc74a501e92275d1",
+        "rev": "bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba",
         "type": "github"
       },
       "original": {
@@ -419,11 +419,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723015306,
-        "narHash": "sha256-jQnFEtH20/OsDPpx71ntZzGdRlpXhUENSQCGTjn//NA=",
+        "lastModified": 1723399884,
+        "narHash": "sha256-97wn0ihhGqfMb8WcUgzzkM/TuAxce2Gd20A8oiruju4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e",
+        "rev": "086f619dd991a4d355c07837448244029fc2d9ab",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1722773431,
-        "narHash": "sha256-puSEio9yjWojIBDBts4BSGZ43rv1LzIevdYOKmW/Mjg=",
+        "lastModified": 1723378259,
+        "narHash": "sha256-8JZVHJAoDgbAk9nn7blBB+wnQbgCq1lIxBsyT7qgeI8=",
         "owner": "nix-community",
         "repo": "lib-aggregate",
-        "rev": "04a4b4d84e02590715e753da3d35fb03cddc6425",
+        "rev": "8834c9b308bf4d9d448dd73be5f9782f4635d4ca",
         "type": "github"
       },
       "original": {
@@ -505,11 +505,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1721505437,
-        "narHash": "sha256-sZpyyf9EiRVyEA9vUVWNxu8yI9MU0nhlEuPBL3hvC60=",
+        "lastModified": 1723372011,
+        "narHash": "sha256-zqenoufFiPfobw74idorZMG8AXG3DnFzbHplt/Nkvrg=",
         "owner": "nix-community",
         "repo": "nix-eval-jobs",
-        "rev": "2e522fb78d7613cecaf683875ab27b6c90e8a84f",
+        "rev": "8802412b8747633e9d80639897e4d58fa6290909",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1722740924,
-        "narHash": "sha256-UQPgA5d8azLZuDHZMPmvDszhuKF1Ek89SrTRtqsQ4Ss=",
+        "lastModified": 1723352546,
+        "narHash": "sha256-WTIrvp0yV8ODd6lxAq4F7EbrPQv0gscBnyfn559c3k8=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "97ca0a0fca0391de835f57e44f369a283e37890f",
+        "rev": "ec78079a904d7d55e81a0468d764d0fffb50ac06",
         "type": "github"
       },
       "original": {
@@ -565,11 +565,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1723041154,
-        "narHash": "sha256-xk2pmNz7rbwMQFi0QUVkqbe97VnAERJOMmJFY06rMFg=",
+        "lastModified": 1723871880,
+        "narHash": "sha256-HKHx2tDZEcKTKKkhyIDRifJW7a4bxOsWlvIVI1qm+ng=",
         "owner": "nix-community",
         "repo": "nix-ld-rs",
-        "rev": "4ce415e564f9c606de91da58c391018e44166125",
+        "rev": "8af5fc9add315c251edea8f659b56fc7836a163f",
         "type": "github"
       },
       "original": {
@@ -585,11 +585,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1723253488,
-        "narHash": "sha256-VGwyu/8zoCYdB1e4zl0xjHdbp0LISMueC5rmzhD9Fws=",
+        "lastModified": 1723858043,
+        "narHash": "sha256-wOn9adhtjolHAOw+xY2mvp3m50mBVeQD3GxW9HJR+zc=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "cb5f0076c97bcdd4d0ecdb945f4816784fab4fa7",
+        "rev": "03d3171c94c36f43c10c46df6fbab127af314da6",
         "type": "github"
       },
       "original": {
@@ -628,11 +628,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1722732880,
-        "narHash": "sha256-do2Mfm3T6SR7a5A804RhjQ+JTsF5hk4JTPGjCTRM/m8=",
+        "lastModified": 1723337705,
+        "narHash": "sha256-znSU0DeNDPt7+LMAfFkvKloMaeQ6yl/U5SqV/ktl1vA=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "8bebd4c74f368aacb047f0141db09ec6b339733c",
+        "rev": "ace7856d327b618d3777e31b1f224b3ab57ed71a",
         "type": "github"
       },
       "original": {
@@ -643,11 +643,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1723307941,
-        "narHash": "sha256-tC6zzSTLRgk9wNQzDYzVGrBjHUcfMDTWcf0WcQazEQU=",
+        "lastModified": 1723911789,
+        "narHash": "sha256-4BPFzElMQ1PHqaLwDva54elCUolg6ImacFbvr+uKVfM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c4e73af4dd854035b481ac24bd1f2317cd5861d5",
+        "rev": "3637306b00b7e57656f56f88ed445e282ce560d3",
         "type": "github"
       },
       "original": {
@@ -697,11 +697,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1723306957,
-        "narHash": "sha256-fuXCd2b3H+cnmkWSPc5VacpS+3QvZnU3fx2HOpAfH0g=",
+        "lastModified": 1723573444,
+        "narHash": "sha256-5R7cF01OqkULUZ/qpAjgs712UGM+N0xFqOk/eYd3V+4=",
         "owner": "nix-community",
         "repo": "nixpkgs-wayland",
-        "rev": "797dc6fb81746869b72537de50a2f3eee4d4a555",
+        "rev": "d281d56bda9456bb8c0a22a608575926fb9a656d",
         "type": "github"
       },
       "original": {
@@ -712,11 +712,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1722421184,
-        "narHash": "sha256-/DJBI6trCeVnasdjUo9pbnodCLZcFqnVZiLUfqLH4jA=",
+        "lastModified": 1723175592,
+        "narHash": "sha256-M0xJ3FbDUc4fRZ84dPGx5VvgFsOzds77KiBMW/mMTnI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9f918d616c5321ad374ae6cb5ea89c9e04bf3e58",
+        "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
         "type": "github"
       },
       "original": {
@@ -760,11 +760,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1723175592,
-        "narHash": "sha256-M0xJ3FbDUc4fRZ84dPGx5VvgFsOzds77KiBMW/mMTnI=",
+        "lastModified": 1723637854,
+        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
+        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
         "type": "github"
       },
       "original": {
@@ -776,11 +776,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1720781449,
-        "narHash": "sha256-po3TZO9kcZwzvkyMJKb0WCzzDtiHWD34XeRaX1lWXp0=",
+        "lastModified": 1723221148,
+        "narHash": "sha256-7pjpeQlZUNQ4eeVntytU3jkw9dFK3k1Htgk2iuXjaD8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b5a3d5a1d951344d683b442c0739010b80039db",
+        "rev": "154bcb95ad51bc257c2ce4043a725de6ca700ef6",
         "type": "github"
       },
       "original": {
@@ -792,11 +792,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1723175592,
-        "narHash": "sha256-M0xJ3FbDUc4fRZ84dPGx5VvgFsOzds77KiBMW/mMTnI=",
+        "lastModified": 1723362943,
+        "narHash": "sha256-dFZRVSgmJkyM0bkPpaYRtG/kRMRTorUIDj8BxoOt1T4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
+        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
         "type": "github"
       },
       "original": {
@@ -808,11 +808,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723307312,
-        "narHash": "sha256-UcvsWK+vM/Cc8lGlqDpSa+75hAQY0LWa6n06VpVZCGQ=",
+        "lastModified": 1723905880,
+        "narHash": "sha256-j9xPPY4sVVmdt6n9q4/bH2IHYnzFJ96rWwBUVF9puPM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0572e827f7bde034f478125ea5a932ff32715616",
+        "rev": "55a2281172b763189cfef53d02e843851cccc51a",
         "type": "github"
       },
       "original": {
@@ -905,11 +905,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723263161,
-        "narHash": "sha256-jb9jGnfyacnUGm+8/En2md3Rc57OJH3M/84Ifwa39E8=",
+        "lastModified": 1723865417,
+        "narHash": "sha256-lz/ZW8ECn+6ZItZ+Rn1dGzPSeqDYONun1kpajCWWZeg=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "4f16dafbf384eebe7b99d99fbdb04018eb2a5db4",
+        "rev": "cca3a30fb8dc87b1f86ec331e37b10024948f449",
         "type": "github"
       },
       "original": {
@@ -1032,11 +1032,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720930114,
-        "narHash": "sha256-VZK73b5hG5bSeAn97TTcnPjXUXtV7j/AtS4KN8ggCS0=",
+        "lastModified": 1723303070,
+        "narHash": "sha256-krGNVA30yptyRonohQ+i9cnK+CfCpedg6z3qzqVJcTs=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "b92afa1501ac73f1d745526adc4f89b527595f14",
+        "rev": "14c092e0326de759e16b37535161b3cb9770cea3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 33

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/c7012d0c18567c889b948781bc74a501e92275d1' (2024-08-09)
  → 'github:cachix/git-hooks.nix/bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba' (2024-08-16)
• Updated input 'home-manager':
    'github:nix-community/home-manager/b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e' (2024-08-07)
  → 'github:nix-community/home-manager/086f619dd991a4d355c07837448244029fc2d9ab' (2024-08-11)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/97ca0a0fca0391de835f57e44f369a283e37890f' (2024-08-04)
  → 'github:nix-community/nix-index-database/ec78079a904d7d55e81a0468d764d0fffb50ac06' (2024-08-11)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/9f918d616c5321ad374ae6cb5ea89c9e04bf3e58' (2024-07-31)
  → 'github:NixOS/nixpkgs/5e0ca22929f3342b19569b21b2f3462f053e497b' (2024-08-09)
• Updated input 'nix-ld-rs':
    'github:nix-community/nix-ld-rs/4ce415e564f9c606de91da58c391018e44166125' (2024-08-07)
  → 'github:nix-community/nix-ld-rs/8af5fc9add315c251edea8f659b56fc7836a163f' (2024-08-17)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/cb5f0076c97bcdd4d0ecdb945f4816784fab4fa7' (2024-08-10)
  → 'github:nix-community/nix-vscode-extensions/03d3171c94c36f43c10c46df6fbab127af314da6' (2024-08-17)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/5e0ca22929f3342b19569b21b2f3462f053e497b' (2024-08-09)
  → 'github:NixOS/nixpkgs/c3aa7b8938b17aebd2deecf7be0636000d62a2b9' (2024-08-14)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/c4e73af4dd854035b481ac24bd1f2317cd5861d5' (2024-08-10)
  → 'github:NixOS/nixpkgs/3637306b00b7e57656f56f88ed445e282ce560d3' (2024-08-17)
• Updated input 'nixpkgs-wayland':
    'github:nix-community/nixpkgs-wayland/797dc6fb81746869b72537de50a2f3eee4d4a555' (2024-08-10)
  → 'github:nix-community/nixpkgs-wayland/d281d56bda9456bb8c0a22a608575926fb9a656d' (2024-08-13)
• Updated input 'nixpkgs-wayland/lib-aggregate':
    'github:nix-community/lib-aggregate/04a4b4d84e02590715e753da3d35fb03cddc6425' (2024-08-04)
  → 'github:nix-community/lib-aggregate/8834c9b308bf4d9d448dd73be5f9782f4635d4ca' (2024-08-11)
• Updated input 'nixpkgs-wayland/lib-aggregate/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/8bebd4c74f368aacb047f0141db09ec6b339733c' (2024-08-04)
  → 'github:nix-community/nixpkgs.lib/ace7856d327b618d3777e31b1f224b3ab57ed71a' (2024-08-11)
• Updated input 'nixpkgs-wayland/nix-eval-jobs':
    'github:nix-community/nix-eval-jobs/2e522fb78d7613cecaf683875ab27b6c90e8a84f' (2024-07-20)
  → 'github:nix-community/nix-eval-jobs/8802412b8747633e9d80639897e4d58fa6290909' (2024-08-11)
• Updated input 'nixpkgs-wayland/nix-eval-jobs/flake-parts':
    'github:hercules-ci/flake-parts/9227223f6d922fee3c7b190b2cc238a99527bbb7' (2024-07-03)
  → 'github:hercules-ci/flake-parts/8471fe90ad337a8074e957b69ca4d0089218391d' (2024-08-01)
• Updated input 'nixpkgs-wayland/nix-eval-jobs/nixpkgs':
    'github:NixOS/nixpkgs/8b5a3d5a1d951344d683b442c0739010b80039db' (2024-07-12)
  → 'github:NixOS/nixpkgs/154bcb95ad51bc257c2ce4043a725de6ca700ef6' (2024-08-09)
• Updated input 'nixpkgs-wayland/nix-eval-jobs/treefmt-nix':
    'github:numtide/treefmt-nix/b92afa1501ac73f1d745526adc4f89b527595f14' (2024-07-14)
  → 'github:numtide/treefmt-nix/14c092e0326de759e16b37535161b3cb9770cea3' (2024-08-10)
• Updated input 'nixpkgs-wayland/nixpkgs':
    'github:nixos/nixpkgs/5e0ca22929f3342b19569b21b2f3462f053e497b' (2024-08-09)
  → 'github:nixos/nixpkgs/a58bc8ad779655e790115244571758e8de055e3d' (2024-08-11)
• Updated input 'nur':
    'github:nix-community/NUR/0572e827f7bde034f478125ea5a932ff32715616' (2024-08-10)
  → 'github:nix-community/NUR/55a2281172b763189cfef53d02e843851cccc51a' (2024-08-17)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/4f16dafbf384eebe7b99d99fbdb04018eb2a5db4' (2024-08-10)
  → 'github:Gerg-L/spicetify-nix/cca3a30fb8dc87b1f86ec331e37b10024948f449' (2024-08-17)
```

Sources Changelog:
```
fastfetch: 55b1603b83bd7a8e84a863b98206fba8694c3922 → f71c4f6d5a48bc16973dd18c954c6512c72587d4
starship_catppuccin: ca2fb0600730fd3958a2cb4d4ca97c401877b365 → 3c4749512e7d552adf48e75e5182a271392ab176
```
