### PR TITLE
chore: update flake.lock & sources (2024-12-28)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -81,7 +81,7 @@
     },
     "dunst_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-07-20",
+        "date": "2024-12-24",
         "extract": null,
         "name": "dunst_catppuccin",
         "passthru": null,
@@ -93,15 +93,15 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "dunst",
-            "rev": "f02cd2894411c9b4caa207cfd8ed6345f97c0455",
-            "sha256": "sha256-EadNqtF1m//blHkV660+d4YjDReVFU2Bzhs0Pb43jh4=",
+            "rev": "5955cf0213d14a3494ec63580a81818b6f7caa66",
+            "sha256": "sha256-rBp9wU6QHpmNAjeaKnI6u8rOUlv8MC70SLUzeKHN/eY=",
             "type": "github"
         },
-        "version": "f02cd2894411c9b4caa207cfd8ed6345f97c0455"
+        "version": "5955cf0213d14a3494ec63580a81818b6f7caa66"
     },
     "eza_themes": {
         "cargoLocks": null,
-        "date": "2024-12-03",
+        "date": "2024-12-26",
         "extract": null,
         "name": "eza_themes",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "eza-community",
             "repo": "eza-themes",
-            "rev": "78601bf47075a8b3681f7b4a7fbe5e258ad469f8",
-            "sha256": "sha256-PJ0zSmAiS2iK3bW/HJ7YtYjjLvkgBSAhbbMezjHU0yA=",
+            "rev": "39c1a6640ceaaa4b59f354e1cb229c292a199e68",
+            "sha256": "sha256-sfQLMjtAcYTLAA664v6CaYlkoBCPtykhzSQCrcMEA2c=",
             "type": "github"
         },
-        "version": "78601bf47075a8b3681f7b4a7fbe5e258ad469f8"
+        "version": "39c1a6640ceaaa4b59f354e1cb229c292a199e68"
     },
     "filen": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -51,27 +51,27 @@
   };
   dunst_catppuccin = {
     pname = "dunst_catppuccin";
-    version = "f02cd2894411c9b4caa207cfd8ed6345f97c0455";
+    version = "5955cf0213d14a3494ec63580a81818b6f7caa66";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "dunst";
-      rev = "f02cd2894411c9b4caa207cfd8ed6345f97c0455";
+      rev = "5955cf0213d14a3494ec63580a81818b6f7caa66";
       fetchSubmodules = false;
-      sha256 = "sha256-EadNqtF1m//blHkV660+d4YjDReVFU2Bzhs0Pb43jh4=";
+      sha256 = "sha256-rBp9wU6QHpmNAjeaKnI6u8rOUlv8MC70SLUzeKHN/eY=";
     };
-    date = "2024-07-20";
+    date = "2024-12-24";
   };
   eza_themes = {
     pname = "eza_themes";
-    version = "78601bf47075a8b3681f7b4a7fbe5e258ad469f8";
+    version = "39c1a6640ceaaa4b59f354e1cb229c292a199e68";
     src = fetchFromGitHub {
       owner = "eza-community";
       repo = "eza-themes";
-      rev = "78601bf47075a8b3681f7b4a7fbe5e258ad469f8";
+      rev = "39c1a6640ceaaa4b59f354e1cb229c292a199e68";
       fetchSubmodules = false;
-      sha256 = "sha256-PJ0zSmAiS2iK3bW/HJ7YtYjjLvkgBSAhbbMezjHU0yA=";
+      sha256 = "sha256-sfQLMjtAcYTLAA664v6CaYlkoBCPtykhzSQCrcMEA2c=";
     };
-    date = "2024-12-03";
+    date = "2024-12-26";
   };
   filen = {
     pname = "filen";

--- a/flake.lock
+++ b/flake.lock
@@ -339,11 +339,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734366194,
-        "narHash": "sha256-vykpJ1xsdkv0j8WOVXrRFHUAdp9NXHpxdnn1F4pYgSw=",
+        "lastModified": 1735344290,
+        "narHash": "sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "80b0fdf483c5d1cb75aaad909bd390d48673857f",
+        "rev": "613691f285dad87694c2ba1c9e6298d04736292d",
         "type": "github"
       },
       "original": {
@@ -422,11 +422,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1734234111,
-        "narHash": "sha256-icEMqBt4HtGH52PU5FHidgBrNJvOfXH6VQKNtnD1aw8=",
+        "lastModified": 1735222882,
+        "narHash": "sha256-kWNi45/mRjQMG+UpaZQ7KyPavYrKfle3WgLn9YeBBVg=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "311d6cf3ad3f56cb051ffab1f480b2909b3f754d",
+        "rev": "7e3246f6ad43b44bc1c16d580d7bf6467f971530",
         "type": "github"
       },
       "original": {
@@ -442,11 +442,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1734745696,
-        "narHash": "sha256-rTGDkcbzfcTL7jE4TtxhNQtDssD1QY8yLo8ApAv3XRs=",
+        "lastModified": 1735350281,
+        "narHash": "sha256-rNhcGVh6Xnc0DKWR5RTTD9OxucfAotd41LEuMCGz228=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "113779a6601d5b5c8ef7c5b5c4ab3f377fd3e2c3",
+        "rev": "57719f14beefb91c5b58da26bb9cffbdb4f70bfa",
         "type": "github"
       },
       "original": {
@@ -457,11 +457,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733940404,
-        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
+        "lastModified": 1734649271,
+        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
         "type": "github"
       },
       "original": {
@@ -517,11 +517,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1734529975,
-        "narHash": "sha256-ze3IJksru9dN0keqUxY0WNf8xrwfs8Ty/z9v/keyBbg=",
+        "lastModified": 1735286948,
+        "narHash": "sha256-JMRV2RI58nV1UqLXqm+lcea1/dr92fYjWU5S+Rz3fmE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "72d11d40b9878a67c38f003c240c2d2e1811e72a",
+        "rev": "31ac92f9628682b294026f0860e14587a09ffb4b",
         "type": "github"
       },
       "original": {
@@ -549,11 +549,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1734737257,
-        "narHash": "sha256-GIMyMt1pkkoXdCq9un859bX6YQZ/iYtukb9R5luazLM=",
+        "lastModified": 1735264675,
+        "narHash": "sha256-MgdXpeX2GuJbtlBrH9EdsUeWl/yXEubyvxM1G+yO4Ak=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c6e20d41d6a9c1d737945962160e8571df55daa",
+        "rev": "d49da4c08359e3c39c4e27c74ac7ac9b70085966",
         "type": "github"
       },
       "original": {
@@ -565,11 +565,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1734424634,
-        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
+        "lastModified": 1735291276,
+        "narHash": "sha256-NYVcA06+blsLG6wpAbSPTCyLvxD/92Hy4vlY9WxFI1M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
+        "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1734794950,
-        "narHash": "sha256-hURloV0tweRN7qQuCa1dwwxVwUxHu1WlZ3GYKccISSg=",
+        "lastModified": 1735403874,
+        "narHash": "sha256-CkytEulg/IsnW1iWmM4/hygqX2vKuF9eHAMRxCemtpk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "911010813761636f28ddda81eb2c49faa8bc4233",
+        "rev": "1fba85eb2f9d7a57a09e5b88b8d1aad407b50998",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734754523,
-        "narHash": "sha256-ywne/i+kIvU6r20dZvib0CprD28aQUYsZKxjAY/hcT8=",
+        "lastModified": 1735359308,
+        "narHash": "sha256-wxsff5tL6UpQ4gzh+ul4iF1UkVFZTV71AfXM0k8k/zc=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "8008cc4f52eb02f503ae6f68c10373c30b8de3dc",
+        "rev": "26f2e859974b87aa946655a058ec7c3e9c94e25d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 52

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/80b0fdf483c5d1cb75aaad909bd390d48673857f' (2024-12-16)
  → 'github:nix-community/home-manager/613691f285dad87694c2ba1c9e6298d04736292d' (2024-12-28)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/311d6cf3ad3f56cb051ffab1f480b2909b3f754d' (2024-12-15)
  → 'github:nix-community/nix-index-database/7e3246f6ad43b44bc1c16d580d7bf6467f971530' (2024-12-26)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/5d67ea6b4b63378b9c13be21e2ec9d1afc921713' (2024-12-11)
  → 'github:NixOS/nixpkgs/d70bd19e0a38ad4790d3913bf08fcbfc9eeca507' (2024-12-19)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/113779a6601d5b5c8ef7c5b5c4ab3f377fd3e2c3' (2024-12-21)
  → 'github:nix-community/nix-vscode-extensions/57719f14beefb91c5b58da26bb9cffbdb4f70bfa' (2024-12-28)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/1c6e20d41d6a9c1d737945962160e8571df55daa' (2024-12-20)
  → 'github:NixOS/nixpkgs/d49da4c08359e3c39c4e27c74ac7ac9b70085966' (2024-12-27)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/72d11d40b9878a67c38f003c240c2d2e1811e72a' (2024-12-18)
  → 'github:NixOS/nixpkgs/31ac92f9628682b294026f0860e14587a09ffb4b' (2024-12-27)
• Updated input 'nur':
    'github:nix-community/NUR/911010813761636f28ddda81eb2c49faa8bc4233' (2024-12-21)
  → 'github:nix-community/NUR/1fba85eb2f9d7a57a09e5b88b8d1aad407b50998' (2024-12-28)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/d3c42f187194c26d9f0309a8ecc469d6c878ce33' (2024-12-17)
  → 'github:nixos/nixpkgs/634fd46801442d760e09493a794c4f15db2d0cbb' (2024-12-27)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/8008cc4f52eb02f503ae6f68c10373c30b8de3dc' (2024-12-21)
  → 'github:Gerg-L/spicetify-nix/26f2e859974b87aa946655a058ec7c3e9c94e25d' (2024-12-28)
```

Sources Changelog:
```
eza_themes: 78601bf47075a8b3681f7b4a7fbe5e258ad469f8 → 39c1a6640ceaaa4b59f354e1cb229c292a199e68
dunst_catppuccin: f02cd2894411c9b4caa207cfd8ed6345f97c0455 → 5955cf0213d14a3494ec63580a81818b6f7caa66
```
