### PR TITLE
chore: update flake.lock & sources (2024-09-21)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "arr_scripts": {
         "cargoLocks": null,
-        "date": "2024-09-09",
+        "date": "2024-09-16",
         "extract": null,
         "name": "arr_scripts",
         "passthru": null,
@@ -13,15 +13,15 @@
             "name": null,
             "owner": "RandomNinjaAtk",
             "repo": "arr-scripts",
-            "rev": "394c395fa6451771b5b64e7cba6edcea9bee6b9b",
-            "sha256": "sha256-fBUt5SOsOsnNiiLNtgyi7/hOInfTi1a0D7O8cIyg8xM=",
+            "rev": "ef8fc991dba53381c7a2c12fb844a31aa41c7e7b",
+            "sha256": "sha256-0h7Ab/wZBSTD2x0xfIiFz4yixH0TD4VzD+cu0RT7GVg=",
             "type": "github"
         },
-        "version": "394c395fa6451771b5b64e7cba6edcea9bee6b9b"
+        "version": "ef8fc991dba53381c7a2c12fb844a31aa41c7e7b"
     },
     "bottom_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-08-09",
+        "date": "2024-09-17",
         "extract": null,
         "name": "bottom_catppuccin",
         "passthru": null,
@@ -33,15 +33,15 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "bottom",
-            "rev": "f33104ec5be6cdde0559c2560f85130e48e10cff",
-            "sha256": "sha256-Ew2yryQFJRICy3RbtQnLMR5pphXPZp1PtaFVxAL2Eu4=",
+            "rev": "ed09bd5a5dd78d83acdc8ff5fdec40a6340ed1c2",
+            "sha256": "sha256-Vi438I+YVvoD2xzq2t9hJ9R3a+2TlDdbakjFYFtjtXQ=",
             "type": "github"
         },
-        "version": "f33104ec5be6cdde0559c2560f85130e48e10cff"
+        "version": "ed09bd5a5dd78d83acdc8ff5fdec40a6340ed1c2"
     },
     "calibre_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-05-10",
+        "date": "2024-09-14",
         "extract": null,
         "name": "calibre_catppuccin",
         "passthru": null,
@@ -53,11 +53,11 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "calibre",
-            "rev": "c0cea844e74b6ffb346969839f8548f96fcde14d",
-            "sha256": "sha256-/Ipm3V6AJrqugg3Er6u1wriOF8NOmdFdSc2bKRfLvV0=",
+            "rev": "27bd12d2d8dcd24b9ce7cae32135fbd41b896921",
+            "sha256": "sha256-JnovYvkIjQXHMFWsmAYIKiA1aexDI3+IkuwwpRdMIcs=",
             "type": "github"
         },
-        "version": "c0cea844e74b6ffb346969839f8548f96fcde14d"
+        "version": "27bd12d2d8dcd24b9ce7cae32135fbd41b896921"
     },
     "catppuccin_zsh_syntax_highlighting": {
         "cargoLocks": null,
@@ -101,7 +101,7 @@
     },
     "fastfetch": {
         "cargoLocks": null,
-        "date": "2024-09-14",
+        "date": "2024-09-21",
         "extract": null,
         "name": "fastfetch",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "fastfetch-cli",
             "repo": "fastfetch",
-            "rev": "3381062ab9e32bb062732cf6aecf4c1f99b73b4d",
-            "sha256": "sha256-DrgNYTiOcP8fxm8JNMvuKivzADFVBc2b/IeDjbsPEds=",
+            "rev": "005d660d77a4a217c0cc46167197ea80a762c9c4",
+            "sha256": "sha256-C9Mv0Sou9pts8496gx+gITNVDeHcwSTevAmlKCYlLVE=",
             "type": "github"
         },
-        "version": "3381062ab9e32bb062732cf6aecf4c1f99b73b4d"
+        "version": "005d660d77a4a217c0cc46167197ea80a762c9c4"
     },
     "filen": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,39 +3,39 @@
 {
   arr_scripts = {
     pname = "arr_scripts";
-    version = "394c395fa6451771b5b64e7cba6edcea9bee6b9b";
+    version = "ef8fc991dba53381c7a2c12fb844a31aa41c7e7b";
     src = fetchFromGitHub {
       owner = "RandomNinjaAtk";
       repo = "arr-scripts";
-      rev = "394c395fa6451771b5b64e7cba6edcea9bee6b9b";
+      rev = "ef8fc991dba53381c7a2c12fb844a31aa41c7e7b";
       fetchSubmodules = false;
-      sha256 = "sha256-fBUt5SOsOsnNiiLNtgyi7/hOInfTi1a0D7O8cIyg8xM=";
+      sha256 = "sha256-0h7Ab/wZBSTD2x0xfIiFz4yixH0TD4VzD+cu0RT7GVg=";
     };
-    date = "2024-09-09";
+    date = "2024-09-16";
   };
   bottom_catppuccin = {
     pname = "bottom_catppuccin";
-    version = "f33104ec5be6cdde0559c2560f85130e48e10cff";
+    version = "ed09bd5a5dd78d83acdc8ff5fdec40a6340ed1c2";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "bottom";
-      rev = "f33104ec5be6cdde0559c2560f85130e48e10cff";
+      rev = "ed09bd5a5dd78d83acdc8ff5fdec40a6340ed1c2";
       fetchSubmodules = false;
-      sha256 = "sha256-Ew2yryQFJRICy3RbtQnLMR5pphXPZp1PtaFVxAL2Eu4=";
+      sha256 = "sha256-Vi438I+YVvoD2xzq2t9hJ9R3a+2TlDdbakjFYFtjtXQ=";
     };
-    date = "2024-08-09";
+    date = "2024-09-17";
   };
   calibre_catppuccin = {
     pname = "calibre_catppuccin";
-    version = "c0cea844e74b6ffb346969839f8548f96fcde14d";
+    version = "27bd12d2d8dcd24b9ce7cae32135fbd41b896921";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "calibre";
-      rev = "c0cea844e74b6ffb346969839f8548f96fcde14d";
+      rev = "27bd12d2d8dcd24b9ce7cae32135fbd41b896921";
       fetchSubmodules = false;
-      sha256 = "sha256-/Ipm3V6AJrqugg3Er6u1wriOF8NOmdFdSc2bKRfLvV0=";
+      sha256 = "sha256-JnovYvkIjQXHMFWsmAYIKiA1aexDI3+IkuwwpRdMIcs=";
     };
-    date = "2024-05-10";
+    date = "2024-09-14";
   };
   catppuccin_zsh_syntax_highlighting = {
     pname = "catppuccin_zsh_syntax_highlighting";
@@ -63,15 +63,15 @@
   };
   fastfetch = {
     pname = "fastfetch";
-    version = "3381062ab9e32bb062732cf6aecf4c1f99b73b4d";
+    version = "005d660d77a4a217c0cc46167197ea80a762c9c4";
     src = fetchFromGitHub {
       owner = "fastfetch-cli";
       repo = "fastfetch";
-      rev = "3381062ab9e32bb062732cf6aecf4c1f99b73b4d";
+      rev = "005d660d77a4a217c0cc46167197ea80a762c9c4";
       fetchSubmodules = false;
-      sha256 = "sha256-DrgNYTiOcP8fxm8JNMvuKivzADFVBc2b/IeDjbsPEds=";
+      sha256 = "sha256-C9Mv0Sou9pts8496gx+gITNVDeHcwSTevAmlKCYlLVE=";
     };
-    date = "2024-09-14";
+    date = "2024-09-21";
   };
   filen = {
     pname = "filen";

--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725513492,
-        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
+        "lastModified": 1726745158,
+        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
+        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726308872,
-        "narHash": "sha256-d4vwO5N4RsLnCY7k5tY9xbdYDWQsY3RDMeUoIa4ms2A=",
+        "lastModified": 1726902823,
+        "narHash": "sha256-Gkc7pwTVLKj4HSvRt8tXNvosl8RS9hrBAEhOjAE0Tt4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6c1a461a444e6ccb3f3e42bb627b510c3a722a57",
+        "rev": "14929f7089268481d86b83ed31ffd88713dcd415",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1725765290,
-        "narHash": "sha256-hwX53i24KyWzp2nWpQsn8lfGQNCP0JoW/bvQmcR1DPY=",
+        "lastModified": 1726449931,
+        "narHash": "sha256-1AX7MyYzP7sNgZiGF8jwehCCI75y2kBGwACeryJs+yE=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "642275444c5a9defce57219c944b3179bf2adaa9",
+        "rev": "c1b0fa0bec5478185eae2fd3f39b9e906fc83995",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1726277723,
-        "narHash": "sha256-/Dk8qrBs9XE2kS3bbvKaq+EZTH9lTsSrkxx/MdTQZ4s=",
+        "lastModified": 1726882701,
+        "narHash": "sha256-n0m5F0Q2ZF6egEm0mvzLCVImzwJaT0GVzYVwD+UnqwE=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "42c1ec06e709349f11bec2b3c61a75018bd6b9b9",
+        "rev": "8822dcf9078f408c5ddbdbbd5c2dc9782fe5eb61",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725634671,
-        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
+        "lastModified": 1726062873,
+        "narHash": "sha256-IiA3jfbR7K/B5+9byVi9BZGWTD4VSbWe8VLpp9B/iYk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
+        "rev": "4f807e8940284ad7925ebd0a0993d2a1791acb2f",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1726331641,
-        "narHash": "sha256-628FUBGEJDHpFTSTap/wVX4VuFQzpi5973hH6r7m/ew=",
+        "lastModified": 1726936325,
+        "narHash": "sha256-k9m9lY9ae4Fnnvg9ZuCYFITMg/MmZLFsKpvTfsm6qjg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfc36088ba14cfe145cad673c92dba5cca7323e1",
+        "rev": "927b67cdc004be8e72e02bf43ff206279b517c63",
         "type": "github"
       },
       "original": {
@@ -527,11 +527,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1726062873,
-        "narHash": "sha256-IiA3jfbR7K/B5+9byVi9BZGWTD4VSbWe8VLpp9B/iYk=",
+        "lastModified": 1726755586,
+        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f807e8940284ad7925ebd0a0993d2a1791acb2f",
+        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
         "type": "github"
       },
       "original": {
@@ -543,11 +543,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1726321580,
-        "narHash": "sha256-nJDp7hN8VAkO62b72d4PGEe9tIl9bn1dn8yIkr9FeCU=",
+        "lastModified": 1726933447,
+        "narHash": "sha256-FH7ilXBForOvOVGp/hjK1hMh5msjzEM+K6krEC1wLbw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49761a5e726649905d015b3b41295ea7fe3d0d71",
+        "rev": "b86b903ac173a19c038b4e8d4ae300351de5509c",
         "type": "github"
       },
       "original": {
@@ -635,11 +635,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726287383,
-        "narHash": "sha256-20DoHPEml+by2U2yja09tprLDFcimQAeL7kDIjLtyeo=",
+        "lastModified": 1726892163,
+        "narHash": "sha256-LZkatWOJcdJ1FvhWNFl54r8aDcnIfeZC5MLtzN15vMc=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "bb37104c197760c5cfca571036a1d011c4c92754",
+        "rev": "426f126ac7014ba7076ddcbf2fafa87c2962d908",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 38

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/7570de7b9b504cfe92025dd1be797bf546f66528' (2024-09-05)
  → 'github:cachix/git-hooks.nix/4e743a6920eab45e8ba0fbe49dc459f1423a4b74' (2024-09-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/6c1a461a444e6ccb3f3e42bb627b510c3a722a57' (2024-09-14)
  → 'github:nix-community/home-manager/14929f7089268481d86b83ed31ffd88713dcd415' (2024-09-21)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/642275444c5a9defce57219c944b3179bf2adaa9' (2024-09-08)
  → 'github:nix-community/nix-index-database/c1b0fa0bec5478185eae2fd3f39b9e906fc83995' (2024-09-16)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/574d1eac1c200690e27b8eb4e24887f8df7ac27c' (2024-09-06)
  → 'github:NixOS/nixpkgs/4f807e8940284ad7925ebd0a0993d2a1791acb2f' (2024-09-11)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/42c1ec06e709349f11bec2b3c61a75018bd6b9b9' (2024-09-14)
  → 'github:nix-community/nix-vscode-extensions/8822dcf9078f408c5ddbdbbd5c2dc9782fe5eb61' (2024-09-21)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/4f807e8940284ad7925ebd0a0993d2a1791acb2f' (2024-09-11)
  → 'github:NixOS/nixpkgs/c04d5652cfa9742b1d519688f65d1bbccea9eb7e' (2024-09-19)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/dfc36088ba14cfe145cad673c92dba5cca7323e1' (2024-09-14)
  → 'github:NixOS/nixpkgs/927b67cdc004be8e72e02bf43ff206279b517c63' (2024-09-21)
• Updated input 'nur':
    'github:nix-community/NUR/49761a5e726649905d015b3b41295ea7fe3d0d71' (2024-09-14)
  → 'github:nix-community/NUR/b86b903ac173a19c038b4e8d4ae300351de5509c' (2024-09-21)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/bb37104c197760c5cfca571036a1d011c4c92754' (2024-09-14)
  → 'github:Gerg-L/spicetify-nix/426f126ac7014ba7076ddcbf2fafa87c2962d908' (2024-09-21)
```

Sources Changelog:
```
fastfetch: 3381062ab9e32bb062732cf6aecf4c1f99b73b4d → 005d660d77a4a217c0cc46167197ea80a762c9c4
arr_scripts: 394c395fa6451771b5b64e7cba6edcea9bee6b9b → ef8fc991dba53381c7a2c12fb844a31aa41c7e7b
calibre_catppuccin: c0cea844e74b6ffb346969839f8548f96fcde14d → 27bd12d2d8dcd24b9ce7cae32135fbd41b896921
bottom_catppuccin: f33104ec5be6cdde0559c2560f85130e48e10cff → ed09bd5a5dd78d83acdc8ff5fdec40a6340ed1c2
```
