### PR TITLE
chore: update flake.lock & sources (2024-11-09)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,7 @@ jobs:
       # mv result_old- result_old
       # mv result_new- result_new
       run: |
+        ./nix.sh ci_increase_storage
         nix build --out-link result_old github:${{ github.repository }}#nixosConfigurations.hp-laptop.config.system.build.toplevel
         nix build --out-link result_new .#nixosConfigurations.hp-laptop.config.system.build.toplevel
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,11 +30,13 @@ jobs:
 
     - name: "Build both closures"
       id: build
+      # nix develop .#ci --command bash -c "nix-fast-build --debug --no-nom --out-link result_old --flake github:${{ github.repository }}#nixosConfigurations.hp-laptop.config.system.build.toplevel"
+      # nix develop .#ci --command bash -c "nix-fast-build --debug --no-nom --out-link result_new --flake .#nixosConfigurations.hp-laptop.config.system.build.toplevel"
+      # mv result_old- result_old
+      # mv result_new- result_new
       run: |
-        nix develop .#ci --command bash -c "nix-fast-build --debug --no-nom --out-link result_old --flake github:${{ github.repository }}#nixosConfigurations.hp-laptop.config.system.build.toplevel"
-        nix develop .#ci --command bash -c "nix-fast-build --debug --no-nom --out-link result_new --flake .#nixosConfigurations.hp-laptop.config.system.build.toplevel"
-        mv result_old- result_old
-        mv result_new- result_new
+        nix build --out-link result_old github:${{ github.repository }}#nixosConfigurations.hp-laptop.config.system.build.toplevel
+        nix build --out-link result_new .#nixosConfigurations.hp-laptop.config.system.build.toplevel
 
     - name: "Diff Profile Closures"
       id: profile-diff

--- a/System/Common/Misc/nix-ld.nix
+++ b/System/Common/Misc/nix-ld.nix
@@ -1,6 +1,62 @@
-{ pkgs, ... }: {
+{ config, pkgs, lib, ... }: {
   programs.nix-ld = {
     enable = true;
-    libraries = pkgs.steam-run.fhsenv.args.multiPkgs pkgs;
+    libraries = with pkgs; [
+      acl
+      attr
+      bzip2
+      dbus
+      expat
+      fontconfig
+      freetype
+      fuse3
+      icu
+      libnotify
+      libsodium
+      libssh
+      libunwind
+      libusb1
+      libuuid
+      nspr
+      nss
+      stdenv.cc.cc
+      util-linux
+      zlib
+      zstd
+    ] ++ lib.optionals (config.hardware.graphics.enable) [
+      pipewire
+      cups
+      libxkbcommon
+      pango
+      mesa
+      libdrm
+      libglvnd
+      libpulseaudio
+      atk
+      cairo
+      alsa-lib
+      at-spi2-atk
+      at-spi2-core
+      gdk-pixbuf
+      glib
+      gtk3
+      libGL
+      libappindicator-gtk3
+      vulkan-loader
+      xorg.libX11
+      xorg.libXScrnSaver
+      xorg.libXcomposite
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXi
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXtst
+      xorg.libxcb
+      xorg.libxkbfile
+      xorg.libxshmfence
+    ];
   };
 }

--- a/Users/WickedWizard/Programs/Games/lutris.nix
+++ b/Users/WickedWizard/Programs/Games/lutris.nix
@@ -1,7 +1,7 @@
-{ pkgs, ... }: {
+{ osConfig, pkgs, ... }: {
   home.packages = with pkgs; [
     (lutris.override {
-      extraLibraries = steam-run.fhsenv.args.multiPkgs;
+      extraLibraries = pkgs: osConfig.programs.nix-ld.libraries;
       # Fixes NixOS/nixpkgs#285748
       extraPkgs = pkgz: with pkgz; [ winetricks ];
       # Since steam is a flatpak.

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -128,11 +128,11 @@
             "name": null,
             "owner": "rafaelmardojai",
             "repo": "firefox-gnome-theme",
-            "rev": "v131",
-            "sha256": "sha256-nf+0/UR5TZArp3Dn3NS3nB+ZGqecTOTOZRCFM3a1veM=",
+            "rev": "v132",
+            "sha256": "sha256-lf9MQs8+NUvQd8b5t+7c4kLqUQixGO9WwWcLa1XYuiQ=",
             "type": "github"
         },
-        "version": "v131"
+        "version": "v132"
     },
     "foot_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -71,13 +71,13 @@
   };
   firefox-gnome-theme = {
     pname = "firefox-gnome-theme";
-    version = "v131";
+    version = "v132";
     src = fetchFromGitHub {
       owner = "rafaelmardojai";
       repo = "firefox-gnome-theme";
-      rev = "v131";
+      rev = "v132";
       fetchSubmodules = false;
-      sha256 = "sha256-nf+0/UR5TZArp3Dn3NS3nB+ZGqecTOTOZRCFM3a1veM=";
+      sha256 = "sha256-lf9MQs8+NUvQd8b5t+7c4kLqUQixGO9WwWcLa1XYuiQ=";
     };
   };
   foot_catppuccin = {

--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730302582,
-        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
+        "lastModified": 1730814269,
+        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
+        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730490306,
-        "narHash": "sha256-AvCVDswOUM9D368HxYD25RsSKp+5o0L0/JHADjLoD38=",
+        "lastModified": 1730837930,
+        "narHash": "sha256-0kZL4m+bKBJUBQse0HanewWO0g8hDdCvBhudzxgehqc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1743615b61c7285976f85b303a36cdf88a556503",
+        "rev": "2f607e07f3ac7e53541120536708e824acccfaa8",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1729999765,
-        "narHash": "sha256-LYsavZXitFjjyETZoij8usXjTa7fa9AIF3Sk3MJSX+Y=",
+        "lastModified": 1730604744,
+        "narHash": "sha256-/MK6QU4iOozJ4oHTfZipGtOgaT/uy/Jm4foCqHQeYR4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "0e3a8778c2ee218eff8de6aacf3d2fa6c33b2d4f",
+        "rev": "cc2ddbf2df8ef7cc933543b1b42b845ee4772318",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1730512048,
-        "narHash": "sha256-u0vI+4AZCX31lbGSC9ZtM/VE8fikgjlZaAIJZSRpt1s=",
+        "lastModified": 1731116699,
+        "narHash": "sha256-E0+gBErwA46lfUetpiwyfjKdnlRCmZsp7O7AJ6eCT44=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "a6d4683cb3b0b3b846015196c8938cdeb5ffc2d9",
+        "rev": "215a7f76ecd4fcdc834304c473759cff0b7d032b",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729665710,
-        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
+        "lastModified": 1730200266,
+        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {
@@ -495,11 +495,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1730327045,
-        "narHash": "sha256-xKel5kd1AbExymxoIfQ7pgcX6hjw9jCgbiBjiUfSVJ8=",
+        "lastModified": 1730963269,
+        "narHash": "sha256-rz30HrFYCHiWEBCKHMffHbMdWJ35hEkcRVU0h7ms3x0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "080166c15633801df010977d9d7474b4a6c549d7",
+        "rev": "83fb6c028368e465cd19bb127b86f971a5e41ebc",
         "type": "github"
       },
       "original": {
@@ -527,11 +527,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1730200266,
-        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {
@@ -543,11 +543,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730562306,
-        "narHash": "sha256-2NheCt0KpXBalU3sO5lfqdWKMHRiI0X5BLNky9kDvRQ=",
+        "lastModified": 1731167095,
+        "narHash": "sha256-brs+6LRG3UN9+XA1ZM73N7wXkqhYoIyrsoolYoGs68U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc8caf40c12843f335a1e9d79630d74466b09d65",
+        "rev": "15a545f08fcd076b21f039998498e7f396e3f1cb",
         "type": "github"
       },
       "original": {
@@ -635,11 +635,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730521028,
-        "narHash": "sha256-vZtg4J+jOADDKgS+s821PeJiTXfawan8mzX3JM3xjqc=",
+        "lastModified": 1731125701,
+        "narHash": "sha256-m3elGanVuEG6d4LFk4YRqqOlVeQUFch/4mSkXlRg+do=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "191323d81e19efa0be5071e17263851e62f35685",
+        "rev": "5a3fb0482dbf4db2746f1c1274ce6ccd5d75f535",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 45

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/af8a16fe5c264f5e9e18bcee2859b40a656876cf' (2024-10-30)
  → 'github:cachix/git-hooks.nix/d70155fdc00df4628446352fc58adc640cd705c2' (2024-11-05)
• Updated input 'git-hooks/nixpkgs-stable':
    'github:NixOS/nixpkgs/194846768975b7ad2c4988bdb82572c00222c0d7' (2024-07-07)
  → 'github:NixOS/nixpkgs/d063c1dd113c91ab27959ba540c0d9753409edf3' (2024-11-04)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1743615b61c7285976f85b303a36cdf88a556503' (2024-11-01)
  → 'github:nix-community/home-manager/2f607e07f3ac7e53541120536708e824acccfaa8' (2024-11-05)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/0e3a8778c2ee218eff8de6aacf3d2fa6c33b2d4f' (2024-10-27)
  → 'github:nix-community/nix-index-database/cc2ddbf2df8ef7cc933543b1b42b845ee4772318' (2024-11-03)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/2768c7d042a37de65bb1b5b3268fc987e534c49d' (2024-10-23)
  → 'github:NixOS/nixpkgs/807e9154dcb16384b1b765ebe9cd2bba2ac287fd' (2024-10-29)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/a6d4683cb3b0b3b846015196c8938cdeb5ffc2d9' (2024-11-02)
  → 'github:nix-community/nix-vscode-extensions/215a7f76ecd4fcdc834304c473759cff0b7d032b' (2024-11-09)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/807e9154dcb16384b1b765ebe9cd2bba2ac287fd' (2024-10-29)
  → 'github:NixOS/nixpkgs/4aa36568d413aca0ea84a1684d2d46f55dbabad7' (2024-11-05)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/080166c15633801df010977d9d7474b4a6c549d7' (2024-10-30)
  → 'github:NixOS/nixpkgs/83fb6c028368e465cd19bb127b86f971a5e41ebc' (2024-11-07)
• Updated input 'nur':
    'github:nix-community/NUR/dc8caf40c12843f335a1e9d79630d74466b09d65' (2024-11-02)
  → 'github:nix-community/NUR/15a545f08fcd076b21f039998498e7f396e3f1cb' (2024-11-09)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/191323d81e19efa0be5071e17263851e62f35685' (2024-11-02)
  → 'github:Gerg-L/spicetify-nix/5a3fb0482dbf4db2746f1c1274ce6ccd5d75f535' (2024-11-09)
```

Sources Changelog:
```
firefox-gnome-theme: v131 → v132
```
