### PR TITLE
chore: update flake.lock & sources (2025-02-08)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "arr_scripts": {
         "cargoLocks": null,
-        "date": "2025-01-16",
+        "date": "2025-02-06",
         "extract": null,
         "name": "arr_scripts",
         "passthru": null,
@@ -13,11 +13,12 @@
             "name": null,
             "owner": "RandomNinjaAtk",
             "repo": "arr-scripts",
-            "rev": "5738fdda3af666712fcf421f20110447c1ecc7ba",
-            "sha256": "sha256-SulpO5MR8hPnZLQwUDKnlC1csso96OPkkvegYeCVw3Q=",
+            "rev": "e3e415569d829431db783e91669c7dd5eb325294",
+            "sha256": "sha256-1fX0Z2ZrLLNlVX4bzk5OU3FhwAG/YhLQBRE7Bb0Tfz4=",
+            "sparseCheckout": [],
             "type": "github"
         },
-        "version": "5738fdda3af666712fcf421f20110447c1ecc7ba"
+        "version": "e3e415569d829431db783e91669c7dd5eb325294"
     },
     "bottom_catppuccin": {
         "cargoLocks": null,
@@ -35,6 +36,7 @@
             "repo": "bottom",
             "rev": "ed09bd5a5dd78d83acdc8ff5fdec40a6340ed1c2",
             "sha256": "sha256-Vi438I+YVvoD2xzq2t9hJ9R3a+2TlDdbakjFYFtjtXQ=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "ed09bd5a5dd78d83acdc8ff5fdec40a6340ed1c2"
@@ -55,6 +57,7 @@
             "repo": "calibre",
             "rev": "27bd12d2d8dcd24b9ce7cae32135fbd41b896921",
             "sha256": "sha256-JnovYvkIjQXHMFWsmAYIKiA1aexDI3+IkuwwpRdMIcs=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "27bd12d2d8dcd24b9ce7cae32135fbd41b896921"
@@ -75,6 +78,7 @@
             "repo": "zsh-syntax-highlighting",
             "rev": "7926c3d3e17d26b3779851a2255b95ee650bd928",
             "sha256": "sha256-l6tztApzYpQ2/CiKuLBf8vI2imM6vPJuFdNDSEi7T/o=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "7926c3d3e17d26b3779851a2255b95ee650bd928"
@@ -95,6 +99,7 @@
             "repo": "dunst",
             "rev": "5955cf0213d14a3494ec63580a81818b6f7caa66",
             "sha256": "sha256-rBp9wU6QHpmNAjeaKnI6u8rOUlv8MC70SLUzeKHN/eY=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "5955cf0213d14a3494ec63580a81818b6f7caa66"
@@ -115,6 +120,7 @@
             "repo": "eza-themes",
             "rev": "a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71",
             "sha256": "sha256-d+bbjgI1JrOGenqZ2aIRK8itkTUV2L4L3vtEN9tEgf8=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71"
@@ -150,6 +156,7 @@
             "repo": "firefox-gnome-theme",
             "rev": "v134",
             "sha256": "sha256-S79Hqn2EtSxU4kp99t8tRschSifWD4p/51++0xNWUxw=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "v134"
@@ -170,6 +177,7 @@
             "repo": "foot",
             "rev": "962ff1a5b6387bc5419e9788a773a080eea5f1e1",
             "sha256": "sha256-eVH3BY2fZe0/OjqucM/IZthV8PMsM9XeIijOg8cNE1Y=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "962ff1a5b6387bc5419e9788a773a080eea5f1e1"
@@ -205,6 +213,7 @@
             "repo": "hyprland",
             "rev": "c388ac55563ddeea0afe9df79d4bfff0096b146b",
             "sha256": "sha256-xSa/z0Pu+ioZ0gFH9qSo9P94NPkEMovstm1avJ7rvzM=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "c388ac55563ddeea0afe9df79d4bfff0096b146b"
@@ -240,6 +249,7 @@
             "repo": "hyprlock",
             "rev": "958e70b1cd8799defd16dee070d07f977d4fd76b",
             "sha256": "sha256-l4CbAUeb/Tg603QnZ/VWxuGqRBztpHN0HLX/h8ndc5w=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "958e70b1cd8799defd16dee070d07f977d4fd76b"
@@ -260,6 +270,7 @@
             "repo": "joplin",
             "rev": "b0a886ce7ba71b48fdbf72ad27f3446400ebcdb9",
             "sha256": "sha256-H19iaemj7XWsd3r7OBvQinrNKMiYGl53ArIp49gZExs=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "b0a886ce7ba71b48fdbf72ad27f3446400ebcdb9"
@@ -280,6 +291,7 @@
             "repo": "nix-fast-build",
             "rev": "906af17fcd50c84615a4660d9c08cf89c01cef7d",
             "sha256": "sha256-HkaJeIFgxncLm8MC1BaWRTkge9b1/+mjPcbzXTRshoM=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "906af17fcd50c84615a4660d9c08cf89c01cef7d"
@@ -300,6 +312,7 @@
             "repo": "obs",
             "rev": "d90002a5315db3a43c39dc52c2a91a99c9330e1f",
             "sha256": "sha256-rU4WTj+2E/+OblAeK0+nzJhisz2V2/KwHBiJVBRj+LQ=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "d90002a5315db3a43c39dc52c2a91a99c9330e1f"
@@ -320,6 +333,7 @@
             "repo": "prismlauncher",
             "rev": "2edbdf5295bc3c12c3dd53b203ab91028fce2c54",
             "sha256": "sha256-+yGrSZztf2sZ9frPT3ydIJDavo4eXs03cQWfdTAmn3w=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "2edbdf5295bc3c12c3dd53b203ab91028fce2c54"
@@ -340,6 +354,7 @@
             "repo": "rofi-bluetooth",
             "rev": "9d91c048ff129819f4c6e9e48a17bd54343bbffb",
             "sha256": "sha256-1Xe3QFThIvJDCUznDP5ZBzwZEMuqmxpDIV+BcVvQDG8=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "9d91c048ff129819f4c6e9e48a17bd54343bbffb"
@@ -360,6 +375,7 @@
             "repo": "rofi",
             "rev": "b636a00fd40a7899a8206195464ae8b7f0450a6d",
             "sha256": "sha256-zA8Zum19pDTgn0KdQ0gD2kqCOXK4OCHBidFpGwrJOqg=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "b636a00fd40a7899a8206195464ae8b7f0450a6d"
@@ -380,6 +396,7 @@
             "repo": "starship",
             "rev": "e99ba6b210c0739af2a18094024ca0bdf4bb3225",
             "sha256": "sha256-1w0TJdQP5lb9jCrCmhPlSexf0PkAlcz8GBDEsRjPRns=",
+            "sparseCheckout": [],
             "type": "github"
         },
         "version": "e99ba6b210c0739af2a18094024ca0bdf4bb3225"

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,15 +3,15 @@
 {
   arr_scripts = {
     pname = "arr_scripts";
-    version = "5738fdda3af666712fcf421f20110447c1ecc7ba";
+    version = "e3e415569d829431db783e91669c7dd5eb325294";
     src = fetchFromGitHub {
       owner = "RandomNinjaAtk";
       repo = "arr-scripts";
-      rev = "5738fdda3af666712fcf421f20110447c1ecc7ba";
+      rev = "e3e415569d829431db783e91669c7dd5eb325294";
       fetchSubmodules = false;
-      sha256 = "sha256-SulpO5MR8hPnZLQwUDKnlC1csso96OPkkvegYeCVw3Q=";
+      sha256 = "sha256-1fX0Z2ZrLLNlVX4bzk5OU3FhwAG/YhLQBRE7Bb0Tfz4=";
     };
-    date = "2025-01-16";
+    date = "2025-02-06";
   };
   bottom_catppuccin = {
     pname = "bottom_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -146,32 +146,16 @@
         "type": "github"
       }
     },
-    "flake-compat_5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1736143030,
-        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
@@ -330,11 +314,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738378034,
-        "narHash": "sha256-mldSa2NhDlnjqeSSFTNnkXIDrCLltpJfhrHUMBBKEiY=",
+        "lastModified": 1739002622,
+        "narHash": "sha256-PtJV5OYQF7XO6XkDYypsYJS3+OsgYaYSmkO3I/A7lZo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "801ddd8693481866c2cfb1efd44ddbae778ea572",
+        "rev": "947eef9e99c42346cf0aac2bebe1cd94924c173b",
         "type": "github"
       },
       "original": {
@@ -411,11 +395,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1737861961,
-        "narHash": "sha256-LIRtMvAwLGb8pBoamzgEF67oKlNPz4LuXiRPVZf+TpE=",
+        "lastModified": 1738466368,
+        "narHash": "sha256-PZhUjtvQZOH3PO0EYdTpQvcqkgkq1NkP2A6w9SPHYsk=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523",
+        "rev": "46a8f5fc9552b776bfc5c5c96ea3bede33f68f52",
         "type": "github"
       },
       "original": {
@@ -431,11 +415,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1738374609,
-        "narHash": "sha256-IyHDXC0zXFTtrheJHdr1M1lS1GkDBPo09/mWDt+UfUQ=",
+        "lastModified": 1738979105,
+        "narHash": "sha256-7eT0+VL9l112QlhHQ3K7vMFpRktH6mRzkpfXeLQJ/rE=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "e26741603fb047295c7015c93746b75601c8c490",
+        "rev": "6457c8c71e998d76799e0a246dd6a2ca13ffe51d",
         "type": "github"
       },
       "original": {
@@ -451,11 +435,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1738343111,
-        "narHash": "sha256-y9st4Y0p5ry+6QdlIGeqxAA6rbEIOO1uXdAc5jxV2Bc=",
+        "lastModified": 1738972302,
+        "narHash": "sha256-Soakx+cbJEdbc2yPNm5zDbWJQWYQEZ57RY0pU6hO6Xo=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "51b9cce097da369550f45ac07879274dc8be81e4",
+        "rev": "8b7f3b4a85903f8998c5993cf37b413dc0ff98c1",
         "type": "github"
       },
       "original": {
@@ -466,11 +450,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737746512,
-        "narHash": "sha256-nU6AezEX4EuahTO1YopzueAXfjFfmCHylYEFCagduHU=",
+        "lastModified": 1738410390,
+        "narHash": "sha256-xvTo0Aw0+veek7hvEVLzErmJyQkEcRk6PSR4zsRQFEc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "825479c345a7f806485b7f00dbe3abb50641b083",
+        "rev": "3a228057f5b619feb3186e986dbe76278d707b6e",
         "type": "github"
       },
       "original": {
@@ -482,14 +466,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1735774519,
-        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
+        "lastModified": 1738452942,
+        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       }
     },
     "nixpkgs-stable": {
@@ -510,11 +494,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1738163270,
-        "narHash": "sha256-B/7Y1v4y+msFFBW1JAdFjNvVthvNdJKiN6EGRPnqfno=",
+        "lastModified": 1738702386,
+        "narHash": "sha256-nJj8f78AYAxl/zqLiFGXn5Im1qjFKU8yBPKoWEeZN5M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "59e618d90c065f55ae48446f307e8c09565d5ab0",
+        "rev": "030ba1976b7c0e1a67d9716b17308ccdab5b381e",
         "type": "github"
       },
       "original": {
@@ -526,11 +510,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1738277201,
-        "narHash": "sha256-6L+WXKCw5mqnUIExvqkD99pJQ41xgyCk6z/H9snClwk=",
+        "lastModified": 1738843498,
+        "narHash": "sha256-7x+Q4xgFj9UxZZO9aUDCR8h4vyYut4zPUvfj3i+jBHE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "666e1b3f09c267afd66addebe80fb05a5ef2b554",
+        "rev": "f5a32fa27df91dfc4b762671a0e0a859a8a0058f",
         "type": "github"
       },
       "original": {
@@ -558,11 +542,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1738142207,
-        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "lastModified": 1738680400,
+        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
         "type": "github"
       },
       "original": {
@@ -574,11 +558,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1738142207,
-        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "lastModified": 1738961098,
+        "narHash": "sha256-yWNBf6VDW38tl179FEuJ0qukthVfB02kv+mRsfUsWC0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "rev": "a3eaf5e8eca7cab680b964138fb79073704aca75",
         "type": "github"
       },
       "original": {
@@ -590,11 +574,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1738142207,
-        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "lastModified": 1738961098,
+        "narHash": "sha256-yWNBf6VDW38tl179FEuJ0qukthVfB02kv+mRsfUsWC0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "rev": "a3eaf5e8eca7cab680b964138fb79073704aca75",
         "type": "github"
       },
       "original": {
@@ -611,11 +595,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1738362438,
-        "narHash": "sha256-EO2dVkMVLThWqv4hobEZEZGWBEuH2Z9SYqQDrbLSclU=",
+        "lastModified": 1739028553,
+        "narHash": "sha256-V9cQY66nkfCWFph7ycX3rZUe1ZMRGLn48MF8V6tRVmQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "95ddad0ff0e67c90314c6ca46324dce5f9a910d2",
+        "rev": "4b1457faf16aab531472ff85eabdf630c247531e",
         "type": "github"
       },
       "original": {
@@ -694,18 +678,17 @@
     },
     "spicetify-nix": {
       "inputs": {
-        "flake-compat": "flake-compat_5",
         "nixpkgs": [
           "nixpkgs"
         ],
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1738380602,
-        "narHash": "sha256-521irgFQstFJZNAXISC4iBNlB/Gnm8qzDrcz1Phm3Nw=",
+        "lastModified": 1738871202,
+        "narHash": "sha256-L6I6Qpqcqz15mc2Une9YUC5bI9Ih815aTKY08seEFMA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "862ecb0c7dd2f77e145a81dfc10eb386449975fb",
+        "rev": "68de149c022e04d85d4b79db265fd3a01890127d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 06

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/b905f6fc23a9051a6e1b741e1438dbfc0634c6de' (2025-01-06)
  → 'github:hercules-ci/flake-parts/32ea77a06711b758da0ad9bd6a844c5740a87abd' (2025-02-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz?narHash=sha256-CewEm1o2eVAnoqb6Ml%2BQi9Gg/EfNAxbRx1lANGVyoLI%3D' (2025-01-01)
  → 'https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz?narHash=sha256-vJzFZGaCpnmo7I6i416HaBLpC%2BhvcURh/BQwROcGIp8%3D' (2025-02-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/801ddd8693481866c2cfb1efd44ddbae778ea572' (2025-02-01)
  → 'github:nix-community/home-manager/947eef9e99c42346cf0aac2bebe1cd94924c173b' (2025-02-08)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523' (2025-01-26)
  → 'github:nix-community/nix-index-database/46a8f5fc9552b776bfc5c5c96ea3bede33f68f52' (2025-02-02)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/825479c345a7f806485b7f00dbe3abb50641b083' (2025-01-24)
  → 'github:NixOS/nixpkgs/3a228057f5b619feb3186e986dbe76278d707b6e' (2025-02-01)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/e26741603fb047295c7015c93746b75601c8c490' (2025-02-01)
  → 'github:nix-community/nix-vscode-extensions/6457c8c71e998d76799e0a246dd6a2ca13ffe51d' (2025-02-08)
• Updated input 'nixos-cosmic':
    'github:lilyinstarlight/nixos-cosmic/51b9cce097da369550f45ac07879274dc8be81e4' (2025-01-31)
  → 'github:lilyinstarlight/nixos-cosmic/8b7f3b4a85903f8998c5993cf37b413dc0ff98c1' (2025-02-07)
• Updated input 'nixos-cosmic/nixpkgs':
    'github:NixOS/nixpkgs/9d3ae807ebd2981d593cddd0080856873139aa40' (2025-01-29)
  → 'github:NixOS/nixpkgs/799ba5bffed04ced7067a91798353d360788b30d' (2025-02-04)
• Updated input 'nixos-cosmic/nixpkgs-stable':
    'github:NixOS/nixpkgs/59e618d90c065f55ae48446f307e8c09565d5ab0' (2025-01-29)
  → 'github:NixOS/nixpkgs/030ba1976b7c0e1a67d9716b17308ccdab5b381e' (2025-02-04)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/9d3ae807ebd2981d593cddd0080856873139aa40' (2025-01-29)
  → 'github:NixOS/nixpkgs/a3eaf5e8eca7cab680b964138fb79073704aca75' (2025-02-07)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/666e1b3f09c267afd66addebe80fb05a5ef2b554' (2025-01-30)
  → 'github:NixOS/nixpkgs/f5a32fa27df91dfc4b762671a0e0a859a8a0058f' (2025-02-06)
• Updated input 'nur':
    'github:nix-community/NUR/95ddad0ff0e67c90314c6ca46324dce5f9a910d2' (2025-01-31)
  → 'github:nix-community/NUR/4b1457faf16aab531472ff85eabdf630c247531e' (2025-02-08)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/9d3ae807ebd2981d593cddd0080856873139aa40' (2025-01-29)
  → 'github:nixos/nixpkgs/a3eaf5e8eca7cab680b964138fb79073704aca75' (2025-02-07)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/862ecb0c7dd2f77e145a81dfc10eb386449975fb' (2025-02-01)
  → 'github:Gerg-L/spicetify-nix/68de149c022e04d85d4b79db265fd3a01890127d' (2025-02-06)
```

Sources Changelog:
```
arr_scripts: 5738fdda3af666712fcf421f20110447c1ecc7ba → e3e415569d829431db783e91669c7dd5eb325294
```
