### PR TITLE
chore: update flake.lock & sources (2024-09-28)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -101,7 +101,7 @@
     },
     "fastfetch": {
         "cargoLocks": null,
-        "date": "2024-09-21",
+        "date": "2024-09-28",
         "extract": null,
         "name": "fastfetch",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "fastfetch-cli",
             "repo": "fastfetch",
-            "rev": "005d660d77a4a217c0cc46167197ea80a762c9c4",
-            "sha256": "sha256-C9Mv0Sou9pts8496gx+gITNVDeHcwSTevAmlKCYlLVE=",
+            "rev": "140b9834cc453388ef15cdd53bc3c813b947ab94",
+            "sha256": "sha256-1MED0XRu0+VAR2Zo7AzvjnF71PP3Ui89pAJZcFEDXF8=",
             "type": "github"
         },
-        "version": "005d660d77a4a217c0cc46167197ea80a762c9c4"
+        "version": "140b9834cc453388ef15cdd53bc3c813b947ab94"
     },
     "filen": {
         "cargoLocks": null,
@@ -156,7 +156,7 @@
     },
     "foot_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-07-20",
+        "date": "2024-09-25",
         "extract": null,
         "name": "foot_catppuccin",
         "passthru": null,
@@ -168,11 +168,11 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "foot",
-            "rev": "17e2bdc8a8d854e8d390919579f87ab7d5f86e38",
-            "sha256": "sha256-L5/HvBe4jGTHNSCxFL+xRh8CKYO3NLJ0ksVJIQxjsZA=",
+            "rev": "962ff1a5b6387bc5419e9788a773a080eea5f1e1",
+            "sha256": "sha256-eVH3BY2fZe0/OjqucM/IZthV8PMsM9XeIijOg8cNE1Y=",
             "type": "github"
         },
-        "version": "17e2bdc8a8d854e8d390919579f87ab7d5f86e38"
+        "version": "962ff1a5b6387bc5419e9788a773a080eea5f1e1"
     },
     "hyprland_background": {
         "cargoLocks": null,
@@ -266,7 +266,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2024-06-27",
+        "date": "2024-09-27",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -278,11 +278,11 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "030e586195c97424844965d2ce680140f6565c02",
-            "sha256": "sha256-8zW6eWvE9T03cMpo/hY8RRZIsSCfs1zmsJOkEZzuYwM=",
+            "rev": "bd134ae2ed8921e58f36bd36612a82906fffd7de",
+            "sha256": "sha256-7WYLxguYPJnmvj4FgmTZ4psrgF/nsW5oUBZ99m1JVyg=",
             "type": "github"
         },
-        "version": "030e586195c97424844965d2ce680140f6565c02"
+        "version": "bd134ae2ed8921e58f36bd36612a82906fffd7de"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -63,15 +63,15 @@
   };
   fastfetch = {
     pname = "fastfetch";
-    version = "005d660d77a4a217c0cc46167197ea80a762c9c4";
+    version = "140b9834cc453388ef15cdd53bc3c813b947ab94";
     src = fetchFromGitHub {
       owner = "fastfetch-cli";
       repo = "fastfetch";
-      rev = "005d660d77a4a217c0cc46167197ea80a762c9c4";
+      rev = "140b9834cc453388ef15cdd53bc3c813b947ab94";
       fetchSubmodules = false;
-      sha256 = "sha256-C9Mv0Sou9pts8496gx+gITNVDeHcwSTevAmlKCYlLVE=";
+      sha256 = "sha256-1MED0XRu0+VAR2Zo7AzvjnF71PP3Ui89pAJZcFEDXF8=";
     };
-    date = "2024-09-21";
+    date = "2024-09-28";
   };
   filen = {
     pname = "filen";
@@ -94,15 +94,15 @@
   };
   foot_catppuccin = {
     pname = "foot_catppuccin";
-    version = "17e2bdc8a8d854e8d390919579f87ab7d5f86e38";
+    version = "962ff1a5b6387bc5419e9788a773a080eea5f1e1";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "foot";
-      rev = "17e2bdc8a8d854e8d390919579f87ab7d5f86e38";
+      rev = "962ff1a5b6387bc5419e9788a773a080eea5f1e1";
       fetchSubmodules = false;
-      sha256 = "sha256-L5/HvBe4jGTHNSCxFL+xRh8CKYO3NLJ0ksVJIQxjsZA=";
+      sha256 = "sha256-eVH3BY2fZe0/OjqucM/IZthV8PMsM9XeIijOg8cNE1Y=";
     };
-    date = "2024-07-20";
+    date = "2024-09-25";
   };
   hyprland_background = {
     pname = "hyprland_background";
@@ -158,15 +158,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "030e586195c97424844965d2ce680140f6565c02";
+    version = "bd134ae2ed8921e58f36bd36612a82906fffd7de";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "030e586195c97424844965d2ce680140f6565c02";
+      rev = "bd134ae2ed8921e58f36bd36612a82906fffd7de";
       fetchSubmodules = false;
-      sha256 = "sha256-8zW6eWvE9T03cMpo/hY8RRZIsSCfs1zmsJOkEZzuYwM=";
+      sha256 = "sha256-7WYLxguYPJnmvj4FgmTZ4psrgF/nsW5oUBZ99m1JVyg=";
     };
-    date = "2024-06-27";
+    date = "2024-09-27";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726745158,
-        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
+        "lastModified": 1727514110,
+        "narHash": "sha256-0YRcOxJG12VGDFH8iS8pJ0aYQQUAgo/r3ZAL+cSh9nk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
+        "rev": "85f7a7177c678de68224af3402ab8ee1bcee25c8",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726902823,
-        "narHash": "sha256-Gkc7pwTVLKj4HSvRt8tXNvosl8RS9hrBAEhOjAE0Tt4=",
+        "lastModified": 1727383923,
+        "narHash": "sha256-4/vacp3CwdGoPf8U4e/N8OsGYtO09WTcQK5FqYfJbKs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "14929f7089268481d86b83ed31ffd88713dcd415",
+        "rev": "ffe2d07e771580a005e675108212597e5b367d2d",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1726449931,
-        "narHash": "sha256-1AX7MyYzP7sNgZiGF8jwehCCI75y2kBGwACeryJs+yE=",
+        "lastModified": 1726975622,
+        "narHash": "sha256-bPDZosnom0+02ywmMZAvmj7zvsQ6mVv/5kmvSgbTkaY=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "c1b0fa0bec5478185eae2fd3f39b9e906fc83995",
+        "rev": "c7515c2fdaf2e1f3f49856cef6cec95bb2138417",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1726882701,
-        "narHash": "sha256-n0m5F0Q2ZF6egEm0mvzLCVImzwJaT0GVzYVwD+UnqwE=",
+        "lastModified": 1727401573,
+        "narHash": "sha256-M3ApPZZbnnWbFTZwV4zEdWppPm3dfbzXVEzD3t1Xr9E=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "8822dcf9078f408c5ddbdbbd5c2dc9782fe5eb61",
+        "rev": "5e908d3ea3e85d444230077cfa93a378204eca38",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726062873,
-        "narHash": "sha256-IiA3jfbR7K/B5+9byVi9BZGWTD4VSbWe8VLpp9B/iYk=",
+        "lastModified": 1726755586,
+        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f807e8940284ad7925ebd0a0993d2a1791acb2f",
+        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1726936325,
-        "narHash": "sha256-k9m9lY9ae4Fnnvg9ZuCYFITMg/MmZLFsKpvTfsm6qjg=",
+        "lastModified": 1727540275,
+        "narHash": "sha256-EaxvWVdARz9+Y0R1B3emgZE5/ydCQISj3oWD50sdl9E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "927b67cdc004be8e72e02bf43ff206279b517c63",
+        "rev": "c9e4eba8f1db8b6602c71bb95ad7a3558690860b",
         "type": "github"
       },
       "original": {
@@ -527,11 +527,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1726755586,
-        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
+        "lastModified": 1727348695,
+        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
+        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
         "type": "github"
       },
       "original": {
@@ -543,11 +543,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1726933447,
-        "narHash": "sha256-FH7ilXBForOvOVGp/hjK1hMh5msjzEM+K6krEC1wLbw=",
+        "lastModified": 1727528107,
+        "narHash": "sha256-lITknUGWTaXxIkNeijopSsl26Q5xhOKmtH5f9y3OX5A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b86b903ac173a19c038b4e8d4ae300351de5509c",
+        "rev": "d148b56d5f3f8774c8dfabc269bbabd65afde015",
         "type": "github"
       },
       "original": {
@@ -635,11 +635,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726892163,
-        "narHash": "sha256-LZkatWOJcdJ1FvhWNFl54r8aDcnIfeZC5MLtzN15vMc=",
+        "lastModified": 1727496988,
+        "narHash": "sha256-fi7G9bODA4iUN1g9psIE1U3h7xulNLtwAq0ziwLh0oM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "426f126ac7014ba7076ddcbf2fafa87c2962d908",
+        "rev": "65a95ae7c145ed836ca7d4a1e6be5154125490cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 39

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/4e743a6920eab45e8ba0fbe49dc459f1423a4b74' (2024-09-19)
  → 'github:cachix/git-hooks.nix/85f7a7177c678de68224af3402ab8ee1bcee25c8' (2024-09-28)
• Updated input 'home-manager':
    'github:nix-community/home-manager/14929f7089268481d86b83ed31ffd88713dcd415' (2024-09-21)
  → 'github:nix-community/home-manager/ffe2d07e771580a005e675108212597e5b367d2d' (2024-09-26)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/c1b0fa0bec5478185eae2fd3f39b9e906fc83995' (2024-09-16)
  → 'github:nix-community/nix-index-database/c7515c2fdaf2e1f3f49856cef6cec95bb2138417' (2024-09-22)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/4f807e8940284ad7925ebd0a0993d2a1791acb2f' (2024-09-11)
  → 'github:NixOS/nixpkgs/c04d5652cfa9742b1d519688f65d1bbccea9eb7e' (2024-09-19)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/8822dcf9078f408c5ddbdbbd5c2dc9782fe5eb61' (2024-09-21)
  → 'github:nix-community/nix-vscode-extensions/5e908d3ea3e85d444230077cfa93a378204eca38' (2024-09-27)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c04d5652cfa9742b1d519688f65d1bbccea9eb7e' (2024-09-19)
  → 'github:NixOS/nixpkgs/1925c603f17fc89f4c8f6bf6f631a802ad85d784' (2024-09-26)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/927b67cdc004be8e72e02bf43ff206279b517c63' (2024-09-21)
  → 'github:NixOS/nixpkgs/c9e4eba8f1db8b6602c71bb95ad7a3558690860b' (2024-09-28)
• Updated input 'nur':
    'github:nix-community/NUR/b86b903ac173a19c038b4e8d4ae300351de5509c' (2024-09-21)
  → 'github:nix-community/NUR/d148b56d5f3f8774c8dfabc269bbabd65afde015' (2024-09-28)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/426f126ac7014ba7076ddcbf2fafa87c2962d908' (2024-09-21)
  → 'github:Gerg-L/spicetify-nix/65a95ae7c145ed836ca7d4a1e6be5154125490cf' (2024-09-28)
```

Sources Changelog:
```
nix-fast-build: 030e586195c97424844965d2ce680140f6565c02 → bd134ae2ed8921e58f36bd36612a82906fffd7de
foot_catppuccin: 17e2bdc8a8d854e8d390919579f87ab7d5f86e38 → 962ff1a5b6387bc5419e9788a773a080eea5f1e1
fastfetch: 005d660d77a4a217c0cc46167197ea80a762c9c4 → 140b9834cc453388ef15cdd53bc3c813b947ab94
```
