### PR TITLE
chore: update flake.lock & sources (2024-11-30)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -148,11 +148,11 @@
             "name": null,
             "owner": "rafaelmardojai",
             "repo": "firefox-gnome-theme",
-            "rev": "v132",
-            "sha256": "sha256-lf9MQs8+NUvQd8b5t+7c4kLqUQixGO9WwWcLa1XYuiQ=",
+            "rev": "v133",
+            "sha256": "sha256-k7v5PE6OcqMkC/u7aokwcxKDmTKM+ejiZGCsH9MK0s0=",
             "type": "github"
         },
-        "version": "v132"
+        "version": "v133"
     },
     "foot_catppuccin": {
         "cargoLocks": null,
@@ -266,7 +266,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2024-10-30",
+        "date": "2024-11-25",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -278,11 +278,11 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "8e7c9d76979381441facb8888f21408312cf177a",
-            "sha256": "sha256-CrbqsC+lEA3w6gLfpqfDMDEKoEta2sl4sbQK6Z/gXak=",
+            "rev": "f51f479d001317204f1a47302db36473dc12fc8f",
+            "sha256": "sha256-y1Q87PRcztZ2C1J/xGHk0VxY/T9wB6YL1nLtRbMYW5g=",
             "type": "github"
         },
-        "version": "8e7c9d76979381441facb8888f21408312cf177a"
+        "version": "f51f479d001317204f1a47302db36473dc12fc8f"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -83,13 +83,13 @@
   };
   firefox-gnome-theme = {
     pname = "firefox-gnome-theme";
-    version = "v132";
+    version = "v133";
     src = fetchFromGitHub {
       owner = "rafaelmardojai";
       repo = "firefox-gnome-theme";
-      rev = "v132";
+      rev = "v133";
       fetchSubmodules = false;
-      sha256 = "sha256-lf9MQs8+NUvQd8b5t+7c4kLqUQixGO9WwWcLa1XYuiQ=";
+      sha256 = "sha256-k7v5PE6OcqMkC/u7aokwcxKDmTKM+ejiZGCsH9MK0s0=";
     };
   };
   foot_catppuccin = {
@@ -158,15 +158,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "8e7c9d76979381441facb8888f21408312cf177a";
+    version = "f51f479d001317204f1a47302db36473dc12fc8f";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "8e7c9d76979381441facb8888f21408312cf177a";
+      rev = "f51f479d001317204f1a47302db36473dc12fc8f";
       fetchSubmodules = false;
-      sha256 = "sha256-CrbqsC+lEA3w6gLfpqfDMDEKoEta2sl4sbQK6Z/gXak=";
+      sha256 = "sha256-y1Q87PRcztZ2C1J/xGHk0VxY/T9wB6YL1nLtRbMYW5g=";
     };
-    date = "2024-10-30";
+    date = "2024-11-25";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
     "flake-compat_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1732722421,
+        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732303962,
-        "narHash": "sha256-5Umjb5AdtxV5jSJd5jxoCckh5mlg+FBQDsyAilu637g=",
+        "lastModified": 1732884235,
+        "narHash": "sha256-r8j6R3nrvwbT1aUp4EPQ1KC7gm0pu9VcV1aNaB+XG6Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8cf9cb2ee78aa129e5b8220135a511a2be254c0c",
+        "rev": "819f682269f4e002884702b87e445c82840c68f2",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1731814505,
-        "narHash": "sha256-l9ryrx1Twh08a+gxrMGM9O/aZKEimZfa6sZVyPCImgI=",
+        "lastModified": 1732519917,
+        "narHash": "sha256-AGXhwHdJV0q/WNgqwrR2zriubLr785b02FphaBtyt1Q=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "bdba246946fb079b87b4cada4df9b1cdf1c06132",
+        "rev": "f4a5ca5771ba9ca31ad24a62c8d511a405303436",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1732326629,
-        "narHash": "sha256-JOnNXfPTm/Ge3JyKd5TXytIEr1Tn11tnmrEiRBiDZLQ=",
+        "lastModified": 1732931481,
+        "narHash": "sha256-W4FRZVN3ExbjEQLoRijmmCu0vWJ5sYMRLzFCCsfDHhU=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "b2dbcc5bbfc981ef7a9e02b502c3b64ae0ee60d5",
+        "rev": "ad53e4155149d1d69e45bc0ade1d9695d81a05b6",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731676054,
-        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
+        "lastModified": 1732014248,
+        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
+        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
         "type": "github"
       },
       "original": {
@@ -495,11 +495,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1731797254,
-        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
+        "lastModified": 1732749044,
+        "narHash": "sha256-T38FQOg0BV5M8FN1712fovzNakSOENEYs+CSkg31C9Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
+        "rev": "0c5b4ecbed5b155b705336aa96d878e55acd8685",
         "type": "github"
       },
       "original": {
@@ -527,11 +527,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1731755305,
-        "narHash": "sha256-v5P3dk5JdiT+4x69ZaB18B8+Rcu3TIOrcdG4uEX7WZ8=",
+        "lastModified": 1732824227,
+        "narHash": "sha256-fYNXgpu1AEeLyd3fQt4Ym0tcVP7cdJ8wRoqJ+CtTRyY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "057f63b6dc1a2c67301286152eb5af20747a9cb4",
+        "rev": "c71ad5c34d51dcbda4c15f44ea4e4aa6bb6ac1e9",
         "type": "github"
       },
       "original": {
@@ -543,11 +543,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732376696,
-        "narHash": "sha256-jtyN+D7xA9ai7GrdrXrvMGuf9wYDTegnUwrQPJH8BKA=",
+        "lastModified": 1732984203,
+        "narHash": "sha256-ZHhTeFMdRZ3UI/UDzzuOiiP7cEBoJj8OTYhjB9xova0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f31ab1bc688575f436a4a4d2796f204e4c592eb",
+        "rev": "3bf72a07ced4187061498ef42dc6cfa901e80194",
         "type": "github"
       },
       "original": {
@@ -635,11 +635,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732335344,
-        "narHash": "sha256-67eg6CecbBPEYeHFS8K7Xqrg3zhUVoCBYP20dcfHSK4=",
+        "lastModified": 1732940172,
+        "narHash": "sha256-0at0wkwsaJfJBCGlwtXfg2JdeY30mZXhrWeoNqhLEYc=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "5a608edd5d050ab47af4e301437684441955ece0",
+        "rev": "0b712938230ab50d2e0cf961cc0f3660f7b18041",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 48

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/8cf9cb2ee78aa129e5b8220135a511a2be254c0c' (2024-11-22)
  → 'github:nix-community/home-manager/819f682269f4e002884702b87e445c82840c68f2' (2024-11-29)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/bdba246946fb079b87b4cada4df9b1cdf1c06132' (2024-11-17)
  → 'github:nix-community/nix-index-database/f4a5ca5771ba9ca31ad24a62c8d511a405303436' (2024-11-25)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/5e4fbfb6b3de1aa2872b76d49fafc942626e2add' (2024-11-15)
  → 'github:NixOS/nixpkgs/23e89b7da85c3640bbc2173fe04f4bd114342367' (2024-11-19)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/b2dbcc5bbfc981ef7a9e02b502c3b64ae0ee60d5' (2024-11-23)
  → 'github:nix-community/nix-vscode-extensions/ad53e4155149d1d69e45bc0ade1d9695d81a05b6' (2024-11-30)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/057f63b6dc1a2c67301286152eb5af20747a9cb4' (2024-11-16)
  → 'github:NixOS/nixpkgs/c71ad5c34d51dcbda4c15f44ea4e4aa6bb6ac1e9' (2024-11-28)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/e8c38b73aeb218e27163376a2d617e61a2ad9b59' (2024-11-16)
  → 'github:NixOS/nixpkgs/0c5b4ecbed5b155b705336aa96d878e55acd8685' (2024-11-27)
• Updated input 'nur':
    'github:nix-community/NUR/6f31ab1bc688575f436a4a4d2796f204e4c592eb' (2024-11-23)
  → 'github:nix-community/NUR/3bf72a07ced4187061498ef42dc6cfa901e80194' (2024-11-30)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/5a608edd5d050ab47af4e301437684441955ece0' (2024-11-23)
  → 'github:Gerg-L/spicetify-nix/0b712938230ab50d2e0cf961cc0f3660f7b18041' (2024-11-30)
• Updated input 'spicetify-nix/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
  → 'github:edolstra/flake-compat/9ed2ac151eada2306ca8c418ebd97807bb08f6ac' (2024-11-27)
```

Sources Changelog:
```
firefox-gnome-theme: v132 → v133
nix-fast-build: 8e7c9d76979381441facb8888f21408312cf177a → f51f479d001317204f1a47302db36473dc12fc8f
```
