### PR TITLE
chore: update flake.lock & sources (2024-12-14)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -148,11 +148,11 @@
             "name": null,
             "owner": "rafaelmardojai",
             "repo": "firefox-gnome-theme",
-            "rev": "v133",
-            "sha256": "sha256-k7v5PE6OcqMkC/u7aokwcxKDmTKM+ejiZGCsH9MK0s0=",
+            "rev": "v133.1",
+            "sha256": "sha256-onO+zd9ssgsLC5ax3UWPZ41DcZPkxdXT8JmmjDkw944=",
             "type": "github"
         },
-        "version": "v133"
+        "version": "v133.1"
     },
     "foot_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -83,13 +83,13 @@
   };
   firefox-gnome-theme = {
     pname = "firefox-gnome-theme";
-    version = "v133";
+    version = "v133.1";
     src = fetchFromGitHub {
       owner = "rafaelmardojai";
       repo = "firefox-gnome-theme";
-      rev = "v133";
+      rev = "v133.1";
       fetchSubmodules = false;
-      sha256 = "sha256-k7v5PE6OcqMkC/u7aokwcxKDmTKM+ejiZGCsH9MK0s0=";
+      sha256 = "sha256-onO+zd9ssgsLC5ax3UWPZ41DcZPkxdXT8JmmjDkw944=";
     };
   };
   foot_catppuccin = {

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733318908,
-        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
+        "lastModified": 1734190932,
+        "narHash": "sha256-nIweyhgHbDMJSH6zlciTe2abEzDKWkW28B6/qM9UWOU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
+        "rev": "c2b3567b03baf0999a1dd14f7e7ab34b46297d68",
         "type": "github"
       },
       "original": {
@@ -339,11 +339,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733572789,
-        "narHash": "sha256-zjO6m5BqxXIyjrnUziAzk4+T4VleqjstNudSqWcpsHI=",
+        "lastModified": 1733951536,
+        "narHash": "sha256-Zb5ZCa7Xj+0gy5XVXINTSr71fCfAv+IKtmIXNrykT54=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7ffc9727d115e433fd884a62dc164b587ff651d",
+        "rev": "1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f",
         "type": "github"
       },
       "original": {
@@ -422,11 +422,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1733024876,
-        "narHash": "sha256-vy9Q41hBE7Zg0yakF79neVgb3i3PQMSMR7uHPpPywFE=",
+        "lastModified": 1733629314,
+        "narHash": "sha256-U0vivjQFAwjNDYt49Krevs1murX9hKBFe2Ye0cHpgbU=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "6e0b7f81367069589a480b91603a10bcf71f3103",
+        "rev": "f1e477a7dd11e27e7f98b646349cd66bbabf2fb8",
         "type": "github"
       },
       "original": {
@@ -442,11 +442,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1733536536,
-        "narHash": "sha256-gTlpRSELDSHMRa1/BwZR7eX5mka5y3YQbb1efLuyovs=",
+        "lastModified": 1734141176,
+        "narHash": "sha256-LWE0LrdgdP8aBRIjIKldxbrfqGb+ZiKK77QX3cLq6I8=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "7aa26ebccf778efe880fda1290db9c1da56ffa4f",
+        "rev": "ec2646a6b7566f0906122d99ffe0aba42e8f33f1",
         "type": "github"
       },
       "original": {
@@ -457,11 +457,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732837521,
-        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
+        "lastModified": 1733392399,
+        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "970e93b9f82e2a0f3675757eb0bfc73297cc6370",
+        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
         "type": "github"
       },
       "original": {
@@ -517,11 +517,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1733384649,
-        "narHash": "sha256-K5DJ2LpPqht7K76bsxetI+YHhGGRyVteTPRQaIIKJpw=",
+        "lastModified": 1734017764,
+        "narHash": "sha256-msOfmyJSjAHgIygI/JD0Ae3JsDv4rT54Nlfr5t6MQMQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "190c31a89e5eec80dd6604d7f9e5af3802a58a13",
+        "rev": "64e9404f308e0f0a0d8cdd7c358f74e34802494b",
         "type": "github"
       },
       "original": {
@@ -549,11 +549,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1733412085,
-        "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
+        "lastModified": 1733808091,
+        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4dc2fc4e62dbf62b84132fe526356fbac7b03541",
+        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
         "type": "github"
       },
       "original": {
@@ -565,11 +565,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1733392399,
-        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
+        "lastModified": 1733940404,
+        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
+        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1733585566,
-        "narHash": "sha256-UAxIvD3Y4JqO/UEcN/aX5PM3SnIHNuSTidUXhaOQnSc=",
+        "lastModified": 1734193359,
+        "narHash": "sha256-8IxxuXZYYmPoPYjgGCqkzSuLYbcJ3YfTgcyj9lKJ38U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8fc302c0bf6538a8ec4f9705dbea484b1752393a",
+        "rev": "e47e15ee1015c505fd0a0eb38811cb1f7880445d",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733544993,
-        "narHash": "sha256-JQwL9JxVYHe/wmNepuNQkJsvVeAeG+P4wjt+L+EuC74=",
+        "lastModified": 1734149768,
+        "narHash": "sha256-pdfUlO6eARnfEnmHy2rUa5DvqyaniLDNEZRGt1pj1VI=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "6ed218850b5a13e4fc3bbb52a7af4e36642b1157",
+        "rev": "af0b468ef40138b62eaeec905106e7b741b4eab6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 50

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/6f4e2a2112050951a314d2733a994fbab94864c6' (2024-12-04)
  → 'github:cachix/git-hooks.nix/c2b3567b03baf0999a1dd14f7e7ab34b46297d68' (2024-12-14)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c7ffc9727d115e433fd884a62dc164b587ff651d' (2024-12-07)
  → 'github:nix-community/home-manager/1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f' (2024-12-11)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/6e0b7f81367069589a480b91603a10bcf71f3103' (2024-12-01)
  → 'github:nix-community/nix-index-database/f1e477a7dd11e27e7f98b646349cd66bbabf2fb8' (2024-12-08)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/970e93b9f82e2a0f3675757eb0bfc73297cc6370' (2024-11-28)
  → 'github:NixOS/nixpkgs/d0797a04b81caeae77bcff10a9dde78bc17f5661' (2024-12-05)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/7aa26ebccf778efe880fda1290db9c1da56ffa4f' (2024-12-07)
  → 'github:nix-community/nix-vscode-extensions/ec2646a6b7566f0906122d99ffe0aba42e8f33f1' (2024-12-14)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/4dc2fc4e62dbf62b84132fe526356fbac7b03541' (2024-12-05)
  → 'github:NixOS/nixpkgs/a0f3e10d94359665dba45b71b4227b0aeb851f8e' (2024-12-10)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/190c31a89e5eec80dd6604d7f9e5af3802a58a13' (2024-12-05)
  → 'github:NixOS/nixpkgs/64e9404f308e0f0a0d8cdd7c358f74e34802494b' (2024-12-12)
• Updated input 'nur':
    'github:nix-community/NUR/8fc302c0bf6538a8ec4f9705dbea484b1752393a' (2024-12-07)
  → 'github:nix-community/NUR/e47e15ee1015c505fd0a0eb38811cb1f7880445d' (2024-12-14)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/d0797a04b81caeae77bcff10a9dde78bc17f5661' (2024-12-05)
  → 'github:nixos/nixpkgs/5d67ea6b4b63378b9c13be21e2ec9d1afc921713' (2024-12-11)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/6ed218850b5a13e4fc3bbb52a7af4e36642b1157' (2024-12-07)
  → 'github:Gerg-L/spicetify-nix/af0b468ef40138b62eaeec905106e7b741b4eab6' (2024-12-14)
```

Sources Changelog:
```
firefox-gnome-theme: v133 → v133.1
```
