### PR TITLE
chore: update flake.lock & sources (2024-10-12)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -246,7 +246,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2024-10-05",
+        "date": "2024-10-07",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -258,11 +258,11 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "2ba025eab61fe026a76bbab3579d1f051dde5275",
-            "sha256": "sha256-gYTZbNvQ7Gz29SRRzoJWHGzktEI6CqPBoXiPVIXdE9c=",
+            "rev": "1775c732071d0ee37c1950ce4ecbf2729487ee71",
+            "sha256": "sha256-57QXMMEELaEbE+ZVg0ngSC7UGZoyYP2QmDGcQSJ8BnE=",
             "type": "github"
         },
-        "version": "2ba025eab61fe026a76bbab3579d1f051dde5275"
+        "version": "1775c732071d0ee37c1950ce4ecbf2729487ee71"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -146,15 +146,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "2ba025eab61fe026a76bbab3579d1f051dde5275";
+    version = "1775c732071d0ee37c1950ce4ecbf2729487ee71";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "2ba025eab61fe026a76bbab3579d1f051dde5275";
+      rev = "1775c732071d0ee37c1950ce4ecbf2729487ee71";
       fetchSubmodules = false;
-      sha256 = "sha256-gYTZbNvQ7Gz29SRRzoJWHGzktEI6CqPBoXiPVIXdE9c=";
+      sha256 = "sha256-57QXMMEELaEbE+ZVg0ngSC7UGZoyYP2QmDGcQSJ8BnE=";
     };
-    date = "2024-10-05";
+    date = "2024-10-07";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -75,11 +75,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722113426,
-        "narHash": "sha256-Yo/3loq572A8Su6aY5GP56knpuKYRvM2a1meP9oJZCw=",
+        "lastModified": 1728330715,
+        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "67cce7359e4cd3c45296fb4aaf6a19e2a9c757ae",
+        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728092656,
-        "narHash": "sha256-eMeCTJZ5xBeQ0f9Os7K8DThNVSo9gy4umZLDfF5q6OM=",
+        "lastModified": 1728727368,
+        "narHash": "sha256-7FMyNISP7K6XDSIt1NJxkXZnEdV3HZUXvFoBaJ/qdOg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "1211305a5b237771e13fcca0c51e60ad47326a9a",
+        "rev": "eb74e0be24a11a1531b5b8659535580554d30b28",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728041527,
-        "narHash": "sha256-03liqiJtk9UP7YQHW4r8MduKCK242FQzud8iWvvlK+o=",
+        "lastModified": 1728726232,
+        "narHash": "sha256-8ZWr1HpciQsrFjvPMvZl0W+b0dilZOqXPoKa2Ux36bc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e",
+        "rev": "d57112db877f07387ce7104b5ac346ede556d2d7",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1727658919,
-        "narHash": "sha256-YAePt2GldkkRJ08LvZNHcuS6shIVStj+K+1DZN3gbnM=",
+        "lastModified": 1728263287,
+        "narHash": "sha256-GJDtsxz2/zw6g/Nrp4XVWBS5IaZ7ZUkuvxPOBEDe7pg=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f9fdf8285690a351e8998f1e703ebdf9cdf51dee",
+        "rev": "5fce10c871bab6d7d5ac9e5e7efbb3a2783f5259",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1728092750,
-        "narHash": "sha256-N3v1gy/DQ6CBV0izEqG+WJvH+k+nsuUy5cfg1h7JawQ=",
+        "lastModified": 1728179514,
+        "narHash": "sha256-mOGZFPYm9SuEXnYiXhgs/JmLu7RofRaMpAYyJiWudkc=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "43482ab1bc35a4cf504d078771804f181c15293c",
+        "rev": "018196c371073d669510fd69dd2f6dc0ec608c41",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727348695,
-        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
+        "lastModified": 1728018373,
+        "narHash": "sha256-NOiTvBbRLIOe5F6RbHaAh6++BNjsb149fGZd1T4+KBg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
+        "rev": "bc947f541ae55e999ffdb4013441347d83b00feb",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1728145375,
-        "narHash": "sha256-VwvVNkaOw0bICez7buomPb4zKEBJx9lUg/JepGtRAEU=",
+        "lastModified": 1728750557,
+        "narHash": "sha256-3hII532bJHJUpqS392NiKIqLEQAKjd4jgqWhgdyWqpg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4b616a8ecce7aaceea5360f9724065c182dc016f",
+        "rev": "bf171746655a97d46cc7a1037749d9e2f15e5889",
         "type": "github"
       },
       "original": {
@@ -527,11 +527,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1728018373,
-        "narHash": "sha256-NOiTvBbRLIOe5F6RbHaAh6++BNjsb149fGZd1T4+KBg=",
+        "lastModified": 1728492678,
+        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc947f541ae55e999ffdb4013441347d83b00feb",
+        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
         "type": "github"
       },
       "original": {
@@ -543,11 +543,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1728137774,
-        "narHash": "sha256-TWYwZGe8WHQAnCb5exr23Ht9g3LDntj9qSi4Zk/8gCg=",
+        "lastModified": 1728747898,
+        "narHash": "sha256-RO3KdBPii0UJX9cMaFnNOG1Y+wp5dlJTEa+5hqhE25U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "df48b722316f5a0eab0cd7d8403dd2c82848e3a2",
+        "rev": "6723f290f06d903352ec0465d875138f707a8fdd",
         "type": "github"
       },
       "original": {
@@ -635,11 +635,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728101832,
-        "narHash": "sha256-0cRtOtkcQvhcKq0vx2C/2uOVUlOmJNZQzcZiK581wto=",
+        "lastModified": 1728706579,
+        "narHash": "sha256-uMa7cC1F2m7DHGOT5yQ1ZoUFVWxsnZDBi9VXwOgnhqw=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "277107c2bc07582899d53e7fc901e93126d944bd",
+        "rev": "59aa525938e501bdacad3753034e864a426b66f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 41

Flakes Changelog:
```
• Updated input 'devshell':
    'github:numtide/devshell/67cce7359e4cd3c45296fb4aaf6a19e2a9c757ae' (2024-07-27)
  → 'github:numtide/devshell/dd6b80932022cea34a019e2bb32f6fa9e494dfef' (2024-10-07)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/1211305a5b237771e13fcca0c51e60ad47326a9a' (2024-10-05)
  → 'github:cachix/git-hooks.nix/eb74e0be24a11a1531b5b8659535580554d30b28' (2024-10-12)
• Updated input 'home-manager':
    'github:nix-community/home-manager/509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e' (2024-10-04)
  → 'github:nix-community/home-manager/d57112db877f07387ce7104b5ac346ede556d2d7' (2024-10-12)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/f9fdf8285690a351e8998f1e703ebdf9cdf51dee' (2024-09-30)
  → 'github:nix-community/nix-index-database/5fce10c871bab6d7d5ac9e5e7efbb3a2783f5259' (2024-10-07)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/1925c603f17fc89f4c8f6bf6f631a802ad85d784' (2024-09-26)
  → 'github:NixOS/nixpkgs/bc947f541ae55e999ffdb4013441347d83b00feb' (2024-10-04)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/43482ab1bc35a4cf504d078771804f181c15293c' (2024-10-05)
  → 'github:nix-community/nix-vscode-extensions/018196c371073d669510fd69dd2f6dc0ec608c41' (2024-10-06)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/bc947f541ae55e999ffdb4013441347d83b00feb' (2024-10-04)
  → 'github:NixOS/nixpkgs/5633bcff0c6162b9e4b5f1264264611e950c8ec7' (2024-10-09)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/4b616a8ecce7aaceea5360f9724065c182dc016f' (2024-10-05)
  → 'github:NixOS/nixpkgs/bf171746655a97d46cc7a1037749d9e2f15e5889' (2024-10-12)
• Updated input 'nur':
    'github:nix-community/NUR/df48b722316f5a0eab0cd7d8403dd2c82848e3a2' (2024-10-05)
  → 'github:nix-community/NUR/6723f290f06d903352ec0465d875138f707a8fdd' (2024-10-12)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/277107c2bc07582899d53e7fc901e93126d944bd' (2024-10-05)
  → 'github:Gerg-L/spicetify-nix/59aa525938e501bdacad3753034e864a426b66f5' (2024-10-12)
```

Sources Changelog:
```
nix-fast-build: 2ba025eab61fe026a76bbab3579d1f051dde5275 → 1775c732071d0ee37c1950ce4ecbf2729487ee71
```
