### PR TITLE
chore: update flake.lock & sources (2024-10-05)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,382 +1,382 @@
 {
-	"arr_scripts": {
-		"cargoLocks": null,
-		"date": "2024-09-16",
-		"extract": null,
-		"name": "arr_scripts",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "RandomNinjaAtk",
-			"repo": "arr-scripts",
-			"rev": "ef8fc991dba53381c7a2c12fb844a31aa41c7e7b",
-			"sha256": "sha256-0h7Ab/wZBSTD2x0xfIiFz4yixH0TD4VzD+cu0RT7GVg=",
-			"type": "github"
-		},
-		"version": "ef8fc991dba53381c7a2c12fb844a31aa41c7e7b"
-	},
-	"bottom_catppuccin": {
-		"cargoLocks": null,
-		"date": "2024-09-17",
-		"extract": null,
-		"name": "bottom_catppuccin",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "catppuccin",
-			"repo": "bottom",
-			"rev": "ed09bd5a5dd78d83acdc8ff5fdec40a6340ed1c2",
-			"sha256": "sha256-Vi438I+YVvoD2xzq2t9hJ9R3a+2TlDdbakjFYFtjtXQ=",
-			"type": "github"
-		},
-		"version": "ed09bd5a5dd78d83acdc8ff5fdec40a6340ed1c2"
-	},
-	"calibre_catppuccin": {
-		"cargoLocks": null,
-		"date": "2024-09-14",
-		"extract": null,
-		"name": "calibre_catppuccin",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "catppuccin",
-			"repo": "calibre",
-			"rev": "27bd12d2d8dcd24b9ce7cae32135fbd41b896921",
-			"sha256": "sha256-JnovYvkIjQXHMFWsmAYIKiA1aexDI3+IkuwwpRdMIcs=",
-			"type": "github"
-		},
-		"version": "27bd12d2d8dcd24b9ce7cae32135fbd41b896921"
-	},
-	"catppuccin_zsh_syntax_highlighting": {
-		"cargoLocks": null,
-		"date": "2024-07-20",
-		"extract": null,
-		"name": "catppuccin_zsh_syntax_highlighting",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "catppuccin",
-			"repo": "zsh-syntax-highlighting",
-			"rev": "7926c3d3e17d26b3779851a2255b95ee650bd928",
-			"sha256": "sha256-l6tztApzYpQ2/CiKuLBf8vI2imM6vPJuFdNDSEi7T/o=",
-			"type": "github"
-		},
-		"version": "7926c3d3e17d26b3779851a2255b95ee650bd928"
-	},
-	"dunst_catppuccin": {
-		"cargoLocks": null,
-		"date": "2024-07-20",
-		"extract": null,
-		"name": "dunst_catppuccin",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "catppuccin",
-			"repo": "dunst",
-			"rev": "f02cd2894411c9b4caa207cfd8ed6345f97c0455",
-			"sha256": "sha256-EadNqtF1m//blHkV660+d4YjDReVFU2Bzhs0Pb43jh4=",
-			"type": "github"
-		},
-		"version": "f02cd2894411c9b4caa207cfd8ed6345f97c0455"
-	},
-	"filen": {
-		"cargoLocks": null,
-		"date": null,
-		"extract": null,
-		"name": "filen",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"name": null,
-			"sha256": "sha256-5vkndT9V/81fUdzS+KTfAjPAGO0IJRx8QhNxBNG8nnU=",
-			"type": "url",
-			"url": "https://cdn.filen.io/desktop/release/filen_x86_64.AppImage"
-		},
-		"version": "latest"
-	},
-	"firefox-gnome-theme": {
-		"cargoLocks": null,
-		"date": null,
-		"extract": null,
-		"name": "firefox-gnome-theme",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "rafaelmardojai",
-			"repo": "firefox-gnome-theme",
-			"rev": "v129",
-			"sha256": "sha256-MOE9NeU2i6Ws1GhGmppMnjOHkNLl2MQMJmGhaMzdoJM=",
-			"type": "github"
-		},
-		"version": "v129"
-	},
-	"foot_catppuccin": {
-		"cargoLocks": null,
-		"date": "2024-09-25",
-		"extract": null,
-		"name": "foot_catppuccin",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "catppuccin",
-			"repo": "foot",
-			"rev": "962ff1a5b6387bc5419e9788a773a080eea5f1e1",
-			"sha256": "sha256-eVH3BY2fZe0/OjqucM/IZthV8PMsM9XeIijOg8cNE1Y=",
-			"type": "github"
-		},
-		"version": "962ff1a5b6387bc5419e9788a773a080eea5f1e1"
-	},
-	"hyprland_background": {
-		"cargoLocks": null,
-		"date": null,
-		"extract": null,
-		"name": "hyprland_background",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"name": null,
-			"sha256": "sha256-fmKFYw2gYAYFjOv4lr8IkXPtZfE1+88yKQ4vjEcax1s=",
-			"type": "url",
-			"url": "https://raw.githubusercontent.com/NixOS/nixos-artwork/master/wallpapers/nixos-wallpaper-catppuccin-mocha.png"
-		},
-		"version": "latest"
-	},
-	"hyprland_catppuccin": {
-		"cargoLocks": null,
-		"date": "2024-06-19",
-		"extract": null,
-		"name": "hyprland_catppuccin",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "catppuccin",
-			"repo": "hyprland",
-			"rev": "c388ac55563ddeea0afe9df79d4bfff0096b146b",
-			"sha256": "sha256-xSa/z0Pu+ioZ0gFH9qSo9P94NPkEMovstm1avJ7rvzM=",
-			"type": "github"
-		},
-		"version": "c388ac55563ddeea0afe9df79d4bfff0096b146b"
-	},
-	"hyprlock_background": {
-		"cargoLocks": null,
-		"date": null,
-		"extract": null,
-		"name": "hyprlock_background",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"name": null,
-			"sha256": "sha256-HRZYeKDmfA53kb3fZxuNWvR8cE96tLrqPZhX4+z4lZA=",
-			"type": "url",
-			"url": "https://raw.githubusercontent.com/zhichaoh/catppuccin-wallpapers/main/os/nix-black-4k.png"
-		},
-		"version": "latest"
-	},
-	"hyprlock_catppuccin": {
-		"cargoLocks": null,
-		"date": "2024-08-06",
-		"extract": null,
-		"name": "hyprlock_catppuccin",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "catppuccin",
-			"repo": "hyprlock",
-			"rev": "958e70b1cd8799defd16dee070d07f977d4fd76b",
-			"sha256": "sha256-l4CbAUeb/Tg603QnZ/VWxuGqRBztpHN0HLX/h8ndc5w=",
-			"type": "github"
-		},
-		"version": "958e70b1cd8799defd16dee070d07f977d4fd76b"
-	},
-	"joplin_catppuccin": {
-		"cargoLocks": null,
-		"date": "2024-06-21",
-		"extract": null,
-		"name": "joplin_catppuccin",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "catppuccin",
-			"repo": "joplin",
-			"rev": "b0a886ce7ba71b48fdbf72ad27f3446400ebcdb9",
-			"sha256": "sha256-H19iaemj7XWsd3r7OBvQinrNKMiYGl53ArIp49gZExs=",
-			"type": "github"
-		},
-		"version": "b0a886ce7ba71b48fdbf72ad27f3446400ebcdb9"
-	},
-	"nix-fast-build": {
-		"cargoLocks": null,
-		"date": "2024-09-27",
-		"extract": null,
-		"name": "nix-fast-build",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "Mic92",
-			"repo": "nix-fast-build",
-			"rev": "bd134ae2ed8921e58f36bd36612a82906fffd7de",
-			"sha256": "sha256-7WYLxguYPJnmvj4FgmTZ4psrgF/nsW5oUBZ99m1JVyg=",
-			"type": "github"
-		},
-		"version": "bd134ae2ed8921e58f36bd36612a82906fffd7de"
-	},
-	"obs_catppuccin": {
-		"cargoLocks": null,
-		"date": "2024-09-14",
-		"extract": null,
-		"name": "obs_catppuccin",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "catppuccin",
-			"repo": "obs",
-			"rev": "d90002a5315db3a43c39dc52c2a91a99c9330e1f",
-			"sha256": "sha256-rU4WTj+2E/+OblAeK0+nzJhisz2V2/KwHBiJVBRj+LQ=",
-			"type": "github"
-		},
-		"version": "d90002a5315db3a43c39dc52c2a91a99c9330e1f"
-	},
-	"prismlauncher_catppuccin": {
-		"cargoLocks": null,
-		"date": "2024-06-11",
-		"extract": null,
-		"name": "prismlauncher_catppuccin",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "catppuccin",
-			"repo": "prismlauncher",
-			"rev": "2edbdf5295bc3c12c3dd53b203ab91028fce2c54",
-			"sha256": "sha256-+yGrSZztf2sZ9frPT3ydIJDavo4eXs03cQWfdTAmn3w=",
-			"type": "github"
-		},
-		"version": "2edbdf5295bc3c12c3dd53b203ab91028fce2c54"
-	},
-	"rofi-bluetooth": {
-		"cargoLocks": null,
-		"date": "2023-02-03",
-		"extract": null,
-		"name": "rofi-bluetooth",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "nickclyde",
-			"repo": "rofi-bluetooth",
-			"rev": "9d91c048ff129819f4c6e9e48a17bd54343bbffb",
-			"sha256": "sha256-1Xe3QFThIvJDCUznDP5ZBzwZEMuqmxpDIV+BcVvQDG8=",
-			"type": "github"
-		},
-		"version": "9d91c048ff129819f4c6e9e48a17bd54343bbffb"
-	},
-	"rofi_catppuccin": {
-		"cargoLocks": null,
-		"date": "2024-06-20",
-		"extract": null,
-		"name": "rofi_catppuccin",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "catppuccin",
-			"repo": "rofi",
-			"rev": "b636a00fd40a7899a8206195464ae8b7f0450a6d",
-			"sha256": "sha256-zA8Zum19pDTgn0KdQ0gD2kqCOXK4OCHBidFpGwrJOqg=",
-			"type": "github"
-		},
-		"version": "b636a00fd40a7899a8206195464ae8b7f0450a6d"
-	},
-	"starship_catppuccin": {
-		"cargoLocks": null,
-		"date": "2024-08-16",
-		"extract": null,
-		"name": "starship_catppuccin",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"deepClone": false,
-			"fetchSubmodules": false,
-			"leaveDotGit": false,
-			"name": null,
-			"owner": "catppuccin",
-			"repo": "starship",
-			"rev": "3c4749512e7d552adf48e75e5182a271392ab176",
-			"sha256": "sha256-t/Hmd2dzBn0AbLUlbL8CBt19/we8spY5nMP0Z+VPMXA=",
-			"type": "github"
-		},
-		"version": "3c4749512e7d552adf48e75e5182a271392ab176"
-	},
-	"wickedwizard_picture": {
-		"cargoLocks": null,
-		"date": null,
-		"extract": null,
-		"name": "wickedwizard_picture",
-		"passthru": null,
-		"pinned": false,
-		"src": {
-			"name": null,
-			"sha256": "sha256-lagT6en5bMTeDsUmFFGMiFeg5O21RFUQez2Y0U8QYZU=",
-			"type": "url",
-			"url": "https://i.pinimg.com/736x/d9/f5/81/d9f58165f05408c80043abebdd62eea5.jpg"
-		},
-		"version": "latest"
-	}
+    "arr_scripts": {
+        "cargoLocks": null,
+        "date": "2024-09-16",
+        "extract": null,
+        "name": "arr_scripts",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "RandomNinjaAtk",
+            "repo": "arr-scripts",
+            "rev": "ef8fc991dba53381c7a2c12fb844a31aa41c7e7b",
+            "sha256": "sha256-0h7Ab/wZBSTD2x0xfIiFz4yixH0TD4VzD+cu0RT7GVg=",
+            "type": "github"
+        },
+        "version": "ef8fc991dba53381c7a2c12fb844a31aa41c7e7b"
+    },
+    "bottom_catppuccin": {
+        "cargoLocks": null,
+        "date": "2024-09-17",
+        "extract": null,
+        "name": "bottom_catppuccin",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "bottom",
+            "rev": "ed09bd5a5dd78d83acdc8ff5fdec40a6340ed1c2",
+            "sha256": "sha256-Vi438I+YVvoD2xzq2t9hJ9R3a+2TlDdbakjFYFtjtXQ=",
+            "type": "github"
+        },
+        "version": "ed09bd5a5dd78d83acdc8ff5fdec40a6340ed1c2"
+    },
+    "calibre_catppuccin": {
+        "cargoLocks": null,
+        "date": "2024-09-14",
+        "extract": null,
+        "name": "calibre_catppuccin",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "calibre",
+            "rev": "27bd12d2d8dcd24b9ce7cae32135fbd41b896921",
+            "sha256": "sha256-JnovYvkIjQXHMFWsmAYIKiA1aexDI3+IkuwwpRdMIcs=",
+            "type": "github"
+        },
+        "version": "27bd12d2d8dcd24b9ce7cae32135fbd41b896921"
+    },
+    "catppuccin_zsh_syntax_highlighting": {
+        "cargoLocks": null,
+        "date": "2024-07-20",
+        "extract": null,
+        "name": "catppuccin_zsh_syntax_highlighting",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "zsh-syntax-highlighting",
+            "rev": "7926c3d3e17d26b3779851a2255b95ee650bd928",
+            "sha256": "sha256-l6tztApzYpQ2/CiKuLBf8vI2imM6vPJuFdNDSEi7T/o=",
+            "type": "github"
+        },
+        "version": "7926c3d3e17d26b3779851a2255b95ee650bd928"
+    },
+    "dunst_catppuccin": {
+        "cargoLocks": null,
+        "date": "2024-07-20",
+        "extract": null,
+        "name": "dunst_catppuccin",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "dunst",
+            "rev": "f02cd2894411c9b4caa207cfd8ed6345f97c0455",
+            "sha256": "sha256-EadNqtF1m//blHkV660+d4YjDReVFU2Bzhs0Pb43jh4=",
+            "type": "github"
+        },
+        "version": "f02cd2894411c9b4caa207cfd8ed6345f97c0455"
+    },
+    "filen": {
+        "cargoLocks": null,
+        "date": null,
+        "extract": null,
+        "name": "filen",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-5vkndT9V/81fUdzS+KTfAjPAGO0IJRx8QhNxBNG8nnU=",
+            "type": "url",
+            "url": "https://cdn.filen.io/desktop/release/filen_x86_64.AppImage"
+        },
+        "version": "latest"
+    },
+    "firefox-gnome-theme": {
+        "cargoLocks": null,
+        "date": null,
+        "extract": null,
+        "name": "firefox-gnome-theme",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "rafaelmardojai",
+            "repo": "firefox-gnome-theme",
+            "rev": "v131",
+            "sha256": "sha256-nf+0/UR5TZArp3Dn3NS3nB+ZGqecTOTOZRCFM3a1veM=",
+            "type": "github"
+        },
+        "version": "v131"
+    },
+    "foot_catppuccin": {
+        "cargoLocks": null,
+        "date": "2024-09-25",
+        "extract": null,
+        "name": "foot_catppuccin",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "foot",
+            "rev": "962ff1a5b6387bc5419e9788a773a080eea5f1e1",
+            "sha256": "sha256-eVH3BY2fZe0/OjqucM/IZthV8PMsM9XeIijOg8cNE1Y=",
+            "type": "github"
+        },
+        "version": "962ff1a5b6387bc5419e9788a773a080eea5f1e1"
+    },
+    "hyprland_background": {
+        "cargoLocks": null,
+        "date": null,
+        "extract": null,
+        "name": "hyprland_background",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-fmKFYw2gYAYFjOv4lr8IkXPtZfE1+88yKQ4vjEcax1s=",
+            "type": "url",
+            "url": "https://raw.githubusercontent.com/NixOS/nixos-artwork/master/wallpapers/nixos-wallpaper-catppuccin-mocha.png"
+        },
+        "version": "latest"
+    },
+    "hyprland_catppuccin": {
+        "cargoLocks": null,
+        "date": "2024-06-19",
+        "extract": null,
+        "name": "hyprland_catppuccin",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "hyprland",
+            "rev": "c388ac55563ddeea0afe9df79d4bfff0096b146b",
+            "sha256": "sha256-xSa/z0Pu+ioZ0gFH9qSo9P94NPkEMovstm1avJ7rvzM=",
+            "type": "github"
+        },
+        "version": "c388ac55563ddeea0afe9df79d4bfff0096b146b"
+    },
+    "hyprlock_background": {
+        "cargoLocks": null,
+        "date": null,
+        "extract": null,
+        "name": "hyprlock_background",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-HRZYeKDmfA53kb3fZxuNWvR8cE96tLrqPZhX4+z4lZA=",
+            "type": "url",
+            "url": "https://raw.githubusercontent.com/zhichaoh/catppuccin-wallpapers/main/os/nix-black-4k.png"
+        },
+        "version": "latest"
+    },
+    "hyprlock_catppuccin": {
+        "cargoLocks": null,
+        "date": "2024-08-06",
+        "extract": null,
+        "name": "hyprlock_catppuccin",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "hyprlock",
+            "rev": "958e70b1cd8799defd16dee070d07f977d4fd76b",
+            "sha256": "sha256-l4CbAUeb/Tg603QnZ/VWxuGqRBztpHN0HLX/h8ndc5w=",
+            "type": "github"
+        },
+        "version": "958e70b1cd8799defd16dee070d07f977d4fd76b"
+    },
+    "joplin_catppuccin": {
+        "cargoLocks": null,
+        "date": "2024-06-21",
+        "extract": null,
+        "name": "joplin_catppuccin",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "joplin",
+            "rev": "b0a886ce7ba71b48fdbf72ad27f3446400ebcdb9",
+            "sha256": "sha256-H19iaemj7XWsd3r7OBvQinrNKMiYGl53ArIp49gZExs=",
+            "type": "github"
+        },
+        "version": "b0a886ce7ba71b48fdbf72ad27f3446400ebcdb9"
+    },
+    "nix-fast-build": {
+        "cargoLocks": null,
+        "date": "2024-10-05",
+        "extract": null,
+        "name": "nix-fast-build",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "Mic92",
+            "repo": "nix-fast-build",
+            "rev": "2ba025eab61fe026a76bbab3579d1f051dde5275",
+            "sha256": "sha256-gYTZbNvQ7Gz29SRRzoJWHGzktEI6CqPBoXiPVIXdE9c=",
+            "type": "github"
+        },
+        "version": "2ba025eab61fe026a76bbab3579d1f051dde5275"
+    },
+    "obs_catppuccin": {
+        "cargoLocks": null,
+        "date": "2024-09-14",
+        "extract": null,
+        "name": "obs_catppuccin",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "obs",
+            "rev": "d90002a5315db3a43c39dc52c2a91a99c9330e1f",
+            "sha256": "sha256-rU4WTj+2E/+OblAeK0+nzJhisz2V2/KwHBiJVBRj+LQ=",
+            "type": "github"
+        },
+        "version": "d90002a5315db3a43c39dc52c2a91a99c9330e1f"
+    },
+    "prismlauncher_catppuccin": {
+        "cargoLocks": null,
+        "date": "2024-06-11",
+        "extract": null,
+        "name": "prismlauncher_catppuccin",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "prismlauncher",
+            "rev": "2edbdf5295bc3c12c3dd53b203ab91028fce2c54",
+            "sha256": "sha256-+yGrSZztf2sZ9frPT3ydIJDavo4eXs03cQWfdTAmn3w=",
+            "type": "github"
+        },
+        "version": "2edbdf5295bc3c12c3dd53b203ab91028fce2c54"
+    },
+    "rofi-bluetooth": {
+        "cargoLocks": null,
+        "date": "2023-02-03",
+        "extract": null,
+        "name": "rofi-bluetooth",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "nickclyde",
+            "repo": "rofi-bluetooth",
+            "rev": "9d91c048ff129819f4c6e9e48a17bd54343bbffb",
+            "sha256": "sha256-1Xe3QFThIvJDCUznDP5ZBzwZEMuqmxpDIV+BcVvQDG8=",
+            "type": "github"
+        },
+        "version": "9d91c048ff129819f4c6e9e48a17bd54343bbffb"
+    },
+    "rofi_catppuccin": {
+        "cargoLocks": null,
+        "date": "2024-06-20",
+        "extract": null,
+        "name": "rofi_catppuccin",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "rofi",
+            "rev": "b636a00fd40a7899a8206195464ae8b7f0450a6d",
+            "sha256": "sha256-zA8Zum19pDTgn0KdQ0gD2kqCOXK4OCHBidFpGwrJOqg=",
+            "type": "github"
+        },
+        "version": "b636a00fd40a7899a8206195464ae8b7f0450a6d"
+    },
+    "starship_catppuccin": {
+        "cargoLocks": null,
+        "date": "2024-08-16",
+        "extract": null,
+        "name": "starship_catppuccin",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "starship",
+            "rev": "3c4749512e7d552adf48e75e5182a271392ab176",
+            "sha256": "sha256-t/Hmd2dzBn0AbLUlbL8CBt19/we8spY5nMP0Z+VPMXA=",
+            "type": "github"
+        },
+        "version": "3c4749512e7d552adf48e75e5182a271392ab176"
+    },
+    "wickedwizard_picture": {
+        "cargoLocks": null,
+        "date": null,
+        "extract": null,
+        "name": "wickedwizard_picture",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-lagT6en5bMTeDsUmFFGMiFeg5O21RFUQez2Y0U8QYZU=",
+            "type": "url",
+            "url": "https://i.pinimg.com/736x/d9/f5/81/d9f58165f05408c80043abebdd62eea5.jpg"
+        },
+        "version": "latest"
+    }
 }

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -71,13 +71,13 @@
   };
   firefox-gnome-theme = {
     pname = "firefox-gnome-theme";
-    version = "v129";
+    version = "v131";
     src = fetchFromGitHub {
       owner = "rafaelmardojai";
       repo = "firefox-gnome-theme";
-      rev = "v129";
+      rev = "v131";
       fetchSubmodules = false;
-      sha256 = "sha256-MOE9NeU2i6Ws1GhGmppMnjOHkNLl2MQMJmGhaMzdoJM=";
+      sha256 = "sha256-nf+0/UR5TZArp3Dn3NS3nB+ZGqecTOTOZRCFM3a1veM=";
     };
   };
   foot_catppuccin = {
@@ -146,15 +146,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "bd134ae2ed8921e58f36bd36612a82906fffd7de";
+    version = "2ba025eab61fe026a76bbab3579d1f051dde5275";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "bd134ae2ed8921e58f36bd36612a82906fffd7de";
+      rev = "2ba025eab61fe026a76bbab3579d1f051dde5275";
       fetchSubmodules = false;
-      sha256 = "sha256-7WYLxguYPJnmvj4FgmTZ4psrgF/nsW5oUBZ99m1JVyg=";
+      sha256 = "sha256-gYTZbNvQ7Gz29SRRzoJWHGzktEI6CqPBoXiPVIXdE9c=";
     };
-    date = "2024-09-27";
+    date = "2024-10-05";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -157,11 +157,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1726153070,
-        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727514110,
-        "narHash": "sha256-0YRcOxJG12VGDFH8iS8pJ0aYQQUAgo/r3ZAL+cSh9nk=",
+        "lastModified": 1728092656,
+        "narHash": "sha256-eMeCTJZ5xBeQ0f9Os7K8DThNVSo9gy4umZLDfF5q6OM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "85f7a7177c678de68224af3402ab8ee1bcee25c8",
+        "rev": "1211305a5b237771e13fcca0c51e60ad47326a9a",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727383923,
-        "narHash": "sha256-4/vacp3CwdGoPf8U4e/N8OsGYtO09WTcQK5FqYfJbKs=",
+        "lastModified": 1728041527,
+        "narHash": "sha256-03liqiJtk9UP7YQHW4r8MduKCK242FQzud8iWvvlK+o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ffe2d07e771580a005e675108212597e5b367d2d",
+        "rev": "509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1726975622,
-        "narHash": "sha256-bPDZosnom0+02ywmMZAvmj7zvsQ6mVv/5kmvSgbTkaY=",
+        "lastModified": 1727658919,
+        "narHash": "sha256-YAePt2GldkkRJ08LvZNHcuS6shIVStj+K+1DZN3gbnM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "c7515c2fdaf2e1f3f49856cef6cec95bb2138417",
+        "rev": "f9fdf8285690a351e8998f1e703ebdf9cdf51dee",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1727401573,
-        "narHash": "sha256-M3ApPZZbnnWbFTZwV4zEdWppPm3dfbzXVEzD3t1Xr9E=",
+        "lastModified": 1728092750,
+        "narHash": "sha256-N3v1gy/DQ6CBV0izEqG+WJvH+k+nsuUy5cfg1h7JawQ=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "5e908d3ea3e85d444230077cfa93a378204eca38",
+        "rev": "43482ab1bc35a4cf504d078771804f181c15293c",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726755586,
-        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
+        "lastModified": 1727348695,
+        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
+        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
         "type": "github"
       },
       "original": {
@@ -451,23 +451,23 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "lastModified": 1727825735,
+        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       }
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1727540275,
-        "narHash": "sha256-EaxvWVdARz9+Y0R1B3emgZE5/ydCQISj3oWD50sdl9E=",
+        "lastModified": 1728145375,
+        "narHash": "sha256-VwvVNkaOw0bICez7buomPb4zKEBJx9lUg/JepGtRAEU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c9e4eba8f1db8b6602c71bb95ad7a3558690860b",
+        "rev": "4b616a8ecce7aaceea5360f9724065c182dc016f",
         "type": "github"
       },
       "original": {
@@ -527,11 +527,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1727348695,
-        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
+        "lastModified": 1728018373,
+        "narHash": "sha256-NOiTvBbRLIOe5F6RbHaAh6++BNjsb149fGZd1T4+KBg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
+        "rev": "bc947f541ae55e999ffdb4013441347d83b00feb",
         "type": "github"
       },
       "original": {
@@ -543,11 +543,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727528107,
-        "narHash": "sha256-lITknUGWTaXxIkNeijopSsl26Q5xhOKmtH5f9y3OX5A=",
+        "lastModified": 1728137774,
+        "narHash": "sha256-TWYwZGe8WHQAnCb5exr23Ht9g3LDntj9qSi4Zk/8gCg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d148b56d5f3f8774c8dfabc269bbabd65afde015",
+        "rev": "df48b722316f5a0eab0cd7d8403dd2c82848e3a2",
         "type": "github"
       },
       "original": {
@@ -635,11 +635,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727496988,
-        "narHash": "sha256-fi7G9bODA4iUN1g9psIE1U3h7xulNLtwAq0ziwLh0oM=",
+        "lastModified": 1728101832,
+        "narHash": "sha256-0cRtOtkcQvhcKq0vx2C/2uOVUlOmJNZQzcZiK581wto=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "65a95ae7c145ed836ca7d4a1e6be5154125490cf",
+        "rev": "277107c2bc07582899d53e7fc901e93126d944bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 40

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a' (2024-09-12)
  → 'github:hercules-ci/flake-parts/3d04084d54bedc3d6b8b736c70ef449225c361b1' (2024-10-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz?narHash=sha256-Ss8QWLXdr2JCBPcYChJhz4xJm%2Bh/xjl4G0c0XlP6a74%3D' (2024-09-01)
  → 'https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz?narHash=sha256-0xHYkMkeLVQAMa7gvkddbPqpxph%2BhDzdu1XdGPJR%2BOs%3D' (2024-10-01)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/85f7a7177c678de68224af3402ab8ee1bcee25c8' (2024-09-28)
  → 'github:cachix/git-hooks.nix/1211305a5b237771e13fcca0c51e60ad47326a9a' (2024-10-05)
• Updated input 'home-manager':
    'github:nix-community/home-manager/ffe2d07e771580a005e675108212597e5b367d2d' (2024-09-26)
  → 'github:nix-community/home-manager/509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e' (2024-10-04)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/c7515c2fdaf2e1f3f49856cef6cec95bb2138417' (2024-09-22)
  → 'github:nix-community/nix-index-database/f9fdf8285690a351e8998f1e703ebdf9cdf51dee' (2024-09-30)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/c04d5652cfa9742b1d519688f65d1bbccea9eb7e' (2024-09-19)
  → 'github:NixOS/nixpkgs/1925c603f17fc89f4c8f6bf6f631a802ad85d784' (2024-09-26)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/5e908d3ea3e85d444230077cfa93a378204eca38' (2024-09-27)
  → 'github:nix-community/nix-vscode-extensions/43482ab1bc35a4cf504d078771804f181c15293c' (2024-10-05)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/1925c603f17fc89f4c8f6bf6f631a802ad85d784' (2024-09-26)
  → 'github:NixOS/nixpkgs/bc947f541ae55e999ffdb4013441347d83b00feb' (2024-10-04)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/c9e4eba8f1db8b6602c71bb95ad7a3558690860b' (2024-09-28)
  → 'github:NixOS/nixpkgs/4b616a8ecce7aaceea5360f9724065c182dc016f' (2024-10-05)
• Updated input 'nur':
    'github:nix-community/NUR/d148b56d5f3f8774c8dfabc269bbabd65afde015' (2024-09-28)
  → 'github:nix-community/NUR/df48b722316f5a0eab0cd7d8403dd2c82848e3a2' (2024-10-05)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/65a95ae7c145ed836ca7d4a1e6be5154125490cf' (2024-09-28)
  → 'github:Gerg-L/spicetify-nix/277107c2bc07582899d53e7fc901e93126d944bd' (2024-10-05)
```

Sources Changelog:
```
nix-fast-build: bd134ae2ed8921e58f36bd36612a82906fffd7de → 2ba025eab61fe026a76bbab3579d1f051dde5275
firefox-gnome-theme: v129 → v131
```
