### PR TITLE
chore: update flake.lock & sources (2024-09-07)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "arr_scripts": {
         "cargoLocks": null,
-        "date": "2024-08-19",
+        "date": "2024-09-05",
         "extract": null,
         "name": "arr_scripts",
         "passthru": null,
@@ -13,11 +13,11 @@
             "name": null,
             "owner": "RandomNinjaAtk",
             "repo": "arr-scripts",
-            "rev": "ae84972d035ee14966c176fb420fbe1d28402feb",
-            "sha256": "sha256-nrET7F+LDmZvH9tgSijbsgzcYntRON75rfjw6n9fLGQ=",
+            "rev": "32d14192f1afbadb20cefd6edf261d38a4474863",
+            "sha256": "sha256-fp9Kcq95KTLvbDYwiadmcSG171E4Uf6Ybsbkr/SytKs=",
             "type": "github"
         },
-        "version": "ae84972d035ee14966c176fb420fbe1d28402feb"
+        "version": "32d14192f1afbadb20cefd6edf261d38a4474863"
     },
     "bottom_catppuccin": {
         "cargoLocks": null,
@@ -101,7 +101,7 @@
     },
     "fastfetch": {
         "cargoLocks": null,
-        "date": "2024-08-31",
+        "date": "2024-09-07",
         "extract": null,
         "name": "fastfetch",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "fastfetch-cli",
             "repo": "fastfetch",
-            "rev": "99e0dc9aaa9ecf3645c086258149058beb1442af",
-            "sha256": "sha256-cb4R9sef3gVWAeMTHfK70jTUL/6/z7uYVB2mrK47OB4=",
+            "rev": "1e4601485a46bdb7c3601ffcba577e67495a44b9",
+            "sha256": "sha256-vZeL3bqwTxbVSdDUVjjoyNUToLPqjVSnd5UyAydm6UM=",
             "type": "github"
         },
-        "version": "99e0dc9aaa9ecf3645c086258149058beb1442af"
+        "version": "1e4601485a46bdb7c3601ffcba577e67495a44b9"
     },
     "filen": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,15 +3,15 @@
 {
   arr_scripts = {
     pname = "arr_scripts";
-    version = "ae84972d035ee14966c176fb420fbe1d28402feb";
+    version = "32d14192f1afbadb20cefd6edf261d38a4474863";
     src = fetchFromGitHub {
       owner = "RandomNinjaAtk";
       repo = "arr-scripts";
-      rev = "ae84972d035ee14966c176fb420fbe1d28402feb";
+      rev = "32d14192f1afbadb20cefd6edf261d38a4474863";
       fetchSubmodules = false;
-      sha256 = "sha256-nrET7F+LDmZvH9tgSijbsgzcYntRON75rfjw6n9fLGQ=";
+      sha256 = "sha256-fp9Kcq95KTLvbDYwiadmcSG171E4Uf6Ybsbkr/SytKs=";
     };
-    date = "2024-08-19";
+    date = "2024-09-05";
   };
   bottom_catppuccin = {
     pname = "bottom_catppuccin";
@@ -63,15 +63,15 @@
   };
   fastfetch = {
     pname = "fastfetch";
-    version = "99e0dc9aaa9ecf3645c086258149058beb1442af";
+    version = "1e4601485a46bdb7c3601ffcba577e67495a44b9";
     src = fetchFromGitHub {
       owner = "fastfetch-cli";
       repo = "fastfetch";
-      rev = "99e0dc9aaa9ecf3645c086258149058beb1442af";
+      rev = "1e4601485a46bdb7c3601ffcba577e67495a44b9";
       fetchSubmodules = false;
-      sha256 = "sha256-cb4R9sef3gVWAeMTHfK70jTUL/6/z7uYVB2mrK47OB4=";
+      sha256 = "sha256-vZeL3bqwTxbVSdDUVjjoyNUToLPqjVSnd5UyAydm6UM=";
     };
-    date = "2024-08-31";
+    date = "2024-09-07";
   };
   filen = {
     pname = "filen";

--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1725024810,
-        "narHash": "sha256-ODYRm8zHfLTH3soTFWE452ydPYz2iTvr9T8ftDMUQ3E=",
+        "lastModified": 1725234343,
+        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af510d4a62d071ea13925ce41c95e3dec816c01d",
+        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
         "type": "github"
       },
       "original": {
@@ -289,11 +289,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724857454,
-        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
+        "lastModified": 1725513492,
+        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
+        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
         "type": "github"
       },
       "original": {
@@ -352,11 +352,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724435763,
-        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
+        "lastModified": 1725694918,
+        "narHash": "sha256-+HsjshXpqNiJHLaJaK0JnIicJ/a1NquKcfn4YZ3ILgg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
+        "rev": "aaebdea769a5c10f1c6e50ebdf5924c1a13f0cda",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1724576102,
-        "narHash": "sha256-uM7n5nNL6fmA0bwMJBNll11f4cMWOFa2Ni6F5KeIldM=",
+        "lastModified": 1725161148,
+        "narHash": "sha256-WfAHq3Ag3vLNFfWxKHjFBFdPI6JIideWFJod9mx1eoo=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "e333d62b70b179da1dd78d94315e8a390f2d12e5",
+        "rev": "32058e9138248874773630c846563b1a78ee7a5b",
         "type": "github"
       },
       "original": {
@@ -458,11 +458,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1725068052,
-        "narHash": "sha256-WqofagIIyZ/hY6vJH65OLXVBgi2FNOezjybwniBvN14=",
+        "lastModified": 1725672853,
+        "narHash": "sha256-z1O6dzCJ27OZpF680tZL0mQphQETdg4DTryvhFOpZyA=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "27661753057dc1d259c7918f6c6777bea26290f1",
+        "rev": "efd33fc8e5a149dd48d86ca6003b51ab3ce4ae21",
         "type": "github"
       },
       "original": {
@@ -473,11 +473,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723175592,
-        "narHash": "sha256-M0xJ3FbDUc4fRZ84dPGx5VvgFsOzds77KiBMW/mMTnI=",
+        "lastModified": 1724819573,
+        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
+        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
         "type": "github"
       },
       "original": {
@@ -489,23 +489,23 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1722555339,
-        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       }
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1725121419,
-        "narHash": "sha256-njodFwX6ed548gA6AWxIa2rGNsiQ+HfVExgaYEANpQM=",
+        "lastModified": 1725727019,
+        "narHash": "sha256-gK337ScwOHTfr79Tdbmt0qrmQfveLB4NtMjqQZXcNUo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a162eecfdc28db4fb932ee53050ebf25ca37eec9",
+        "rev": "de299daf5e38b67ad16fb0bba7c22b917098d0f7",
         "type": "github"
       },
       "original": {
@@ -549,11 +549,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1724224976,
-        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
+        "lastModified": 1711001935,
+        "narHash": "sha256-URtGpHue7HHZK0mrHnSf8wJ6OmMKYSsoLmJybrOLFSQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
+        "rev": "20f77aa09916374aa3141cbc605c955626762c9a",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1724819573,
-        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
+        "lastModified": 1725634671,
+        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
         "type": "github"
       },
       "original": {
@@ -597,11 +597,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1725115514,
-        "narHash": "sha256-llfa5ShJmYH4dYAwBf8B1c1lCv1GRq385VBfq4QztLw=",
+        "lastModified": 1725720394,
+        "narHash": "sha256-DMNkkUAI1bpRCaLYs+RR8+DFqfOh0ScBn/jjCQ3P0e4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a8d5d58e80863bff01f9800f8f6f8bf9c207d0a",
+        "rev": "63fc93a575265d2764ad65817e0415c24cfc8801",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725077747,
-        "narHash": "sha256-4SwFxe789QXOtGNFbwldpqFzkKxIFuyDysFttFWB5eM=",
+        "lastModified": 1725682572,
+        "narHash": "sha256-K5feij1p3mheXVD6NO9l5LjAHPFRXucWT60/x+l2pf0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "305b6034ad329268eb33c079e2d33740ccf329ea",
+        "rev": "c208a9bd17d0e0b9dc91dd20b5fe0ff5df3b9ac8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 36

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/af510d4a62d071ea13925ce41c95e3dec816c01d' (2024-08-30)
  → 'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6' (2024-09-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz?narHash=sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q%3D' (2024-08-01)
  → 'https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz?narHash=sha256-Ss8QWLXdr2JCBPcYChJhz4xJm%2Bh/xjl4G0c0XlP6a74%3D' (2024-09-01)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/4509ca64f1084e73bc7a721b20c669a8d4c5ebe6' (2024-08-28)
  → 'github:cachix/git-hooks.nix/7570de7b9b504cfe92025dd1be797bf546f66528' (2024-09-05)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c2cd2a52e02f1dfa1c88f95abeb89298d46023be' (2024-08-23)
  → 'github:nix-community/home-manager/aaebdea769a5c10f1c6e50ebdf5924c1a13f0cda' (2024-09-07)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/e333d62b70b179da1dd78d94315e8a390f2d12e5' (2024-08-25)
  → 'github:nix-community/nix-index-database/32058e9138248874773630c846563b1a78ee7a5b' (2024-09-01)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/5e0ca22929f3342b19569b21b2f3462f053e497b' (2024-08-09)
  → 'github:NixOS/nixpkgs/71e91c409d1e654808b2621f28a327acfdad8dc2' (2024-08-28)
• Updated input 'nix-ld-rs/nixpkgs':
    'github:NixOS/nixpkgs/c374d94f1536013ca8e92341b540eba4c22f9c62' (2024-08-21)
  → 'github:NixOS/nixpkgs/20f77aa09916374aa3141cbc605c955626762c9a' (2024-03-21)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/27661753057dc1d259c7918f6c6777bea26290f1' (2024-08-31)
  → 'github:nix-community/nix-vscode-extensions/efd33fc8e5a149dd48d86ca6003b51ab3ce4ae21' (2024-09-07)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/71e91c409d1e654808b2621f28a327acfdad8dc2' (2024-08-28)
  → 'github:NixOS/nixpkgs/574d1eac1c200690e27b8eb4e24887f8df7ac27c' (2024-09-06)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/a162eecfdc28db4fb932ee53050ebf25ca37eec9' (2024-08-31)
  → 'github:NixOS/nixpkgs/de299daf5e38b67ad16fb0bba7c22b917098d0f7' (2024-09-07)
• Updated input 'nur':
    'github:nix-community/NUR/2a8d5d58e80863bff01f9800f8f6f8bf9c207d0a' (2024-08-31)
  → 'github:nix-community/NUR/63fc93a575265d2764ad65817e0415c24cfc8801' (2024-09-07)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/305b6034ad329268eb33c079e2d33740ccf329ea' (2024-08-31)
  → 'github:Gerg-L/spicetify-nix/c208a9bd17d0e0b9dc91dd20b5fe0ff5df3b9ac8' (2024-09-07)
```

Sources Changelog:
```
fastfetch: 99e0dc9aaa9ecf3645c086258149058beb1442af → 1e4601485a46bdb7c3601ffcba577e67495a44b9
arr_scripts: ae84972d035ee14966c176fb420fbe1d28402feb → 32d14192f1afbadb20cefd6edf261d38a4474863
```
