### PR TITLE
chore: update flake.lock & sources (2024-11-23)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -99,6 +99,26 @@
         },
         "version": "f02cd2894411c9b4caa207cfd8ed6345f97c0455"
     },
+    "eza_themes": {
+        "cargoLocks": null,
+        "date": "2024-10-27",
+        "extract": null,
+        "name": "eza_themes",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "eza-community",
+            "repo": "eza-themes",
+            "rev": "74be26bbd2ce76b29c37250a2fb7cb5d6644c964",
+            "sha256": "sha256-Gs21+A/to2AqjQsqMlWeOuSowYPOuSZ3fK6LRdBPUmI=",
+            "type": "github"
+        },
+        "version": "74be26bbd2ce76b29c37250a2fb7cb5d6644c964"
+    },
     "filen": {
         "cargoLocks": null,
         "date": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -61,6 +61,18 @@
     };
     date = "2024-07-20";
   };
+  eza_themes = {
+    pname = "eza_themes";
+    version = "74be26bbd2ce76b29c37250a2fb7cb5d6644c964";
+    src = fetchFromGitHub {
+      owner = "eza-community";
+      repo = "eza-themes";
+      rev = "74be26bbd2ce76b29c37250a2fb7cb5d6644c964";
+      fetchSubmodules = false;
+      sha256 = "sha256-Gs21+A/to2AqjQsqMlWeOuSowYPOuSZ3fK6LRdBPUmI=";
+    };
+    date = "2024-10-27";
+  };
   filen = {
     pname = "filen";
     version = "latest";

--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731363552,
-        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "lastModified": 1732021966,
+        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731604581,
-        "narHash": "sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM=",
+        "lastModified": 1732303962,
+        "narHash": "sha256-5Umjb5AdtxV5jSJd5jxoCckh5mlg+FBQDsyAilu637g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d0862ee2d7c6f6cd720d6f32213fa425004be10",
+        "rev": "8cf9cb2ee78aa129e5b8220135a511a2be254c0c",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1731593150,
-        "narHash": "sha256-FvksinoI2Y6kuwH+cKBu1oDA8uPGfoRqgtQV6O8GDc4=",
+        "lastModified": 1731814505,
+        "narHash": "sha256-l9ryrx1Twh08a+gxrMGM9O/aZKEimZfa6sZVyPCImgI=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "40d882b55e89add1ded379cc99edaab24983d6d9",
+        "rev": "bdba246946fb079b87b4cada4df9b1cdf1c06132",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1731721953,
-        "narHash": "sha256-Wh+SleqO6vQc4M6UI90zbm3al2Hq3OLbMupJmrTIdq8=",
+        "lastModified": 1732326629,
+        "narHash": "sha256-JOnNXfPTm/Ge3JyKd5TXytIEr1Tn11tnmrEiRBiDZLQ=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "32e3b124252161fcd7e0623c6e6faf9d535c1a3f",
+        "rev": "b2dbcc5bbfc981ef7a9e02b502c3b64ae0ee60d5",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730785428,
-        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
+        "lastModified": 1731676054,
+        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
         "type": "github"
       },
       "original": {
@@ -543,11 +543,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731774903,
-        "narHash": "sha256-TB2eby0+4Gv2BHIc1W6u+LxtKcfT5kulmfzFZjq6Biw=",
+        "lastModified": 1732376696,
+        "narHash": "sha256-jtyN+D7xA9ai7GrdrXrvMGuf9wYDTegnUwrQPJH8BKA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "564dae7415d2c37073a0a002a8d92f1cbcee4556",
+        "rev": "6f31ab1bc688575f436a4a4d2796f204e4c592eb",
         "type": "github"
       },
       "original": {
@@ -635,11 +635,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731759572,
-        "narHash": "sha256-wJfvdHRAQNIiWxvgFemX0ZsTCskq3QnD7HCG5Na7NLc=",
+        "lastModified": 1732335344,
+        "narHash": "sha256-67eg6CecbBPEYeHFS8K7Xqrg3zhUVoCBYP20dcfHSK4=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "068214cd7f099b8ed9388986c6792b387f3b4276",
+        "rev": "5a608edd5d050ab47af4e301437684441955ece0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 47

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0' (2024-11-11)
  → 'github:cachix/git-hooks.nix/3308484d1a443fc5bc92012435d79e80458fe43c' (2024-11-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1d0862ee2d7c6f6cd720d6f32213fa425004be10' (2024-11-14)
  → 'github:nix-community/home-manager/8cf9cb2ee78aa129e5b8220135a511a2be254c0c' (2024-11-22)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/40d882b55e89add1ded379cc99edaab24983d6d9' (2024-11-14)
  → 'github:nix-community/nix-index-database/bdba246946fb079b87b4cada4df9b1cdf1c06132' (2024-11-17)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/4aa36568d413aca0ea84a1684d2d46f55dbabad7' (2024-11-05)
  → 'github:NixOS/nixpkgs/5e4fbfb6b3de1aa2872b76d49fafc942626e2add' (2024-11-15)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/32e3b124252161fcd7e0623c6e6faf9d535c1a3f' (2024-11-16)
  → 'github:nix-community/nix-vscode-extensions/b2dbcc5bbfc981ef7a9e02b502c3b64ae0ee60d5' (2024-11-23)
• Updated input 'nur':
    'github:nix-community/NUR/564dae7415d2c37073a0a002a8d92f1cbcee4556' (2024-11-16)
  → 'github:nix-community/NUR/6f31ab1bc688575f436a4a4d2796f204e4c592eb' (2024-11-23)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/068214cd7f099b8ed9388986c6792b387f3b4276' (2024-11-16)
  → 'github:Gerg-L/spicetify-nix/5a608edd5d050ab47af4e301437684441955ece0' (2024-11-23)
```

Sources Changelog:
```
eza_themes: ∅ → 74be26bbd2ce76b29c37250a2fb7cb5d6644c964
```
