### PR TITLE
chore: update flake.lock & sources (2025-01-11)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "arr_scripts": {
         "cargoLocks": null,
-        "date": "2025-01-03",
+        "date": "2025-01-10",
         "extract": null,
         "name": "arr_scripts",
         "passthru": null,
@@ -13,11 +13,11 @@
             "name": null,
             "owner": "RandomNinjaAtk",
             "repo": "arr-scripts",
-            "rev": "a3b85556a87dd2c2ca59155b2a192c3f674cdc3a",
-            "sha256": "sha256-AEfKQm6Crlhe67g9TAPLrtDPUuYillskaWgK8xMr9d4=",
+            "rev": "5714eeba59dc1ddac774f1b4a670398834f893b1",
+            "sha256": "sha256-DyYvJpQscjzlz4Lxc5Oww0AqvJ3wK6qvb9v5InDNOHU=",
             "type": "github"
         },
-        "version": "a3b85556a87dd2c2ca59155b2a192c3f674cdc3a"
+        "version": "5714eeba59dc1ddac774f1b4a670398834f893b1"
     },
     "bottom_catppuccin": {
         "cargoLocks": null,
@@ -101,7 +101,7 @@
     },
     "eza_themes": {
         "cargoLocks": null,
-        "date": "2024-12-26",
+        "date": "2025-01-10",
         "extract": null,
         "name": "eza_themes",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "eza-community",
             "repo": "eza-themes",
-            "rev": "39c1a6640ceaaa4b59f354e1cb229c292a199e68",
-            "sha256": "sha256-sfQLMjtAcYTLAA664v6CaYlkoBCPtykhzSQCrcMEA2c=",
+            "rev": "266feb8d373ac201bd28d7522e4e65cb2865f082",
+            "sha256": "sha256-K9k+jE27kK8PlN6BbTfMLhCagnWCc6CIO1lkqvWl9fE=",
             "type": "github"
         },
-        "version": "39c1a6640ceaaa4b59f354e1cb229c292a199e68"
+        "version": "266feb8d373ac201bd28d7522e4e65cb2865f082"
     },
     "filen": {
         "cargoLocks": null,
@@ -266,7 +266,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2024-12-20",
+        "date": "2025-01-11",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -278,11 +278,11 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "ed736c65a8cb58a85369f6ee1c3f4403aa904fcc",
-            "sha256": "sha256-BCpd50t/3JU4ydiNfJxH3LzQDzyGbBI0CKWaeplnkVg=",
+            "rev": "906af17fcd50c84615a4660d9c08cf89c01cef7d",
+            "sha256": "sha256-HkaJeIFgxncLm8MC1BaWRTkge9b1/+mjPcbzXTRshoM=",
             "type": "github"
         },
-        "version": "ed736c65a8cb58a85369f6ee1c3f4403aa904fcc"
+        "version": "906af17fcd50c84615a4660d9c08cf89c01cef7d"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,15 +3,15 @@
 {
   arr_scripts = {
     pname = "arr_scripts";
-    version = "a3b85556a87dd2c2ca59155b2a192c3f674cdc3a";
+    version = "5714eeba59dc1ddac774f1b4a670398834f893b1";
     src = fetchFromGitHub {
       owner = "RandomNinjaAtk";
       repo = "arr-scripts";
-      rev = "a3b85556a87dd2c2ca59155b2a192c3f674cdc3a";
+      rev = "5714eeba59dc1ddac774f1b4a670398834f893b1";
       fetchSubmodules = false;
-      sha256 = "sha256-AEfKQm6Crlhe67g9TAPLrtDPUuYillskaWgK8xMr9d4=";
+      sha256 = "sha256-DyYvJpQscjzlz4Lxc5Oww0AqvJ3wK6qvb9v5InDNOHU=";
     };
-    date = "2025-01-03";
+    date = "2025-01-10";
   };
   bottom_catppuccin = {
     pname = "bottom_catppuccin";
@@ -63,15 +63,15 @@
   };
   eza_themes = {
     pname = "eza_themes";
-    version = "39c1a6640ceaaa4b59f354e1cb229c292a199e68";
+    version = "266feb8d373ac201bd28d7522e4e65cb2865f082";
     src = fetchFromGitHub {
       owner = "eza-community";
       repo = "eza-themes";
-      rev = "39c1a6640ceaaa4b59f354e1cb229c292a199e68";
+      rev = "266feb8d373ac201bd28d7522e4e65cb2865f082";
       fetchSubmodules = false;
-      sha256 = "sha256-sfQLMjtAcYTLAA664v6CaYlkoBCPtykhzSQCrcMEA2c=";
+      sha256 = "sha256-K9k+jE27kK8PlN6BbTfMLhCagnWCc6CIO1lkqvWl9fE=";
     };
-    date = "2024-12-26";
+    date = "2025-01-10";
   };
   filen = {
     pname = "filen";
@@ -158,15 +158,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "ed736c65a8cb58a85369f6ee1c3f4403aa904fcc";
+    version = "906af17fcd50c84615a4660d9c08cf89c01cef7d";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "ed736c65a8cb58a85369f6ee1c3f4403aa904fcc";
+      rev = "906af17fcd50c84615a4660d9c08cf89c01cef7d";
       fetchSubmodules = false;
-      sha256 = "sha256-BCpd50t/3JU4ydiNfJxH3LzQDzyGbBI0CKWaeplnkVg=";
+      sha256 = "sha256-HkaJeIFgxncLm8MC1BaWRTkge9b1/+mjPcbzXTRshoM=";
     };
-    date = "2024-12-20";
+    date = "2025-01-11";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -157,11 +157,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1735774679,
-        "narHash": "sha256-soePLBazJk0qQdDVhdbM98vYdssfs3WFedcq+raipRI=",
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f2f7418ce0ab4a5309a4596161d154cfc877af66",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735344290,
-        "narHash": "sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM=",
+        "lastModified": 1736373539,
+        "narHash": "sha256-dinzAqCjenWDxuy+MqUQq0I4zUSfaCvN9rzuCmgMZJY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "613691f285dad87694c2ba1c9e6298d04736292d",
+        "rev": "bd65bc3cde04c16755955630b344bc9e35272c56",
         "type": "github"
       },
       "original": {
@@ -421,11 +421,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1735443188,
-        "narHash": "sha256-AydPpRBh8+NOkrLylG7vTsHrGO2b5L7XkMEL5HlzcA8=",
+        "lastModified": 1736440205,
+        "narHash": "sha256-QJgTI//KEGuEJC6FDxuI9Dq8PewIpnxD2NVx2/OHbfc=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "55ab1e1df5daf2476e6b826b69a82862dcbd7544",
+        "rev": "a2200b499efa01ca8646173e94cdfcc93188f2b8",
         "type": "github"
       },
       "original": {
@@ -441,11 +441,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1735955120,
-        "narHash": "sha256-gmIt30sWS5U44ySODi3Q/89IV6ylt5P0eKayg0pXQTA=",
+        "lastModified": 1736560114,
+        "narHash": "sha256-+kL+Nw3eEToKDalXJqa6fjLQqgTftTWLypr4Hj7tFKw=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "06a3dcdfa6e6c39695203c281cf6d2c800bd7649",
+        "rev": "e26efb7bac0fcdc28b92596c5c2acaaf4713124f",
         "type": "github"
       },
       "original": {
@@ -456,11 +456,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735291276,
-        "narHash": "sha256-NYVcA06+blsLG6wpAbSPTCyLvxD/92Hy4vlY9WxFI1M=",
+        "lastModified": 1735834308,
+        "narHash": "sha256-dklw3AXr3OGO4/XT1Tu3Xz9n/we8GctZZ75ZWVqAVhk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
+        "rev": "6df24922a1400241dae323af55f30e4318a6ca65",
         "type": "github"
       },
       "original": {
@@ -532,11 +532,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1735922141,
-        "narHash": "sha256-vk0xwGZSlvZ/596yxOtsk4gxsIx2VemzdjiU8zhjgWw=",
+        "lastModified": 1736200483,
+        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d29ab98cd4a70a387b8ceea3e930b3340d41ac5a",
+        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
         "type": "github"
       },
       "original": {
@@ -548,11 +548,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1735834308,
-        "narHash": "sha256-dklw3AXr3OGO4/XT1Tu3Xz9n/we8GctZZ75ZWVqAVhk=",
+        "lastModified": 1736344531,
+        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6df24922a1400241dae323af55f30e4318a6ca65",
+        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
         "type": "github"
       },
       "original": {
@@ -569,11 +569,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1735998325,
-        "narHash": "sha256-4Zh6FUTQSbAfalbPyrzRTH0GTapf9/qlCEs2OaejFJQ=",
+        "lastModified": 1736610420,
+        "narHash": "sha256-MvvjzN4DJSQmRLQSfQWC3a70GWVu6RiwE0D71c8el2U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "867df4df63ec4f24b79aa6ea97805e2d5efd376a",
+        "rev": "bc3d78ce1ae003f42ddd6434256262861247cfe1",
         "type": "github"
       },
       "original": {
@@ -661,11 +661,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735964101,
-        "narHash": "sha256-FUKeipaDxAFf+0jun6CKk37g7UALIeisSz6L19KL+WM=",
+        "lastModified": 1736568948,
+        "narHash": "sha256-nnaMeMQPDg1GLQPBejn4nBtvQKSRVv64IIPZ7XmX5u0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "5b2bbc7a627ea983cef34f4a8ec81cd597529943",
+        "rev": "3da50a44c6c47b3361e56231123797101892c565",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 02

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/f2f7418ce0ab4a5309a4596161d154cfc877af66' (2025-01-01)
  → 'github:hercules-ci/flake-parts/b905f6fc23a9051a6e1b741e1438dbfc0634c6de' (2025-01-06)
• Updated input 'home-manager':
    'github:nix-community/home-manager/613691f285dad87694c2ba1c9e6298d04736292d' (2024-12-28)
  → 'github:nix-community/home-manager/bd65bc3cde04c16755955630b344bc9e35272c56' (2025-01-08)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/55ab1e1df5daf2476e6b826b69a82862dcbd7544' (2024-12-29)
  → 'github:nix-community/nix-index-database/a2200b499efa01ca8646173e94cdfcc93188f2b8' (2025-01-09)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/634fd46801442d760e09493a794c4f15db2d0cbb' (2024-12-27)
  → 'github:NixOS/nixpkgs/6df24922a1400241dae323af55f30e4318a6ca65' (2025-01-02)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/06a3dcdfa6e6c39695203c281cf6d2c800bd7649' (2025-01-04)
  → 'github:nix-community/nix-vscode-extensions/e26efb7bac0fcdc28b92596c5c2acaaf4713124f' (2025-01-11)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/d29ab98cd4a70a387b8ceea3e930b3340d41ac5a' (2025-01-03)
  → 'github:NixOS/nixpkgs/3f0a8ac25fb674611b98089ca3a5dd6480175751' (2025-01-06)
• Updated input 'nur':
    'github:nix-community/NUR/867df4df63ec4f24b79aa6ea97805e2d5efd376a' (2025-01-04)
  → 'github:nix-community/NUR/bc3d78ce1ae003f42ddd6434256262861247cfe1' (2025-01-11)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/6df24922a1400241dae323af55f30e4318a6ca65' (2025-01-02)
  → 'github:nixos/nixpkgs/bffc22eb12172e6db3c5dde9e3e5628f8e3e7912' (2025-01-08)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/5b2bbc7a627ea983cef34f4a8ec81cd597529943' (2025-01-04)
  → 'github:Gerg-L/spicetify-nix/3da50a44c6c47b3361e56231123797101892c565' (2025-01-11)
```

Sources Changelog:
```
nix-fast-build: ed736c65a8cb58a85369f6ee1c3f4403aa904fcc → 906af17fcd50c84615a4660d9c08cf89c01cef7d
eza_themes: 39c1a6640ceaaa4b59f354e1cb229c292a199e68 → 266feb8d373ac201bd28d7522e4e65cb2865f082
arr_scripts: a3b85556a87dd2c2ca59155b2a192c3f674cdc3a → 5714eeba59dc1ddac774f1b4a670398834f893b1
```
