### PR TITLE
chore: update flake.lock & sources (2024-08-24)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "arr_scripts": {
         "cargoLocks": null,
-        "date": "2024-08-08",
+        "date": "2024-08-19",
         "extract": null,
         "name": "arr_scripts",
         "passthru": null,
@@ -13,11 +13,11 @@
             "name": null,
             "owner": "RandomNinjaAtk",
             "repo": "arr-scripts",
-            "rev": "8d9271f31d8282a3c7bbfc1eea008d631b5ce70e",
-            "sha256": "sha256-kUcmeeHoCHMQuRrtOrLPrpvpW0LmRf2smbzncQIIC9Y=",
+            "rev": "ae84972d035ee14966c176fb420fbe1d28402feb",
+            "sha256": "sha256-nrET7F+LDmZvH9tgSijbsgzcYntRON75rfjw6n9fLGQ=",
             "type": "github"
         },
-        "version": "8d9271f31d8282a3c7bbfc1eea008d631b5ce70e"
+        "version": "ae84972d035ee14966c176fb420fbe1d28402feb"
     },
     "bottom_catppuccin": {
         "cargoLocks": null,
@@ -101,7 +101,7 @@
     },
     "fastfetch": {
         "cargoLocks": null,
-        "date": "2024-08-17",
+        "date": "2024-08-24",
         "extract": null,
         "name": "fastfetch",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "fastfetch-cli",
             "repo": "fastfetch",
-            "rev": "f71c4f6d5a48bc16973dd18c954c6512c72587d4",
-            "sha256": "sha256-9XczKSoIEJo2yEfnEWMuF1HN8jUimlXPomCxGo+imP0=",
+            "rev": "788cad3cbe4262e022774becf36f0df2847abf46",
+            "sha256": "sha256-4MOK+4QQzE3wH0WQY9LYJY4CLmrLMaFip41eA6eN/Ns=",
             "type": "github"
         },
-        "version": "f71c4f6d5a48bc16973dd18c954c6512c72587d4"
+        "version": "788cad3cbe4262e022774becf36f0df2847abf46"
     },
     "filen": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,15 +3,15 @@
 {
   arr_scripts = {
     pname = "arr_scripts";
-    version = "8d9271f31d8282a3c7bbfc1eea008d631b5ce70e";
+    version = "ae84972d035ee14966c176fb420fbe1d28402feb";
     src = fetchFromGitHub {
       owner = "RandomNinjaAtk";
       repo = "arr-scripts";
-      rev = "8d9271f31d8282a3c7bbfc1eea008d631b5ce70e";
+      rev = "ae84972d035ee14966c176fb420fbe1d28402feb";
       fetchSubmodules = false;
-      sha256 = "sha256-kUcmeeHoCHMQuRrtOrLPrpvpW0LmRf2smbzncQIIC9Y=";
+      sha256 = "sha256-nrET7F+LDmZvH9tgSijbsgzcYntRON75rfjw6n9fLGQ=";
     };
-    date = "2024-08-08";
+    date = "2024-08-19";
   };
   bottom_catppuccin = {
     pname = "bottom_catppuccin";
@@ -63,15 +63,15 @@
   };
   fastfetch = {
     pname = "fastfetch";
-    version = "f71c4f6d5a48bc16973dd18c954c6512c72587d4";
+    version = "788cad3cbe4262e022774becf36f0df2847abf46";
     src = fetchFromGitHub {
       owner = "fastfetch-cli";
       repo = "fastfetch";
-      rev = "f71c4f6d5a48bc16973dd18c954c6512c72587d4";
+      rev = "788cad3cbe4262e022774becf36f0df2847abf46";
       fetchSubmodules = false;
-      sha256 = "sha256-9XczKSoIEJo2yEfnEWMuF1HN8jUimlXPomCxGo+imP0=";
+      sha256 = "sha256-4MOK+4QQzE3wH0WQY9LYJY4CLmrLMaFip41eA6eN/Ns=";
     };
-    date = "2024-08-17";
+    date = "2024-08-24";
   };
   filen = {
     pname = "filen";

--- a/flake.lock
+++ b/flake.lock
@@ -356,11 +356,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723803910,
-        "narHash": "sha256-yezvUuFiEnCFbGuwj/bQcqg7RykIEqudOy/RBrId0pc=",
+        "lastModified": 1724440431,
+        "narHash": "sha256-9etXEOUtzeMgqg1u0wp+EdwG7RpmrAZ2yX516bMj2aE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba",
+        "rev": "c8a54057aae480c56e28ef3e14e4960628ac495b",
         "type": "github"
       },
       "original": {
@@ -419,11 +419,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723399884,
-        "narHash": "sha256-97wn0ihhGqfMb8WcUgzzkM/TuAxce2Gd20A8oiruju4=",
+        "lastModified": 1724435763,
+        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "086f619dd991a4d355c07837448244029fc2d9ab",
+        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1723352546,
-        "narHash": "sha256-WTIrvp0yV8ODd6lxAq4F7EbrPQv0gscBnyfn559c3k8=",
+        "lastModified": 1723950649,
+        "narHash": "sha256-dHMkGjwwCGj0c2MKyCjRXVBXq2Sz3TWbbM23AS7/5Hc=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "ec78079a904d7d55e81a0468d764d0fffb50ac06",
+        "rev": "392828aafbed62a6ea6ccab13728df2e67481805",
         "type": "github"
       },
       "original": {
@@ -585,11 +585,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1723858043,
-        "narHash": "sha256-wOn9adhtjolHAOw+xY2mvp3m50mBVeQD3GxW9HJR+zc=",
+        "lastModified": 1724505248,
+        "narHash": "sha256-z7IDP73lE1YnoP16zNaO9bk2VWMM0R7Ggu6vmChz8Rc=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "03d3171c94c36f43c10c46df6fbab127af314da6",
+        "rev": "0f42b6d543ed08062efc38be9687daaa8b32d6ac",
         "type": "github"
       },
       "original": {
@@ -643,11 +643,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1723911789,
-        "narHash": "sha256-4BPFzElMQ1PHqaLwDva54elCUolg6ImacFbvr+uKVfM=",
+        "lastModified": 1724516770,
+        "narHash": "sha256-7LSxYY1IyQsxo9fBdjzDjigrMsyKRCd5vOZuYplbppo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3637306b00b7e57656f56f88ed445e282ce560d3",
+        "rev": "0c2d0b6ea59a90061c55b515a3c84d5e37111bea",
         "type": "github"
       },
       "original": {
@@ -712,11 +712,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1723175592,
-        "narHash": "sha256-M0xJ3FbDUc4fRZ84dPGx5VvgFsOzds77KiBMW/mMTnI=",
+        "lastModified": 1723637854,
+        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
+        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
         "type": "github"
       },
       "original": {
@@ -760,11 +760,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1723637854,
-        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
+        "lastModified": 1724224976,
+        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
+        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
         "type": "github"
       },
       "original": {
@@ -808,11 +808,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723905880,
-        "narHash": "sha256-j9xPPY4sVVmdt6n9q4/bH2IHYnzFJ96rWwBUVF9puPM=",
+        "lastModified": 1724513920,
+        "narHash": "sha256-TuXs7BNsNv3HwPCWjq9pS4PnJR332v+rj1kCxr/qIYk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "55a2281172b763189cfef53d02e843851cccc51a",
+        "rev": "a35d60441c835e2b2f66092faf03e21e1e17601c",
         "type": "github"
       },
       "original": {
@@ -905,11 +905,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723865417,
-        "narHash": "sha256-lz/ZW8ECn+6ZItZ+Rn1dGzPSeqDYONun1kpajCWWZeg=",
+        "lastModified": 1724472954,
+        "narHash": "sha256-65NfzEvwdJGHsOZA+w4AUFUG10RyfuQltct3h++gsw0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "cca3a30fb8dc87b1f86ec331e37b10024948f449",
+        "rev": "3caf2a241f7af52419ce97c6682b0467219ab914",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 34

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba' (2024-08-16)
  → 'github:cachix/git-hooks.nix/c8a54057aae480c56e28ef3e14e4960628ac495b' (2024-08-23)
• Updated input 'home-manager':
    'github:nix-community/home-manager/086f619dd991a4d355c07837448244029fc2d9ab' (2024-08-11)
  → 'github:nix-community/home-manager/c2cd2a52e02f1dfa1c88f95abeb89298d46023be' (2024-08-23)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/ec78079a904d7d55e81a0468d764d0fffb50ac06' (2024-08-11)
  → 'github:nix-community/nix-index-database/392828aafbed62a6ea6ccab13728df2e67481805' (2024-08-18)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/5e0ca22929f3342b19569b21b2f3462f053e497b' (2024-08-09)
  → 'github:NixOS/nixpkgs/c3aa7b8938b17aebd2deecf7be0636000d62a2b9' (2024-08-14)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/03d3171c94c36f43c10c46df6fbab127af314da6' (2024-08-17)
  → 'github:nix-community/nix-vscode-extensions/0f42b6d543ed08062efc38be9687daaa8b32d6ac' (2024-08-24)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c3aa7b8938b17aebd2deecf7be0636000d62a2b9' (2024-08-14)
  → 'github:NixOS/nixpkgs/c374d94f1536013ca8e92341b540eba4c22f9c62' (2024-08-21)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/3637306b00b7e57656f56f88ed445e282ce560d3' (2024-08-17)
  → 'github:NixOS/nixpkgs/0c2d0b6ea59a90061c55b515a3c84d5e37111bea' (2024-08-24)
• Updated input 'nur':
    'github:nix-community/NUR/55a2281172b763189cfef53d02e843851cccc51a' (2024-08-17)
  → 'github:nix-community/NUR/a35d60441c835e2b2f66092faf03e21e1e17601c' (2024-08-24)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/cca3a30fb8dc87b1f86ec331e37b10024948f449' (2024-08-17)
  → 'github:Gerg-L/spicetify-nix/3caf2a241f7af52419ce97c6682b0467219ab914' (2024-08-24)
```

Sources Changelog:
```
fastfetch: f71c4f6d5a48bc16973dd18c954c6512c72587d4 → 788cad3cbe4262e022774becf36f0df2847abf46
arr_scripts: 8d9271f31d8282a3c7bbfc1eea008d631b5ce70e → ae84972d035ee14966c176fb420fbe1d28402feb
```
