### PR TITLE
chore: update flake.lock & sources (2025-01-18)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "arr_scripts": {
         "cargoLocks": null,
-        "date": "2025-01-10",
+        "date": "2025-01-16",
         "extract": null,
         "name": "arr_scripts",
         "passthru": null,
@@ -13,11 +13,11 @@
             "name": null,
             "owner": "RandomNinjaAtk",
             "repo": "arr-scripts",
-            "rev": "5714eeba59dc1ddac774f1b4a670398834f893b1",
-            "sha256": "sha256-DyYvJpQscjzlz4Lxc5Oww0AqvJ3wK6qvb9v5InDNOHU=",
+            "rev": "5738fdda3af666712fcf421f20110447c1ecc7ba",
+            "sha256": "sha256-SulpO5MR8hPnZLQwUDKnlC1csso96OPkkvegYeCVw3Q=",
             "type": "github"
         },
-        "version": "5714eeba59dc1ddac774f1b4a670398834f893b1"
+        "version": "5738fdda3af666712fcf421f20110447c1ecc7ba"
     },
     "bottom_catppuccin": {
         "cargoLocks": null,
@@ -148,11 +148,11 @@
             "name": null,
             "owner": "rafaelmardojai",
             "repo": "firefox-gnome-theme",
-            "rev": "v133.1",
-            "sha256": "sha256-onO+zd9ssgsLC5ax3UWPZ41DcZPkxdXT8JmmjDkw944=",
+            "rev": "v134",
+            "sha256": "sha256-S79Hqn2EtSxU4kp99t8tRschSifWD4p/51++0xNWUxw=",
             "type": "github"
         },
-        "version": "v133.1"
+        "version": "v134"
     },
     "foot_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,15 +3,15 @@
 {
   arr_scripts = {
     pname = "arr_scripts";
-    version = "5714eeba59dc1ddac774f1b4a670398834f893b1";
+    version = "5738fdda3af666712fcf421f20110447c1ecc7ba";
     src = fetchFromGitHub {
       owner = "RandomNinjaAtk";
       repo = "arr-scripts";
-      rev = "5714eeba59dc1ddac774f1b4a670398834f893b1";
+      rev = "5738fdda3af666712fcf421f20110447c1ecc7ba";
       fetchSubmodules = false;
-      sha256 = "sha256-DyYvJpQscjzlz4Lxc5Oww0AqvJ3wK6qvb9v5InDNOHU=";
+      sha256 = "sha256-SulpO5MR8hPnZLQwUDKnlC1csso96OPkkvegYeCVw3Q=";
     };
-    date = "2025-01-10";
+    date = "2025-01-16";
   };
   bottom_catppuccin = {
     pname = "bottom_catppuccin";
@@ -83,13 +83,13 @@
   };
   firefox-gnome-theme = {
     pname = "firefox-gnome-theme";
-    version = "v133.1";
+    version = "v134";
     src = fetchFromGitHub {
       owner = "rafaelmardojai";
       repo = "firefox-gnome-theme";
-      rev = "v133.1";
+      rev = "v134";
       fetchSubmodules = false;
-      sha256 = "sha256-onO+zd9ssgsLC5ax3UWPZ41DcZPkxdXT8JmmjDkw944=";
+      sha256 = "sha256-S79Hqn2EtSxU4kp99t8tRschSifWD4p/51++0xNWUxw=";
     };
   };
   foot_catppuccin = {

--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1723293904,
-        "narHash": "sha256-b+uqzj+Wa6xgMS9aNbX4I+sXeb5biPDi39VgvSFqFvU=",
+        "lastModified": 1736955230,
+        "narHash": "sha256-uenf8fv2eG5bKM8C/UvFaiJMZ4IpUFaQxk9OH5t/1gA=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "f6291c5935fdc4e0bef208cfc0dcab7e3f7a1c41",
+        "rev": "e600439ec4c273cf11e06fe4d9d906fb98fa097c",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735882644,
-        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
+        "lastModified": 1737043064,
+        "narHash": "sha256-I/OuxGwXwRi5gnFPsyCvVR+IfFstA+QXEpHu1hvsgD8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
+        "rev": "94ee657f6032d913fe0ef49adaa743804635b0bb",
         "type": "github"
       },
       "original": {
@@ -421,11 +421,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1736440205,
-        "narHash": "sha256-QJgTI//KEGuEJC6FDxuI9Dq8PewIpnxD2NVx2/OHbfc=",
+        "lastModified": 1736652904,
+        "narHash": "sha256-8uolHABgroXqzs03QdulHp8H9e5kWQZnnhcda1MKbBM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "a2200b499efa01ca8646173e94cdfcc93188f2b8",
+        "rev": "271e5bd7c57e1f001693799518b10a02d1123b12",
         "type": "github"
       },
       "original": {
@@ -441,11 +441,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1736560114,
-        "narHash": "sha256-+kL+Nw3eEToKDalXJqa6fjLQqgTftTWLypr4Hj7tFKw=",
+        "lastModified": 1737164178,
+        "narHash": "sha256-Vx+05Uvr6ibnswCh0o57tWmXAla1JeYVVZP5F6n28hI=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "e26efb7bac0fcdc28b92596c5c2acaaf4713124f",
+        "rev": "f6762acb15005c5bf8a189f832c29f1ca4dfa246",
         "type": "github"
       },
       "original": {
@@ -456,11 +456,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735834308,
-        "narHash": "sha256-dklw3AXr3OGO4/XT1Tu3Xz9n/we8GctZZ75ZWVqAVhk=",
+        "lastModified": 1736344531,
+        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6df24922a1400241dae323af55f30e4318a6ca65",
+        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
         "type": "github"
       },
       "original": {
@@ -532,11 +532,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1736200483,
-        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
+        "lastModified": 1736916166,
+        "narHash": "sha256-puPDoVKxkuNmYIGMpMQiK8bEjaACcCksolsG36gdaNQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
+        "rev": "e24b4c09e963677b1beea49d411cd315a024ad3a",
         "type": "github"
       },
       "original": {
@@ -548,11 +548,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1736344531,
-        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
+        "lastModified": 1737062831,
+        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
+        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
         "type": "github"
       },
       "original": {
@@ -569,11 +569,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1736610420,
-        "narHash": "sha256-MvvjzN4DJSQmRLQSfQWC3a70GWVu6RiwE0D71c8el2U=",
+        "lastModified": 1737215167,
+        "narHash": "sha256-ygGOvYQQl5xWsl5QiZQ6kRZoctbXuyaBNtxr/bAq+jM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bc3d78ce1ae003f42ddd6434256262861247cfe1",
+        "rev": "f8570bd2fb99a0cab2b3f7d7cd4da783e1e3b520",
         "type": "github"
       },
       "original": {
@@ -661,11 +661,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736568948,
-        "narHash": "sha256-nnaMeMQPDg1GLQPBejn4nBtvQKSRVv64IIPZ7XmX5u0=",
+        "lastModified": 1737173687,
+        "narHash": "sha256-+WxaXc30KhTuCa9U8Nv2mJApIBq85CfA5fbcVsvdfxo=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "3da50a44c6c47b3361e56231123797101892c565",
+        "rev": "c68c2ac0814ab386d2cbd3b9178e729b4fc805f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 03

Flakes Changelog:
```
• Updated input 'agenix':
    'github:ryantm/agenix/f6291c5935fdc4e0bef208cfc0dcab7e3f7a1c41' (2024-08-10)
  → 'github:ryantm/agenix/e600439ec4c273cf11e06fe4d9d906fb98fa097c' (2025-01-15)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/a5a961387e75ae44cc20f0a57ae463da5e959656' (2025-01-03)
  → 'github:cachix/git-hooks.nix/94ee657f6032d913fe0ef49adaa743804635b0bb' (2025-01-16)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/a2200b499efa01ca8646173e94cdfcc93188f2b8' (2025-01-09)
  → 'github:nix-community/nix-index-database/271e5bd7c57e1f001693799518b10a02d1123b12' (2025-01-12)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/6df24922a1400241dae323af55f30e4318a6ca65' (2025-01-02)
  → 'github:NixOS/nixpkgs/bffc22eb12172e6db3c5dde9e3e5628f8e3e7912' (2025-01-08)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/e26efb7bac0fcdc28b92596c5c2acaaf4713124f' (2025-01-11)
  → 'github:nix-community/nix-vscode-extensions/f6762acb15005c5bf8a189f832c29f1ca4dfa246' (2025-01-18)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/3f0a8ac25fb674611b98089ca3a5dd6480175751' (2025-01-06)
  → 'github:NixOS/nixpkgs/e24b4c09e963677b1beea49d411cd315a024ad3a' (2025-01-15)
• Updated input 'nur':
    'github:nix-community/NUR/bc3d78ce1ae003f42ddd6434256262861247cfe1' (2025-01-11)
  → 'github:nix-community/NUR/f8570bd2fb99a0cab2b3f7d7cd4da783e1e3b520' (2025-01-18)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/bffc22eb12172e6db3c5dde9e3e5628f8e3e7912' (2025-01-08)
  → 'github:nixos/nixpkgs/5df43628fdf08d642be8ba5b3625a6c70731c19c' (2025-01-16)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/3da50a44c6c47b3361e56231123797101892c565' (2025-01-11)
  → 'github:Gerg-L/spicetify-nix/c68c2ac0814ab386d2cbd3b9178e729b4fc805f0' (2025-01-18)
```

Sources Changelog:
```
firefox-gnome-theme: v133.1 → v134
arr_scripts: 5714eeba59dc1ddac774f1b4a670398834f893b1 → 5738fdda3af666712fcf421f20110447c1ecc7ba
```
