### PR TITLE
chore: update flake.lock & sources (2024-12-21)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -266,7 +266,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2024-12-01",
+        "date": "2024-12-20",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -278,11 +278,11 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "95f5dc09a725a1916fd064f01eb3be9a5f487095",
-            "sha256": "sha256-lThMnu0otRxDTso07OU72+RZrUNokXwLKTjzTWGrxUo=",
+            "rev": "ed736c65a8cb58a85369f6ee1c3f4403aa904fcc",
+            "sha256": "sha256-BCpd50t/3JU4ydiNfJxH3LzQDzyGbBI0CKWaeplnkVg=",
             "type": "github"
         },
-        "version": "95f5dc09a725a1916fd064f01eb3be9a5f487095"
+        "version": "ed736c65a8cb58a85369f6ee1c3f4403aa904fcc"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -158,15 +158,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "95f5dc09a725a1916fd064f01eb3be9a5f487095";
+    version = "ed736c65a8cb58a85369f6ee1c3f4403aa904fcc";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "95f5dc09a725a1916fd064f01eb3be9a5f487095";
+      rev = "ed736c65a8cb58a85369f6ee1c3f4403aa904fcc";
       fetchSubmodules = false;
-      sha256 = "sha256-lThMnu0otRxDTso07OU72+RZrUNokXwLKTjzTWGrxUo=";
+      sha256 = "sha256-BCpd50t/3JU4ydiNfJxH3LzQDzyGbBI0CKWaeplnkVg=";
     };
-    date = "2024-12-01";
+    date = "2024-12-20";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734190932,
-        "narHash": "sha256-nIweyhgHbDMJSH6zlciTe2abEzDKWkW28B6/qM9UWOU=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "c2b3567b03baf0999a1dd14f7e7ab34b46297d68",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {
@@ -339,11 +339,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733951536,
-        "narHash": "sha256-Zb5ZCa7Xj+0gy5XVXINTSr71fCfAv+IKtmIXNrykT54=",
+        "lastModified": 1734366194,
+        "narHash": "sha256-vykpJ1xsdkv0j8WOVXrRFHUAdp9NXHpxdnn1F4pYgSw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f",
+        "rev": "80b0fdf483c5d1cb75aaad909bd390d48673857f",
         "type": "github"
       },
       "original": {
@@ -422,11 +422,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1733629314,
-        "narHash": "sha256-U0vivjQFAwjNDYt49Krevs1murX9hKBFe2Ye0cHpgbU=",
+        "lastModified": 1734234111,
+        "narHash": "sha256-icEMqBt4HtGH52PU5FHidgBrNJvOfXH6VQKNtnD1aw8=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f1e477a7dd11e27e7f98b646349cd66bbabf2fb8",
+        "rev": "311d6cf3ad3f56cb051ffab1f480b2909b3f754d",
         "type": "github"
       },
       "original": {
@@ -442,11 +442,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1734141176,
-        "narHash": "sha256-LWE0LrdgdP8aBRIjIKldxbrfqGb+ZiKK77QX3cLq6I8=",
+        "lastModified": 1734745696,
+        "narHash": "sha256-rTGDkcbzfcTL7jE4TtxhNQtDssD1QY8yLo8ApAv3XRs=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "ec2646a6b7566f0906122d99ffe0aba42e8f33f1",
+        "rev": "113779a6601d5b5c8ef7c5b5c4ab3f377fd3e2c3",
         "type": "github"
       },
       "original": {
@@ -457,11 +457,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733392399,
-        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
+        "lastModified": 1733940404,
+        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
+        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
         "type": "github"
       },
       "original": {
@@ -517,11 +517,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1734017764,
-        "narHash": "sha256-msOfmyJSjAHgIygI/JD0Ae3JsDv4rT54Nlfr5t6MQMQ=",
+        "lastModified": 1734529975,
+        "narHash": "sha256-ze3IJksru9dN0keqUxY0WNf8xrwfs8Ty/z9v/keyBbg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64e9404f308e0f0a0d8cdd7c358f74e34802494b",
+        "rev": "72d11d40b9878a67c38f003c240c2d2e1811e72a",
         "type": "github"
       },
       "original": {
@@ -549,11 +549,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1733808091,
-        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
+        "lastModified": 1734737257,
+        "narHash": "sha256-GIMyMt1pkkoXdCq9un859bX6YQZ/iYtukb9R5luazLM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
+        "rev": "1c6e20d41d6a9c1d737945962160e8571df55daa",
         "type": "github"
       },
       "original": {
@@ -565,11 +565,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1733940404,
-        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
+        "lastModified": 1734424634,
+        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1734193359,
-        "narHash": "sha256-8IxxuXZYYmPoPYjgGCqkzSuLYbcJ3YfTgcyj9lKJ38U=",
+        "lastModified": 1734794950,
+        "narHash": "sha256-hURloV0tweRN7qQuCa1dwwxVwUxHu1WlZ3GYKccISSg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e47e15ee1015c505fd0a0eb38811cb1f7880445d",
+        "rev": "911010813761636f28ddda81eb2c49faa8bc4233",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734149768,
-        "narHash": "sha256-pdfUlO6eARnfEnmHy2rUa5DvqyaniLDNEZRGt1pj1VI=",
+        "lastModified": 1734754523,
+        "narHash": "sha256-ywne/i+kIvU6r20dZvib0CprD28aQUYsZKxjAY/hcT8=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "af0b468ef40138b62eaeec905106e7b741b4eab6",
+        "rev": "8008cc4f52eb02f503ae6f68c10373c30b8de3dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 51

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/c2b3567b03baf0999a1dd14f7e7ab34b46297d68' (2024-12-14)
  → 'github:cachix/git-hooks.nix/f0f0dc4920a903c3e08f5bdb9246bb572fcae498' (2024-12-21)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f' (2024-12-11)
  → 'github:nix-community/home-manager/80b0fdf483c5d1cb75aaad909bd390d48673857f' (2024-12-16)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/f1e477a7dd11e27e7f98b646349cd66bbabf2fb8' (2024-12-08)
  → 'github:nix-community/nix-index-database/311d6cf3ad3f56cb051ffab1f480b2909b3f754d' (2024-12-15)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/d0797a04b81caeae77bcff10a9dde78bc17f5661' (2024-12-05)
  → 'github:NixOS/nixpkgs/5d67ea6b4b63378b9c13be21e2ec9d1afc921713' (2024-12-11)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/ec2646a6b7566f0906122d99ffe0aba42e8f33f1' (2024-12-14)
  → 'github:nix-community/nix-vscode-extensions/113779a6601d5b5c8ef7c5b5c4ab3f377fd3e2c3' (2024-12-21)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a0f3e10d94359665dba45b71b4227b0aeb851f8e' (2024-12-10)
  → 'github:NixOS/nixpkgs/1c6e20d41d6a9c1d737945962160e8571df55daa' (2024-12-20)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/64e9404f308e0f0a0d8cdd7c358f74e34802494b' (2024-12-12)
  → 'github:NixOS/nixpkgs/72d11d40b9878a67c38f003c240c2d2e1811e72a' (2024-12-18)
• Updated input 'nur':
    'github:nix-community/NUR/e47e15ee1015c505fd0a0eb38811cb1f7880445d' (2024-12-14)
  → 'github:nix-community/NUR/911010813761636f28ddda81eb2c49faa8bc4233' (2024-12-21)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/5d67ea6b4b63378b9c13be21e2ec9d1afc921713' (2024-12-11)
  → 'github:nixos/nixpkgs/d3c42f187194c26d9f0309a8ecc469d6c878ce33' (2024-12-17)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/af0b468ef40138b62eaeec905106e7b741b4eab6' (2024-12-14)
  → 'github:Gerg-L/spicetify-nix/8008cc4f52eb02f503ae6f68c10373c30b8de3dc' (2024-12-21)
```

Sources Changelog:
```
nix-fast-build: 95f5dc09a725a1916fd064f01eb3be9a5f487095 → ed736c65a8cb58a85369f6ee1c3f4403aa904fcc
```
