### PR TITLE
chore: update flake.lock & sources (2024-10-26)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -318,11 +318,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729321331,
-        "narHash": "sha256-KVyQq+ez/oB30/WbdNgVD8g/bda34z8NiU187QKQb74=",
+        "lastModified": 1729894599,
+        "narHash": "sha256-nL9nzNE5/re/P+zOv7NX6bRm5e+DeS1HIufQUJ01w20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "122f70545b29ccb922e655b08acfe05bfb44ec68",
+        "rev": "93435d27d250fa986bfec6b2ff263161ff8288cb",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1728790083,
-        "narHash": "sha256-grMdAd4KSU6uPqsfLzA1B/3pb9GtGI9o8qb0qFzEU/Y=",
+        "lastModified": 1729394935,
+        "narHash": "sha256-2ntUG+NJKdfhlrh/tF+jOU0fOesO7lm5ZZVSYitsvH8=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "5c54c33aa04df5dd4b0984b7eb861d1981009b22",
+        "rev": "04f8a11f247ba00263b060fbcdc95484fd046104",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1729302344,
-        "narHash": "sha256-txj6S9QC1IiUlxz41dU8QORG47Mu0vX7ldwNKud2oy4=",
+        "lastModified": 1729907150,
+        "narHash": "sha256-8Hh+Gbm0G21gtEdowFN0pQuwoMnNflOhm4P7MQxf9jM=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "a2a26f1bada2202572599346eb952bd3e130af66",
+        "rev": "5b2a08e28a23bd1b0e749aca0240d35405c7b019",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728492678,
-        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
+        "lastModified": 1729256560,
+        "narHash": "sha256-/uilDXvCIEs3C9l73JTACm4quuHUsIHcns1c+cHUJwA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+        "rev": "4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1729355961,
-        "narHash": "sha256-uNfKgZx6mNZN8Ah3tMtXajtIFrAxLLK7oMsPnYSNdz8=",
+        "lastModified": 1729959795,
+        "narHash": "sha256-UM15ra3JOsynko8inB0O//dMdCkH/DCm34HSGNAg6C0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "746cf3d0e76c1bc57d4be5e1397b07fabad54bf6",
+        "rev": "00d5b58b53527392abc282a6323941d508e558bd",
         "type": "github"
       },
       "original": {
@@ -527,11 +527,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1729256560,
-        "narHash": "sha256-/uilDXvCIEs3C9l73JTACm4quuHUsIHcns1c+cHUJwA=",
+        "lastModified": 1729665710,
+        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0",
+        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
         "type": "github"
       },
       "original": {
@@ -543,11 +543,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1729352734,
-        "narHash": "sha256-t2Oa7G1TC6FI+nY/fs90dqW4eldKx63IQpOxB0wkLks=",
+        "lastModified": 1729957534,
+        "narHash": "sha256-Xsp8cPOxURZ7vYYajwEjgNvhCwgNMJKzN8NgbeUd7tk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf63061034d17d8f39d08107856eca1e004efc14",
+        "rev": "347b1faa86f58335ac1a19ad93122bdd29116a52",
         "type": "github"
       },
       "original": {
@@ -635,11 +635,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729311378,
-        "narHash": "sha256-EJieGv/hQr3EIo5hEvYHjvi8dMZc8fdT1nXrq6I0Ob0=",
+        "lastModified": 1729916250,
+        "narHash": "sha256-a+rWl/o2FaJnjm5iM6sFPriybHx3c7NsMsnlW+vYPHI=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "3dd5c8c33ee1b8d20d855e9fa425361719931b04",
+        "rev": "2562a5819140581377530077888b37137d2d05fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 43

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/122f70545b29ccb922e655b08acfe05bfb44ec68' (2024-10-19)
  → 'github:nix-community/home-manager/93435d27d250fa986bfec6b2ff263161ff8288cb' (2024-10-25)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/5c54c33aa04df5dd4b0984b7eb861d1981009b22' (2024-10-13)
  → 'github:nix-community/nix-index-database/04f8a11f247ba00263b060fbcdc95484fd046104' (2024-10-20)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/5633bcff0c6162b9e4b5f1264264611e950c8ec7' (2024-10-09)
  → 'github:NixOS/nixpkgs/4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0' (2024-10-18)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/a2a26f1bada2202572599346eb952bd3e130af66' (2024-10-19)
  → 'github:nix-community/nix-vscode-extensions/5b2a08e28a23bd1b0e749aca0240d35405c7b019' (2024-10-26)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0' (2024-10-18)
  → 'github:NixOS/nixpkgs/2768c7d042a37de65bb1b5b3268fc987e534c49d' (2024-10-23)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/746cf3d0e76c1bc57d4be5e1397b07fabad54bf6' (2024-10-19)
  → 'github:NixOS/nixpkgs/00d5b58b53527392abc282a6323941d508e558bd' (2024-10-26)
• Updated input 'nur':
    'github:nix-community/NUR/bf63061034d17d8f39d08107856eca1e004efc14' (2024-10-19)
  → 'github:nix-community/NUR/347b1faa86f58335ac1a19ad93122bdd29116a52' (2024-10-26)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/3dd5c8c33ee1b8d20d855e9fa425361719931b04' (2024-10-19)
  → 'github:Gerg-L/spicetify-nix/2562a5819140581377530077888b37137d2d05fc' (2024-10-26)
```

Sources Changelog:
```
No changes!
```
