### PR TITLE
chore: update flake.lock & sources (2024-08-31)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -101,7 +101,7 @@
     },
     "fastfetch": {
         "cargoLocks": null,
-        "date": "2024-08-24",
+        "date": "2024-08-31",
         "extract": null,
         "name": "fastfetch",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "fastfetch-cli",
             "repo": "fastfetch",
-            "rev": "788cad3cbe4262e022774becf36f0df2847abf46",
-            "sha256": "sha256-4MOK+4QQzE3wH0WQY9LYJY4CLmrLMaFip41eA6eN/Ns=",
+            "rev": "99e0dc9aaa9ecf3645c086258149058beb1442af",
+            "sha256": "sha256-cb4R9sef3gVWAeMTHfK70jTUL/6/z7uYVB2mrK47OB4=",
             "type": "github"
         },
-        "version": "788cad3cbe4262e022774becf36f0df2847abf46"
+        "version": "99e0dc9aaa9ecf3645c086258149058beb1442af"
     },
     "filen": {
         "cargoLocks": null,
@@ -286,7 +286,7 @@
     },
     "obs_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-04-03",
+        "date": "2024-08-30",
         "extract": null,
         "name": "obs_catppuccin",
         "passthru": null,
@@ -298,11 +298,11 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "obs",
-            "rev": "e7c4fcf387415a20cb747121bc0416c4c8ae3362",
-            "sha256": "sha256-dZcgIPMa1AUFXcMPT99YUUhvxHbniv0Anbh9/DB00NY=",
+            "rev": "b17939991545bdd6232e688ec5004b6dfae46f69",
+            "sha256": "sha256-1Stlcfcl/DZMPPqsShst849Ns0Lgk9D2SekMhTy7zZY=",
             "type": "github"
         },
-        "version": "e7c4fcf387415a20cb747121bc0416c4c8ae3362"
+        "version": "b17939991545bdd6232e688ec5004b6dfae46f69"
     },
     "prismlauncher_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -63,15 +63,15 @@
   };
   fastfetch = {
     pname = "fastfetch";
-    version = "788cad3cbe4262e022774becf36f0df2847abf46";
+    version = "99e0dc9aaa9ecf3645c086258149058beb1442af";
     src = fetchFromGitHub {
       owner = "fastfetch-cli";
       repo = "fastfetch";
-      rev = "788cad3cbe4262e022774becf36f0df2847abf46";
+      rev = "99e0dc9aaa9ecf3645c086258149058beb1442af";
       fetchSubmodules = false;
-      sha256 = "sha256-4MOK+4QQzE3wH0WQY9LYJY4CLmrLMaFip41eA6eN/Ns=";
+      sha256 = "sha256-cb4R9sef3gVWAeMTHfK70jTUL/6/z7uYVB2mrK47OB4=";
     };
-    date = "2024-08-24";
+    date = "2024-08-31";
   };
   filen = {
     pname = "filen";
@@ -170,15 +170,15 @@
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";
-    version = "e7c4fcf387415a20cb747121bc0416c4c8ae3362";
+    version = "b17939991545bdd6232e688ec5004b6dfae46f69";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "obs";
-      rev = "e7c4fcf387415a20cb747121bc0416c4c8ae3362";
+      rev = "b17939991545bdd6232e688ec5004b6dfae46f69";
       fetchSubmodules = false;
-      sha256 = "sha256-dZcgIPMa1AUFXcMPT99YUUhvxHbniv0Anbh9/DB00NY=";
+      sha256 = "sha256-1Stlcfcl/DZMPPqsShst849Ns0Lgk9D2SekMhTy7zZY=";
     };
-    date = "2024-04-03";
+    date = "2024-08-30";
   };
   prismlauncher_catppuccin = {
     pname = "prismlauncher_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1725024810,
+        "narHash": "sha256-ODYRm8zHfLTH3soTFWE452ydPYz2iTvr9T8ftDMUQ3E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "af510d4a62d071ea13925ce41c95e3dec816c01d",
         "type": "github"
       },
       "original": {
@@ -356,11 +356,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724440431,
-        "narHash": "sha256-9etXEOUtzeMgqg1u0wp+EdwG7RpmrAZ2yX516bMj2aE=",
+        "lastModified": 1724857454,
+        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "c8a54057aae480c56e28ef3e14e4960628ac495b",
+        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1723378259,
-        "narHash": "sha256-8JZVHJAoDgbAk9nn7blBB+wnQbgCq1lIxBsyT7qgeI8=",
+        "lastModified": 1724587851,
+        "narHash": "sha256-+tnTRvR9TzXQDl5OynS+tKBZyPB6viT99zs4fXI0lfk=",
         "owner": "nix-community",
         "repo": "lib-aggregate",
-        "rev": "8834c9b308bf4d9d448dd73be5f9782f4635d4ca",
+        "rev": "eda1cdaddc64064f53e65ae614e061010e5fb92f",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1723950649,
-        "narHash": "sha256-dHMkGjwwCGj0c2MKyCjRXVBXq2Sz3TWbbM23AS7/5Hc=",
+        "lastModified": 1724576102,
+        "narHash": "sha256-uM7n5nNL6fmA0bwMJBNll11f4cMWOFa2Ni6F5KeIldM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "392828aafbed62a6ea6ccab13728df2e67481805",
+        "rev": "e333d62b70b179da1dd78d94315e8a390f2d12e5",
         "type": "github"
       },
       "original": {
@@ -585,11 +585,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1724505248,
-        "narHash": "sha256-z7IDP73lE1YnoP16zNaO9bk2VWMM0R7Ggu6vmChz8Rc=",
+        "lastModified": 1725068052,
+        "narHash": "sha256-WqofagIIyZ/hY6vJH65OLXVBgi2FNOezjybwniBvN14=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "0f42b6d543ed08062efc38be9687daaa8b32d6ac",
+        "rev": "27661753057dc1d259c7918f6c6777bea26290f1",
         "type": "github"
       },
       "original": {
@@ -628,11 +628,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1723337705,
-        "narHash": "sha256-znSU0DeNDPt7+LMAfFkvKloMaeQ6yl/U5SqV/ktl1vA=",
+        "lastModified": 1724547350,
+        "narHash": "sha256-WKkGeNpenNMKD1gOF0Xuqi3VsKX/QCAiwz9qe5PDvzA=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "ace7856d327b618d3777e31b1f224b3ab57ed71a",
+        "rev": "b741d900fecd2f0c32d90f853b24be9f5f098b7d",
         "type": "github"
       },
       "original": {
@@ -643,11 +643,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1724516770,
-        "narHash": "sha256-7LSxYY1IyQsxo9fBdjzDjigrMsyKRCd5vOZuYplbppo=",
+        "lastModified": 1725121419,
+        "narHash": "sha256-njodFwX6ed548gA6AWxIa2rGNsiQ+HfVExgaYEANpQM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c2d0b6ea59a90061c55b515a3c84d5e37111bea",
+        "rev": "a162eecfdc28db4fb932ee53050ebf25ca37eec9",
         "type": "github"
       },
       "original": {
@@ -697,11 +697,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1723573444,
-        "narHash": "sha256-5R7cF01OqkULUZ/qpAjgs712UGM+N0xFqOk/eYd3V+4=",
+        "lastModified": 1725116853,
+        "narHash": "sha256-opr/FAc2xpImCLthPphqJ6DX+qqoVOB8XzaAdlOfjVI=",
         "owner": "nix-community",
         "repo": "nixpkgs-wayland",
-        "rev": "d281d56bda9456bb8c0a22a608575926fb9a656d",
+        "rev": "7d56d07ba9a74f956340356e01e3858e65199ab5",
         "type": "github"
       },
       "original": {
@@ -712,11 +712,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1723637854,
-        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
+        "lastModified": 1724224976,
+        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
+        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
         "type": "github"
       },
       "original": {
@@ -760,11 +760,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1724224976,
-        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
+        "lastModified": 1724819573,
+        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
+        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
         "type": "github"
       },
       "original": {
@@ -792,11 +792,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1723362943,
-        "narHash": "sha256-dFZRVSgmJkyM0bkPpaYRtG/kRMRTorUIDj8BxoOt1T4=",
+        "lastModified": 1724819573,
+        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
+        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
         "type": "github"
       },
       "original": {
@@ -808,11 +808,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724513920,
-        "narHash": "sha256-TuXs7BNsNv3HwPCWjq9pS4PnJR332v+rj1kCxr/qIYk=",
+        "lastModified": 1725115514,
+        "narHash": "sha256-llfa5ShJmYH4dYAwBf8B1c1lCv1GRq385VBfq4QztLw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a35d60441c835e2b2f66092faf03e21e1e17601c",
+        "rev": "2a8d5d58e80863bff01f9800f8f6f8bf9c207d0a",
         "type": "github"
       },
       "original": {
@@ -905,11 +905,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724472954,
-        "narHash": "sha256-65NfzEvwdJGHsOZA+w4AUFUG10RyfuQltct3h++gsw0=",
+        "lastModified": 1725077747,
+        "narHash": "sha256-4SwFxe789QXOtGNFbwldpqFzkKxIFuyDysFttFWB5eM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "3caf2a241f7af52419ce97c6682b0467219ab914",
+        "rev": "305b6034ad329268eb33c079e2d33740ccf329ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 35

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/8471fe90ad337a8074e957b69ca4d0089218391d' (2024-08-01)
  → 'github:hercules-ci/flake-parts/af510d4a62d071ea13925ce41c95e3dec816c01d' (2024-08-30)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/c8a54057aae480c56e28ef3e14e4960628ac495b' (2024-08-23)
  → 'github:cachix/git-hooks.nix/4509ca64f1084e73bc7a721b20c669a8d4c5ebe6' (2024-08-28)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/392828aafbed62a6ea6ccab13728df2e67481805' (2024-08-18)
  → 'github:nix-community/nix-index-database/e333d62b70b179da1dd78d94315e8a390f2d12e5' (2024-08-25)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/c3aa7b8938b17aebd2deecf7be0636000d62a2b9' (2024-08-14)
  → 'github:NixOS/nixpkgs/c374d94f1536013ca8e92341b540eba4c22f9c62' (2024-08-21)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/0f42b6d543ed08062efc38be9687daaa8b32d6ac' (2024-08-24)
  → 'github:nix-community/nix-vscode-extensions/27661753057dc1d259c7918f6c6777bea26290f1' (2024-08-31)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c374d94f1536013ca8e92341b540eba4c22f9c62' (2024-08-21)
  → 'github:NixOS/nixpkgs/71e91c409d1e654808b2621f28a327acfdad8dc2' (2024-08-28)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/0c2d0b6ea59a90061c55b515a3c84d5e37111bea' (2024-08-24)
  → 'github:NixOS/nixpkgs/a162eecfdc28db4fb932ee53050ebf25ca37eec9' (2024-08-31)
• Updated input 'nixpkgs-wayland':
    'github:nix-community/nixpkgs-wayland/d281d56bda9456bb8c0a22a608575926fb9a656d' (2024-08-13)
  → 'github:nix-community/nixpkgs-wayland/7d56d07ba9a74f956340356e01e3858e65199ab5' (2024-08-31)
• Updated input 'nixpkgs-wayland/lib-aggregate':
    'github:nix-community/lib-aggregate/8834c9b308bf4d9d448dd73be5f9782f4635d4ca' (2024-08-11)
  → 'github:nix-community/lib-aggregate/eda1cdaddc64064f53e65ae614e061010e5fb92f' (2024-08-25)
• Updated input 'nixpkgs-wayland/lib-aggregate/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/ace7856d327b618d3777e31b1f224b3ab57ed71a' (2024-08-11)
  → 'github:nix-community/nixpkgs.lib/b741d900fecd2f0c32d90f853b24be9f5f098b7d' (2024-08-25)
• Updated input 'nixpkgs-wayland/nixpkgs':
    'github:nixos/nixpkgs/a58bc8ad779655e790115244571758e8de055e3d' (2024-08-11)
  → 'github:nixos/nixpkgs/71e91c409d1e654808b2621f28a327acfdad8dc2' (2024-08-28)
• Updated input 'nur':
    'github:nix-community/NUR/a35d60441c835e2b2f66092faf03e21e1e17601c' (2024-08-24)
  → 'github:nix-community/NUR/2a8d5d58e80863bff01f9800f8f6f8bf9c207d0a' (2024-08-31)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/3caf2a241f7af52419ce97c6682b0467219ab914' (2024-08-24)
  → 'github:Gerg-L/spicetify-nix/305b6034ad329268eb33c079e2d33740ccf329ea' (2024-08-31)
```

Sources Changelog:
```
fastfetch: 788cad3cbe4262e022774becf36f0df2847abf46 → 99e0dc9aaa9ecf3645c086258149058beb1442af
obs_catppuccin: e7c4fcf387415a20cb747121bc0416c4c8ae3362 → b17939991545bdd6232e688ec5004b6dfae46f69
```
