### PR TITLE
chore: update flake.lock & sources (2025-02-01)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -15,6 +15,7 @@
             "repo": "arr-scripts",
             "rev": "5738fdda3af666712fcf421f20110447c1ecc7ba",
             "sha256": "sha256-SulpO5MR8hPnZLQwUDKnlC1csso96OPkkvegYeCVw3Q=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "5738fdda3af666712fcf421f20110447c1ecc7ba"
@@ -35,6 +36,7 @@
             "repo": "bottom",
             "rev": "ed09bd5a5dd78d83acdc8ff5fdec40a6340ed1c2",
             "sha256": "sha256-Vi438I+YVvoD2xzq2t9hJ9R3a+2TlDdbakjFYFtjtXQ=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "ed09bd5a5dd78d83acdc8ff5fdec40a6340ed1c2"
@@ -55,6 +57,7 @@
             "repo": "calibre",
             "rev": "27bd12d2d8dcd24b9ce7cae32135fbd41b896921",
             "sha256": "sha256-JnovYvkIjQXHMFWsmAYIKiA1aexDI3+IkuwwpRdMIcs=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "27bd12d2d8dcd24b9ce7cae32135fbd41b896921"
@@ -75,6 +78,7 @@
             "repo": "zsh-syntax-highlighting",
             "rev": "7926c3d3e17d26b3779851a2255b95ee650bd928",
             "sha256": "sha256-l6tztApzYpQ2/CiKuLBf8vI2imM6vPJuFdNDSEi7T/o=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "7926c3d3e17d26b3779851a2255b95ee650bd928"
@@ -95,6 +99,7 @@
             "repo": "dunst",
             "rev": "5955cf0213d14a3494ec63580a81818b6f7caa66",
             "sha256": "sha256-rBp9wU6QHpmNAjeaKnI6u8rOUlv8MC70SLUzeKHN/eY=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "5955cf0213d14a3494ec63580a81818b6f7caa66"
@@ -115,6 +120,7 @@
             "repo": "eza-themes",
             "rev": "a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71",
             "sha256": "sha256-d+bbjgI1JrOGenqZ2aIRK8itkTUV2L4L3vtEN9tEgf8=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71"
@@ -150,6 +156,7 @@
             "repo": "firefox-gnome-theme",
             "rev": "v134",
             "sha256": "sha256-S79Hqn2EtSxU4kp99t8tRschSifWD4p/51++0xNWUxw=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "v134"
@@ -170,6 +177,7 @@
             "repo": "foot",
             "rev": "962ff1a5b6387bc5419e9788a773a080eea5f1e1",
             "sha256": "sha256-eVH3BY2fZe0/OjqucM/IZthV8PMsM9XeIijOg8cNE1Y=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "962ff1a5b6387bc5419e9788a773a080eea5f1e1"
@@ -205,6 +213,7 @@
             "repo": "hyprland",
             "rev": "c388ac55563ddeea0afe9df79d4bfff0096b146b",
             "sha256": "sha256-xSa/z0Pu+ioZ0gFH9qSo9P94NPkEMovstm1avJ7rvzM=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "c388ac55563ddeea0afe9df79d4bfff0096b146b"
@@ -240,6 +249,7 @@
             "repo": "hyprlock",
             "rev": "958e70b1cd8799defd16dee070d07f977d4fd76b",
             "sha256": "sha256-l4CbAUeb/Tg603QnZ/VWxuGqRBztpHN0HLX/h8ndc5w=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "958e70b1cd8799defd16dee070d07f977d4fd76b"
@@ -260,6 +270,7 @@
             "repo": "joplin",
             "rev": "b0a886ce7ba71b48fdbf72ad27f3446400ebcdb9",
             "sha256": "sha256-H19iaemj7XWsd3r7OBvQinrNKMiYGl53ArIp49gZExs=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "b0a886ce7ba71b48fdbf72ad27f3446400ebcdb9"
@@ -280,6 +291,7 @@
             "repo": "nix-fast-build",
             "rev": "906af17fcd50c84615a4660d9c08cf89c01cef7d",
             "sha256": "sha256-HkaJeIFgxncLm8MC1BaWRTkge9b1/+mjPcbzXTRshoM=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "906af17fcd50c84615a4660d9c08cf89c01cef7d"
@@ -300,6 +312,7 @@
             "repo": "obs",
             "rev": "d90002a5315db3a43c39dc52c2a91a99c9330e1f",
             "sha256": "sha256-rU4WTj+2E/+OblAeK0+nzJhisz2V2/KwHBiJVBRj+LQ=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "d90002a5315db3a43c39dc52c2a91a99c9330e1f"
@@ -320,6 +333,7 @@
             "repo": "prismlauncher",
             "rev": "2edbdf5295bc3c12c3dd53b203ab91028fce2c54",
             "sha256": "sha256-+yGrSZztf2sZ9frPT3ydIJDavo4eXs03cQWfdTAmn3w=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "2edbdf5295bc3c12c3dd53b203ab91028fce2c54"
@@ -340,6 +354,7 @@
             "repo": "rofi-bluetooth",
             "rev": "9d91c048ff129819f4c6e9e48a17bd54343bbffb",
             "sha256": "sha256-1Xe3QFThIvJDCUznDP5ZBzwZEMuqmxpDIV+BcVvQDG8=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "9d91c048ff129819f4c6e9e48a17bd54343bbffb"
@@ -360,6 +375,7 @@
             "repo": "rofi",
             "rev": "b636a00fd40a7899a8206195464ae8b7f0450a6d",
             "sha256": "sha256-zA8Zum19pDTgn0KdQ0gD2kqCOXK4OCHBidFpGwrJOqg=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "b636a00fd40a7899a8206195464ae8b7f0450a6d"
@@ -380,6 +396,7 @@
             "repo": "starship",
             "rev": "e99ba6b210c0739af2a18094024ca0bdf4bb3225",
             "sha256": "sha256-1w0TJdQP5lb9jCrCmhPlSexf0PkAlcz8GBDEsRjPRns=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "e99ba6b210c0739af2a18094024ca0bdf4bb3225"

--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,8 @@
       "locked": {
         "lastModified": 1737465171,
         "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
-        "lastModified": 1737465171,
-        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
@@ -341,11 +338,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737762889,
-        "narHash": "sha256-5HGG09bh/Yx0JA8wtBMAzt0HMCL1bYZ93x4IqzVExio=",
+        "lastModified": 1738415006,
+        "narHash": "sha256-ZlLTnqIQQ8OE6AtT+fluB642j2R9tnvxHHtpnmLjSxQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "daf04c5950b676f47a794300657f1d3d14c1a120",
+        "rev": "8544cd092047a7e92d0dce011108a563de7fc0f2",
         "type": "github"
       },
       "original": {
@@ -443,11 +440,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1737891152,
-        "narHash": "sha256-6qXE4S0vVMyEuiaXdmGfXJLabL3htfETHANUnj2c5UI=",
+        "lastModified": 1738374609,
+        "narHash": "sha256-IyHDXC0zXFTtrheJHdr1M1lS1GkDBPo09/mWDt+UfUQ=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "94e4452b948a3dab711bb6b3261cca4066ac0a49",
+        "rev": "e26741603fb047295c7015c93746b75601c8c490",
         "type": "github"
       },
       "original": {
@@ -502,11 +499,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1737672001,
-        "narHash": "sha256-YnHJJ19wqmibLQdUeq9xzE6CjrMA568KN/lFPuSVs4I=",
+        "lastModified": 1738277201,
+        "narHash": "sha256-6L+WXKCw5mqnUIExvqkD99pJQ41xgyCk6z/H9snClwk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "035f8c0853c2977b24ffc4d0a42c74f00b182cd8",
+        "rev": "666e1b3f09c267afd66addebe80fb05a5ef2b554",
         "type": "github"
       },
       "original": {
@@ -534,11 +531,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1737746512,
-        "narHash": "sha256-nU6AezEX4EuahTO1YopzueAXfjFfmCHylYEFCagduHU=",
+        "lastModified": 1738142207,
+        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "825479c345a7f806485b7f00dbe3abb50641b083",
+        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
         "type": "github"
       },
       "original": {
@@ -550,11 +547,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1737746512,
-        "narHash": "sha256-nU6AezEX4EuahTO1YopzueAXfjFfmCHylYEFCagduHU=",
+        "lastModified": 1738142207,
+        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "825479c345a7f806485b7f00dbe3abb50641b083",
+        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
         "type": "github"
       },
       "original": {
@@ -571,11 +568,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1737891900,
-        "narHash": "sha256-F2QPj+b9GRNdPfQFbkGkWGX6k/cooQ/erLOvXmPk24U=",
+        "lastModified": 1738362438,
+        "narHash": "sha256-EO2dVkMVLThWqv4hobEZEZGWBEuH2Z9SYqQDrbLSclU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e05dbeb1dd69b28ce28d9ad2209dcd2a6db0fe8b",
+        "rev": "95ddad0ff0e67c90314c6ca46324dce5f9a910d2",
         "type": "github"
       },
       "original": {
@@ -627,7 +624,7 @@
         "nixpkgs-stable": "nixpkgs-stable_2",
         "nur": "nur",
         "spicetify-nix": "spicetify-nix",
-        "systems": "systems_5"
+        "systems": "systems_6"
       }
     },
     "rust-overlay": {
@@ -660,14 +657,15 @@
         "flake-compat": "flake-compat_4",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1737864911,
-        "narHash": "sha256-yQGyYTEDJreafvnHQvTvCHxmmqy77mrUyzJV1zr3XN0=",
+        "lastModified": 1738411789,
+        "narHash": "sha256-xA8n3Ka7DqlNO7xvmk41cXjc8+JLbIlJZC9Q8l34or8=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "b65b84d6b8e9cd59af6524f05a1972fbe6fecce5",
+        "rev": "d90043d8c160505e4adb756deff9bed5d2153d5e",
         "type": "github"
       },
       "original": {
@@ -737,6 +735,21 @@
       }
     },
     "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
Automated Pull Request for Week 05

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/daf04c5950b676f47a794300657f1d3d14c1a120' (2025-01-24)
  → 'github:nix-community/home-manager/8544cd092047a7e92d0dce011108a563de7fc0f2' (2025-02-01)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/94e4452b948a3dab711bb6b3261cca4066ac0a49' (2025-01-26)
  → 'github:nix-community/nix-vscode-extensions/e26741603fb047295c7015c93746b75601c8c490' (2025-02-01)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/825479c345a7f806485b7f00dbe3abb50641b083' (2025-01-24)
  → 'github:NixOS/nixpkgs/9d3ae807ebd2981d593cddd0080856873139aa40' (2025-01-29)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/035f8c0853c2977b24ffc4d0a42c74f00b182cd8' (2025-01-23)
  → 'github:NixOS/nixpkgs/666e1b3f09c267afd66addebe80fb05a5ef2b554' (2025-01-30)
• Updated input 'nur':
    'github:nix-community/NUR/e05dbeb1dd69b28ce28d9ad2209dcd2a6db0fe8b' (2025-01-26)
  → 'github:nix-community/NUR/95ddad0ff0e67c90314c6ca46324dce5f9a910d2' (2025-01-31)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/825479c345a7f806485b7f00dbe3abb50641b083' (2025-01-24)
  → 'github:nixos/nixpkgs/9d3ae807ebd2981d593cddd0080856873139aa40' (2025-01-29)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/b65b84d6b8e9cd59af6524f05a1972fbe6fecce5' (2025-01-26)
  → 'github:Gerg-L/spicetify-nix/d90043d8c160505e4adb756deff9bed5d2153d5e' (2025-02-01)
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e' (2023-04-09)
```

Sources Changelog:
```
No changes!
```
