### PR TITLE
chore: update flake.lock & sources (2024-10-19)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "arr_scripts": {
         "cargoLocks": null,
-        "date": "2024-09-16",
+        "date": "2024-10-16",
         "extract": null,
         "name": "arr_scripts",
         "passthru": null,
@@ -13,11 +13,11 @@
             "name": null,
             "owner": "RandomNinjaAtk",
             "repo": "arr-scripts",
-            "rev": "ef8fc991dba53381c7a2c12fb844a31aa41c7e7b",
-            "sha256": "sha256-0h7Ab/wZBSTD2x0xfIiFz4yixH0TD4VzD+cu0RT7GVg=",
+            "rev": "f7c59f85192b771e16cc9f52aaf06289136ee0d7",
+            "sha256": "sha256-IjGuhXmaLLewYhja7pUo2+RIQ8rwK1K2FzQ5q8PSuDg=",
             "type": "github"
         },
-        "version": "ef8fc991dba53381c7a2c12fb844a31aa41c7e7b"
+        "version": "f7c59f85192b771e16cc9f52aaf06289136ee0d7"
     },
     "bottom_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,15 +3,15 @@
 {
   arr_scripts = {
     pname = "arr_scripts";
-    version = "ef8fc991dba53381c7a2c12fb844a31aa41c7e7b";
+    version = "f7c59f85192b771e16cc9f52aaf06289136ee0d7";
     src = fetchFromGitHub {
       owner = "RandomNinjaAtk";
       repo = "arr-scripts";
-      rev = "ef8fc991dba53381c7a2c12fb844a31aa41c7e7b";
+      rev = "f7c59f85192b771e16cc9f52aaf06289136ee0d7";
       fetchSubmodules = false;
-      sha256 = "sha256-0h7Ab/wZBSTD2x0xfIiFz4yixH0TD4VzD+cu0RT7GVg=";
+      sha256 = "sha256-IjGuhXmaLLewYhja7pUo2+RIQ8rwK1K2FzQ5q8PSuDg=";
     };
-    date = "2024-09-16";
+    date = "2024-10-16";
   };
   bottom_catppuccin = {
     pname = "bottom_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,8 @@
       "locked": {
         "lastModified": 1728330715,
         "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
-        "lastModified": 1728330715,
-        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
         "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
         "type": "github"
       },
@@ -258,11 +255,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728778939,
-        "narHash": "sha256-WybK5E3hpGxtCYtBwpRj1E9JoiVxe+8kX83snTNaFHE=",
+        "lastModified": 1729104314,
+        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "ff68f91754be6f3427e4986d7949e6273659be1d",
+        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
         "type": "github"
       },
       "original": {
@@ -321,11 +318,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729027341,
-        "narHash": "sha256-IqWD7bA9iJVifvJlB4vs2KUXVhN+d9lECWdNB4jJ0tE=",
+        "lastModified": 1729321331,
+        "narHash": "sha256-KVyQq+ez/oB30/WbdNgVD8g/bda34z8NiU187QKQb74=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2a4fd1cfd8ed5648583dadef86966a8231024221",
+        "rev": "122f70545b29ccb922e655b08acfe05bfb44ec68",
         "type": "github"
       },
       "original": {
@@ -423,11 +420,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1729043231,
-        "narHash": "sha256-Dhn3CI3e8cexWhwDVuKGQu7DjCXKLut5aT928x5WIDw=",
+        "lastModified": 1729302344,
+        "narHash": "sha256-txj6S9QC1IiUlxz41dU8QORG47Mu0vX7ldwNKud2oy4=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "81a5fdadd8b5b473d8a51a6ec751c94ed180707e",
+        "rev": "a2a26f1bada2202572599346eb952bd3e130af66",
         "type": "github"
       },
       "original": {
@@ -466,11 +463,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1729074508,
-        "narHash": "sha256-IeLstgksQnNxYbq0sZ41EMR7vO8pzEam1tAS4Danzxo=",
+        "lastModified": 1729355961,
+        "narHash": "sha256-uNfKgZx6mNZN8Ah3tMtXajtIFrAxLLK7oMsPnYSNdz8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "954524966ed5b174a1b8db0f9299a5507994cd6f",
+        "rev": "746cf3d0e76c1bc57d4be5e1397b07fabad54bf6",
         "type": "github"
       },
       "original": {
@@ -530,11 +527,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1728888510,
-        "narHash": "sha256-nsNdSldaAyu6PE3YUA+YQLqUDJh+gRbBooMMekZJwvI=",
+        "lastModified": 1729256560,
+        "narHash": "sha256-/uilDXvCIEs3C9l73JTACm4quuHUsIHcns1c+cHUJwA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+        "rev": "4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0",
         "type": "github"
       },
       "original": {
@@ -546,11 +543,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1729068513,
-        "narHash": "sha256-mnJcqMZ/hgLVIYWU7y4aOUNsuJtUrPjYJGZEPwr5O3A=",
+        "lastModified": 1729352734,
+        "narHash": "sha256-t2Oa7G1TC6FI+nY/fs90dqW4eldKx63IQpOxB0wkLks=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f0a20a333243bb5ebf954f37c960c8856d83dfb",
+        "rev": "bf63061034d17d8f39d08107856eca1e004efc14",
         "type": "github"
       },
       "original": {
@@ -638,11 +635,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729052237,
-        "narHash": "sha256-9eBLOj83C4WHF1WSZn6NvRo7eat8acYK1G9ajfESYNY=",
+        "lastModified": 1729311378,
+        "narHash": "sha256-EJieGv/hQr3EIo5hEvYHjvi8dMZc8fdT1nXrq6I0Ob0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "a83d478b4512fdb80e2dd5a86c5d67e73e0c8b7e",
+        "rev": "3dd5c8c33ee1b8d20d855e9fa425361719931b04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 42

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/ff68f91754be6f3427e4986d7949e6273659be1d' (2024-10-13)
  → 'github:cachix/git-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6' (2024-10-16)
• Updated input 'home-manager':
    'github:nix-community/home-manager/2a4fd1cfd8ed5648583dadef86966a8231024221' (2024-10-15)
  → 'github:nix-community/home-manager/122f70545b29ccb922e655b08acfe05bfb44ec68' (2024-10-19)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/81a5fdadd8b5b473d8a51a6ec751c94ed180707e' (2024-10-16)
  → 'github:nix-community/nix-vscode-extensions/a2a26f1bada2202572599346eb952bd3e130af66' (2024-10-19)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c' (2024-10-14)
  → 'github:NixOS/nixpkgs/4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0' (2024-10-18)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/954524966ed5b174a1b8db0f9299a5507994cd6f' (2024-10-16)
  → 'github:NixOS/nixpkgs/746cf3d0e76c1bc57d4be5e1397b07fabad54bf6' (2024-10-19)
• Updated input 'nur':
    'github:nix-community/NUR/4f0a20a333243bb5ebf954f37c960c8856d83dfb' (2024-10-16)
  → 'github:nix-community/NUR/bf63061034d17d8f39d08107856eca1e004efc14' (2024-10-19)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/a83d478b4512fdb80e2dd5a86c5d67e73e0c8b7e' (2024-10-16)
  → 'github:Gerg-L/spicetify-nix/3dd5c8c33ee1b8d20d855e9fa425361719931b04' (2024-10-19)
```

Sources Changelog:
```
arr_scripts: ef8fc991dba53381c7a2c12fb844a31aa41c7e7b → f7c59f85192b771e16cc9f52aaf06289136ee0d7
```
