### PR TITLE
chore: update flake.lock & sources (2024-11-16)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,7 +51,7 @@ jobs:
       id: vulnix
       run: |
         echo "Vulnerabilities in closure: " >> comment.txt
-        nix shell nixpkgs#vulnix --command bash -c "vulnix -C ./result_new 2>&1 | tee -a comment.txt"
+        nix shell nixpkgs#vulnix --command bash -c "vulnix ./result_new 2>&1 | tee -a comment.txt"
 
     - name: PR comment with file
       uses: thollander/actions-comment-pull-request@v2

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -346,7 +346,7 @@
     },
     "starship_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-08-16",
+        "date": "2024-11-11",
         "extract": null,
         "name": "starship_catppuccin",
         "passthru": null,
@@ -358,11 +358,11 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "starship",
-            "rev": "3c4749512e7d552adf48e75e5182a271392ab176",
-            "sha256": "sha256-t/Hmd2dzBn0AbLUlbL8CBt19/we8spY5nMP0Z+VPMXA=",
+            "rev": "31b224a6408015d1e17a5766de6b764cf9af3c1c",
+            "sha256": "sha256-TjcoBlgmRoqXKdXH/eC5dWk7uqUSkvyV4ir9WqFR1pY=",
             "type": "github"
         },
-        "version": "3c4749512e7d552adf48e75e5182a271392ab176"
+        "version": "31b224a6408015d1e17a5766de6b764cf9af3c1c"
     },
     "wickedwizard_picture": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -206,15 +206,15 @@
   };
   starship_catppuccin = {
     pname = "starship_catppuccin";
-    version = "3c4749512e7d552adf48e75e5182a271392ab176";
+    version = "31b224a6408015d1e17a5766de6b764cf9af3c1c";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "starship";
-      rev = "3c4749512e7d552adf48e75e5182a271392ab176";
+      rev = "31b224a6408015d1e17a5766de6b764cf9af3c1c";
       fetchSubmodules = false;
-      sha256 = "sha256-t/Hmd2dzBn0AbLUlbL8CBt19/we8spY5nMP0Z+VPMXA=";
+      sha256 = "sha256-TjcoBlgmRoqXKdXH/eC5dWk7uqUSkvyV4ir9WqFR1pY=";
     };
-    date = "2024-08-16";
+    date = "2024-11-11";
   };
   wickedwizard_picture = {
     pname = "wickedwizard_picture";

--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730814269,
-        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730837930,
-        "narHash": "sha256-0kZL4m+bKBJUBQse0HanewWO0g8hDdCvBhudzxgehqc=",
+        "lastModified": 1731604581,
+        "narHash": "sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f607e07f3ac7e53541120536708e824acccfaa8",
+        "rev": "1d0862ee2d7c6f6cd720d6f32213fa425004be10",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1730604744,
-        "narHash": "sha256-/MK6QU4iOozJ4oHTfZipGtOgaT/uy/Jm4foCqHQeYR4=",
+        "lastModified": 1731593150,
+        "narHash": "sha256-FvksinoI2Y6kuwH+cKBu1oDA8uPGfoRqgtQV6O8GDc4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "cc2ddbf2df8ef7cc933543b1b42b845ee4772318",
+        "rev": "40d882b55e89add1ded379cc99edaab24983d6d9",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1731116699,
-        "narHash": "sha256-E0+gBErwA46lfUetpiwyfjKdnlRCmZsp7O7AJ6eCT44=",
+        "lastModified": 1731721953,
+        "narHash": "sha256-Wh+SleqO6vQc4M6UI90zbm3al2Hq3OLbMupJmrTIdq8=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "215a7f76ecd4fcdc834304c473759cff0b7d032b",
+        "rev": "32e3b124252161fcd7e0623c6e6faf9d535c1a3f",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730200266,
-        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {
@@ -495,11 +495,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1730963269,
-        "narHash": "sha256-rz30HrFYCHiWEBCKHMffHbMdWJ35hEkcRVU0h7ms3x0=",
+        "lastModified": 1731652201,
+        "narHash": "sha256-XUO0JKP1hlww0d7mm3kpmIr4hhtR4zicg5Wwes9cPMg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "83fb6c028368e465cd19bb127b86f971a5e41ebc",
+        "rev": "c21b77913ea840f8bcf9adf4c41cecc2abffd38d",
         "type": "github"
       },
       "original": {
@@ -527,11 +527,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1730785428,
-        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
+        "lastModified": 1731319897,
+        "narHash": "sha256-PbABj4tnbWFMfBp6OcUK5iGy1QY+/Z96ZcLpooIbuEI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+        "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
         "type": "github"
       },
       "original": {
@@ -543,11 +543,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731167095,
-        "narHash": "sha256-brs+6LRG3UN9+XA1ZM73N7wXkqhYoIyrsoolYoGs68U=",
+        "lastModified": 1731774903,
+        "narHash": "sha256-TB2eby0+4Gv2BHIc1W6u+LxtKcfT5kulmfzFZjq6Biw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "15a545f08fcd076b21f039998498e7f396e3f1cb",
+        "rev": "564dae7415d2c37073a0a002a8d92f1cbcee4556",
         "type": "github"
       },
       "original": {
@@ -635,11 +635,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731125701,
-        "narHash": "sha256-m3elGanVuEG6d4LFk4YRqqOlVeQUFch/4mSkXlRg+do=",
+        "lastModified": 1731759572,
+        "narHash": "sha256-wJfvdHRAQNIiWxvgFemX0ZsTCskq3QnD7HCG5Na7NLc=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "5a3fb0482dbf4db2746f1c1274ce6ccd5d75f535",
+        "rev": "068214cd7f099b8ed9388986c6792b387f3b4276",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 46

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/d70155fdc00df4628446352fc58adc640cd705c2' (2024-11-05)
  → 'github:cachix/git-hooks.nix/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0' (2024-11-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/2f607e07f3ac7e53541120536708e824acccfaa8' (2024-11-05)
  → 'github:nix-community/home-manager/1d0862ee2d7c6f6cd720d6f32213fa425004be10' (2024-11-14)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/cc2ddbf2df8ef7cc933543b1b42b845ee4772318' (2024-11-03)
  → 'github:nix-community/nix-index-database/40d882b55e89add1ded379cc99edaab24983d6d9' (2024-11-14)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/807e9154dcb16384b1b765ebe9cd2bba2ac287fd' (2024-10-29)
  → 'github:NixOS/nixpkgs/4aa36568d413aca0ea84a1684d2d46f55dbabad7' (2024-11-05)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/215a7f76ecd4fcdc834304c473759cff0b7d032b' (2024-11-09)
  → 'github:nix-community/nix-vscode-extensions/32e3b124252161fcd7e0623c6e6faf9d535c1a3f' (2024-11-16)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/4aa36568d413aca0ea84a1684d2d46f55dbabad7' (2024-11-05)
  → 'github:NixOS/nixpkgs/dc460ec76cbff0e66e269457d7b728432263166c' (2024-11-11)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/83fb6c028368e465cd19bb127b86f971a5e41ebc' (2024-11-07)
  → 'github:NixOS/nixpkgs/c21b77913ea840f8bcf9adf4c41cecc2abffd38d' (2024-11-15)
• Updated input 'nur':
    'github:nix-community/NUR/15a545f08fcd076b21f039998498e7f396e3f1cb' (2024-11-09)
  → 'github:nix-community/NUR/564dae7415d2c37073a0a002a8d92f1cbcee4556' (2024-11-16)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/5a3fb0482dbf4db2746f1c1274ce6ccd5d75f535' (2024-11-09)
  → 'github:Gerg-L/spicetify-nix/068214cd7f099b8ed9388986c6792b387f3b4276' (2024-11-16)
```

Sources Changelog:
```
starship_catppuccin: 3c4749512e7d552adf48e75e5182a271392ab176 → 31b224a6408015d1e17a5766de6b764cf9af3c1c
```
