### PR TITLE
chore: update flake.lock & sources (2024-09-14)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "arr_scripts": {
         "cargoLocks": null,
-        "date": "2024-09-05",
+        "date": "2024-09-09",
         "extract": null,
         "name": "arr_scripts",
         "passthru": null,
@@ -13,11 +13,11 @@
             "name": null,
             "owner": "RandomNinjaAtk",
             "repo": "arr-scripts",
-            "rev": "32d14192f1afbadb20cefd6edf261d38a4474863",
-            "sha256": "sha256-fp9Kcq95KTLvbDYwiadmcSG171E4Uf6Ybsbkr/SytKs=",
+            "rev": "394c395fa6451771b5b64e7cba6edcea9bee6b9b",
+            "sha256": "sha256-fBUt5SOsOsnNiiLNtgyi7/hOInfTi1a0D7O8cIyg8xM=",
             "type": "github"
         },
-        "version": "32d14192f1afbadb20cefd6edf261d38a4474863"
+        "version": "394c395fa6451771b5b64e7cba6edcea9bee6b9b"
     },
     "bottom_catppuccin": {
         "cargoLocks": null,
@@ -101,7 +101,7 @@
     },
     "fastfetch": {
         "cargoLocks": null,
-        "date": "2024-09-07",
+        "date": "2024-09-14",
         "extract": null,
         "name": "fastfetch",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "fastfetch-cli",
             "repo": "fastfetch",
-            "rev": "1e4601485a46bdb7c3601ffcba577e67495a44b9",
-            "sha256": "sha256-vZeL3bqwTxbVSdDUVjjoyNUToLPqjVSnd5UyAydm6UM=",
+            "rev": "3381062ab9e32bb062732cf6aecf4c1f99b73b4d",
+            "sha256": "sha256-DrgNYTiOcP8fxm8JNMvuKivzADFVBc2b/IeDjbsPEds=",
             "type": "github"
         },
-        "version": "1e4601485a46bdb7c3601ffcba577e67495a44b9"
+        "version": "3381062ab9e32bb062732cf6aecf4c1f99b73b4d"
     },
     "filen": {
         "cargoLocks": null,
@@ -286,7 +286,7 @@
     },
     "obs_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-08-30",
+        "date": "2024-09-14",
         "extract": null,
         "name": "obs_catppuccin",
         "passthru": null,
@@ -298,11 +298,11 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "obs",
-            "rev": "b17939991545bdd6232e688ec5004b6dfae46f69",
-            "sha256": "sha256-1Stlcfcl/DZMPPqsShst849Ns0Lgk9D2SekMhTy7zZY=",
+            "rev": "d90002a5315db3a43c39dc52c2a91a99c9330e1f",
+            "sha256": "sha256-rU4WTj+2E/+OblAeK0+nzJhisz2V2/KwHBiJVBRj+LQ=",
             "type": "github"
         },
-        "version": "b17939991545bdd6232e688ec5004b6dfae46f69"
+        "version": "d90002a5315db3a43c39dc52c2a91a99c9330e1f"
     },
     "prismlauncher_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,15 +3,15 @@
 {
   arr_scripts = {
     pname = "arr_scripts";
-    version = "32d14192f1afbadb20cefd6edf261d38a4474863";
+    version = "394c395fa6451771b5b64e7cba6edcea9bee6b9b";
     src = fetchFromGitHub {
       owner = "RandomNinjaAtk";
       repo = "arr-scripts";
-      rev = "32d14192f1afbadb20cefd6edf261d38a4474863";
+      rev = "394c395fa6451771b5b64e7cba6edcea9bee6b9b";
       fetchSubmodules = false;
-      sha256 = "sha256-fp9Kcq95KTLvbDYwiadmcSG171E4Uf6Ybsbkr/SytKs=";
+      sha256 = "sha256-fBUt5SOsOsnNiiLNtgyi7/hOInfTi1a0D7O8cIyg8xM=";
     };
-    date = "2024-09-05";
+    date = "2024-09-09";
   };
   bottom_catppuccin = {
     pname = "bottom_catppuccin";
@@ -63,15 +63,15 @@
   };
   fastfetch = {
     pname = "fastfetch";
-    version = "1e4601485a46bdb7c3601ffcba577e67495a44b9";
+    version = "3381062ab9e32bb062732cf6aecf4c1f99b73b4d";
     src = fetchFromGitHub {
       owner = "fastfetch-cli";
       repo = "fastfetch";
-      rev = "1e4601485a46bdb7c3601ffcba577e67495a44b9";
+      rev = "3381062ab9e32bb062732cf6aecf4c1f99b73b4d";
       fetchSubmodules = false;
-      sha256 = "sha256-vZeL3bqwTxbVSdDUVjjoyNUToLPqjVSnd5UyAydm6UM=";
+      sha256 = "sha256-DrgNYTiOcP8fxm8JNMvuKivzADFVBc2b/IeDjbsPEds=";
     };
-    date = "2024-09-07";
+    date = "2024-09-14";
   };
   filen = {
     pname = "filen";
@@ -170,15 +170,15 @@
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";
-    version = "b17939991545bdd6232e688ec5004b6dfae46f69";
+    version = "d90002a5315db3a43c39dc52c2a91a99c9330e1f";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "obs";
-      rev = "b17939991545bdd6232e688ec5004b6dfae46f69";
+      rev = "d90002a5315db3a43c39dc52c2a91a99c9330e1f";
       fetchSubmodules = false;
-      sha256 = "sha256-1Stlcfcl/DZMPPqsShst849Ns0Lgk9D2SekMhTy7zZY=";
+      sha256 = "sha256-rU4WTj+2E/+OblAeK0+nzJhisz2V2/KwHBiJVBRj+LQ=";
     };
-    date = "2024-08-30";
+    date = "2024-09-14";
   };
   prismlauncher_catppuccin = {
     pname = "prismlauncher_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
         "type": "github"
       },
       "original": {
@@ -352,11 +352,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725694918,
-        "narHash": "sha256-+HsjshXpqNiJHLaJaK0JnIicJ/a1NquKcfn4YZ3ILgg=",
+        "lastModified": 1726308872,
+        "narHash": "sha256-d4vwO5N4RsLnCY7k5tY9xbdYDWQsY3RDMeUoIa4ms2A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aaebdea769a5c10f1c6e50ebdf5924c1a13f0cda",
+        "rev": "6c1a461a444e6ccb3f3e42bb627b510c3a722a57",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1725161148,
-        "narHash": "sha256-WfAHq3Ag3vLNFfWxKHjFBFdPI6JIideWFJod9mx1eoo=",
+        "lastModified": 1725765290,
+        "narHash": "sha256-hwX53i24KyWzp2nWpQsn8lfGQNCP0JoW/bvQmcR1DPY=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "32058e9138248874773630c846563b1a78ee7a5b",
+        "rev": "642275444c5a9defce57219c944b3179bf2adaa9",
         "type": "github"
       },
       "original": {
@@ -458,11 +458,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1725672853,
-        "narHash": "sha256-z1O6dzCJ27OZpF680tZL0mQphQETdg4DTryvhFOpZyA=",
+        "lastModified": 1726277723,
+        "narHash": "sha256-/Dk8qrBs9XE2kS3bbvKaq+EZTH9lTsSrkxx/MdTQZ4s=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "efd33fc8e5a149dd48d86ca6003b51ab3ce4ae21",
+        "rev": "42c1ec06e709349f11bec2b3c61a75018bd6b9b9",
         "type": "github"
       },
       "original": {
@@ -473,11 +473,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724819573,
-        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
+        "lastModified": 1725634671,
+        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
         "type": "github"
       },
       "original": {
@@ -501,11 +501,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1725727019,
-        "narHash": "sha256-gK337ScwOHTfr79Tdbmt0qrmQfveLB4NtMjqQZXcNUo=",
+        "lastModified": 1726331641,
+        "narHash": "sha256-628FUBGEJDHpFTSTap/wVX4VuFQzpi5973hH6r7m/ew=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "de299daf5e38b67ad16fb0bba7c22b917098d0f7",
+        "rev": "dfc36088ba14cfe145cad673c92dba5cca7323e1",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1725634671,
-        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
+        "lastModified": 1726062873,
+        "narHash": "sha256-IiA3jfbR7K/B5+9byVi9BZGWTD4VSbWe8VLpp9B/iYk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
+        "rev": "4f807e8940284ad7925ebd0a0993d2a1791acb2f",
         "type": "github"
       },
       "original": {
@@ -597,11 +597,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1725720394,
-        "narHash": "sha256-DMNkkUAI1bpRCaLYs+RR8+DFqfOh0ScBn/jjCQ3P0e4=",
+        "lastModified": 1726321580,
+        "narHash": "sha256-nJDp7hN8VAkO62b72d4PGEe9tIl9bn1dn8yIkr9FeCU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "63fc93a575265d2764ad65817e0415c24cfc8801",
+        "rev": "49761a5e726649905d015b3b41295ea7fe3d0d71",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725682572,
-        "narHash": "sha256-K5feij1p3mheXVD6NO9l5LjAHPFRXucWT60/x+l2pf0=",
+        "lastModified": 1726287383,
+        "narHash": "sha256-20DoHPEml+by2U2yja09tprLDFcimQAeL7kDIjLtyeo=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "c208a9bd17d0e0b9dc91dd20b5fe0ff5df3b9ac8",
+        "rev": "bb37104c197760c5cfca571036a1d011c4c92754",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 37

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6' (2024-09-01)
  → 'github:hercules-ci/flake-parts/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a' (2024-09-12)
• Updated input 'home-manager':
    'github:nix-community/home-manager/aaebdea769a5c10f1c6e50ebdf5924c1a13f0cda' (2024-09-07)
  → 'github:nix-community/home-manager/6c1a461a444e6ccb3f3e42bb627b510c3a722a57' (2024-09-14)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/32058e9138248874773630c846563b1a78ee7a5b' (2024-09-01)
  → 'github:nix-community/nix-index-database/642275444c5a9defce57219c944b3179bf2adaa9' (2024-09-08)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/71e91c409d1e654808b2621f28a327acfdad8dc2' (2024-08-28)
  → 'github:NixOS/nixpkgs/574d1eac1c200690e27b8eb4e24887f8df7ac27c' (2024-09-06)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/efd33fc8e5a149dd48d86ca6003b51ab3ce4ae21' (2024-09-07)
  → 'github:nix-community/nix-vscode-extensions/42c1ec06e709349f11bec2b3c61a75018bd6b9b9' (2024-09-14)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/574d1eac1c200690e27b8eb4e24887f8df7ac27c' (2024-09-06)
  → 'github:NixOS/nixpkgs/4f807e8940284ad7925ebd0a0993d2a1791acb2f' (2024-09-11)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/de299daf5e38b67ad16fb0bba7c22b917098d0f7' (2024-09-07)
  → 'github:NixOS/nixpkgs/dfc36088ba14cfe145cad673c92dba5cca7323e1' (2024-09-14)
• Updated input 'nur':
    'github:nix-community/NUR/63fc93a575265d2764ad65817e0415c24cfc8801' (2024-09-07)
  → 'github:nix-community/NUR/49761a5e726649905d015b3b41295ea7fe3d0d71' (2024-09-14)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/c208a9bd17d0e0b9dc91dd20b5fe0ff5df3b9ac8' (2024-09-07)
  → 'github:Gerg-L/spicetify-nix/bb37104c197760c5cfca571036a1d011c4c92754' (2024-09-14)
```

Sources Changelog:
```
arr_scripts: 32d14192f1afbadb20cefd6edf261d38a4474863 → 394c395fa6451771b5b64e7cba6edcea9bee6b9b
fastfetch: 1e4601485a46bdb7c3601ffcba577e67495a44b9 → 3381062ab9e32bb062732cf6aecf4c1f99b73b4d
obs_catppuccin: b17939991545bdd6232e688ec5004b6dfae46f69 → d90002a5315db3a43c39dc52c2a91a99c9330e1f
```
