### PR TITLE
chore: update flake.lock & sources (2025-01-25)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -101,7 +101,7 @@
     },
     "eza_themes": {
         "cargoLocks": null,
-        "date": "2025-01-10",
+        "date": "2025-01-24",
         "extract": null,
         "name": "eza_themes",
         "passthru": null,
@@ -113,11 +113,11 @@
             "name": null,
             "owner": "eza-community",
             "repo": "eza-themes",
-            "rev": "266feb8d373ac201bd28d7522e4e65cb2865f082",
-            "sha256": "sha256-K9k+jE27kK8PlN6BbTfMLhCagnWCc6CIO1lkqvWl9fE=",
+            "rev": "a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71",
+            "sha256": "sha256-d+bbjgI1JrOGenqZ2aIRK8itkTUV2L4L3vtEN9tEgf8=",
             "type": "github"
         },
-        "version": "266feb8d373ac201bd28d7522e4e65cb2865f082"
+        "version": "a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71"
     },
     "filen": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -63,15 +63,15 @@
   };
   eza_themes = {
     pname = "eza_themes";
-    version = "266feb8d373ac201bd28d7522e4e65cb2865f082";
+    version = "a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71";
     src = fetchFromGitHub {
       owner = "eza-community";
       repo = "eza-themes";
-      rev = "266feb8d373ac201bd28d7522e4e65cb2865f082";
+      rev = "a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71";
       fetchSubmodules = false;
-      sha256 = "sha256-K9k+jE27kK8PlN6BbTfMLhCagnWCc6CIO1lkqvWl9fE=";
+      sha256 = "sha256-d+bbjgI1JrOGenqZ2aIRK8itkTUV2L4L3vtEN9tEgf8=";
     };
-    date = "2025-01-10";
+    date = "2025-01-24";
   };
   filen = {
     pname = "filen";

--- a/flake.lock
+++ b/flake.lock
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737043064,
-        "narHash": "sha256-I/OuxGwXwRi5gnFPsyCvVR+IfFstA+QXEpHu1hvsgD8=",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "94ee657f6032d913fe0ef49adaa743804635b0bb",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {
@@ -421,11 +421,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1736652904,
-        "narHash": "sha256-8uolHABgroXqzs03QdulHp8H9e5kWQZnnhcda1MKbBM=",
+        "lastModified": 1737257306,
+        "narHash": "sha256-lEGgpA4kGafc76+Amnz+gh1L/cwUS2pePFlf22WEyh8=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "271e5bd7c57e1f001693799518b10a02d1123b12",
+        "rev": "744d330659e207a1883d2da0141d35e520eb87bd",
         "type": "github"
       },
       "original": {
@@ -441,11 +441,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1737164178,
-        "narHash": "sha256-Vx+05Uvr6ibnswCh0o57tWmXAla1JeYVVZP5F6n28hI=",
+        "lastModified": 1737768919,
+        "narHash": "sha256-0fJ9O6ijORRRWRbS+TrZQqefl+7Zgx9I6uknfTitCJk=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "f6762acb15005c5bf8a189f832c29f1ca4dfa246",
+        "rev": "cb0aee6840fb29b70439880656ca6a313a6af101",
         "type": "github"
       },
       "original": {
@@ -456,11 +456,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736344531,
-        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
+        "lastModified": 1737062831,
+        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
+        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
         "type": "github"
       },
       "original": {
@@ -532,11 +532,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1736916166,
-        "narHash": "sha256-puPDoVKxkuNmYIGMpMQiK8bEjaACcCksolsG36gdaNQ=",
+        "lastModified": 1737672001,
+        "narHash": "sha256-YnHJJ19wqmibLQdUeq9xzE6CjrMA568KN/lFPuSVs4I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e24b4c09e963677b1beea49d411cd315a024ad3a",
+        "rev": "035f8c0853c2977b24ffc4d0a42c74f00b182cd8",
         "type": "github"
       },
       "original": {
@@ -548,11 +548,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1737062831,
-        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "lastModified": 1737632463,
+        "narHash": "sha256-38J9QfeGSej341ouwzqf77WIHAScihAKCt8PQJ+NH28=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
+        "rev": "0aa475546ed21629c4f5bbf90e38c846a99ec9e9",
         "type": "github"
       },
       "original": {
@@ -569,11 +569,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1737215167,
-        "narHash": "sha256-ygGOvYQQl5xWsl5QiZQ6kRZoctbXuyaBNtxr/bAq+jM=",
+        "lastModified": 1737816726,
+        "narHash": "sha256-R/VvHkGSpr3iEdU+3W67Y+bgBaH68SbXhp2wBocTl/w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8570bd2fb99a0cab2b3f7d7cd4da783e1e3b520",
+        "rev": "03732dc5ba625019dfd975212760cf42523ce277",
         "type": "github"
       },
       "original": {
@@ -661,11 +661,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737173687,
-        "narHash": "sha256-+WxaXc30KhTuCa9U8Nv2mJApIBq85CfA5fbcVsvdfxo=",
+        "lastModified": 1737778506,
+        "narHash": "sha256-kdqwOnk0jFb3E01HFqUFAW+NQuBp39uwrpWSXmFAKGs=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "c68c2ac0814ab386d2cbd3b9178e729b4fc805f0",
+        "rev": "aeaa9b2fad9d658e8982a140327e345feffe8850",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 04

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/94ee657f6032d913fe0ef49adaa743804635b0bb' (2025-01-16)
  → 'github:cachix/git-hooks.nix/9364dc02281ce2d37a1f55b6e51f7c0f65a75f17' (2025-01-21)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/271e5bd7c57e1f001693799518b10a02d1123b12' (2025-01-12)
  → 'github:nix-community/nix-index-database/744d330659e207a1883d2da0141d35e520eb87bd' (2025-01-19)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/bffc22eb12172e6db3c5dde9e3e5628f8e3e7912' (2025-01-08)
  → 'github:NixOS/nixpkgs/5df43628fdf08d642be8ba5b3625a6c70731c19c' (2025-01-16)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/f6762acb15005c5bf8a189f832c29f1ca4dfa246' (2025-01-18)
  → 'github:nix-community/nix-vscode-extensions/cb0aee6840fb29b70439880656ca6a313a6af101' (2025-01-25)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/e24b4c09e963677b1beea49d411cd315a024ad3a' (2025-01-15)
  → 'github:NixOS/nixpkgs/035f8c0853c2977b24ffc4d0a42c74f00b182cd8' (2025-01-23)
• Updated input 'nur':
    'github:nix-community/NUR/f8570bd2fb99a0cab2b3f7d7cd4da783e1e3b520' (2025-01-18)
  → 'github:nix-community/NUR/03732dc5ba625019dfd975212760cf42523ce277' (2025-01-25)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/5df43628fdf08d642be8ba5b3625a6c70731c19c' (2025-01-16)
  → 'github:nixos/nixpkgs/0aa475546ed21629c4f5bbf90e38c846a99ec9e9' (2025-01-23)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/c68c2ac0814ab386d2cbd3b9178e729b4fc805f0' (2025-01-18)
  → 'github:Gerg-L/spicetify-nix/aeaa9b2fad9d658e8982a140327e345feffe8850' (2025-01-25)
```

Sources Changelog:
```
eza_themes: 266feb8d373ac201bd28d7522e4e65cb2865f082 → a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71
```
