### PR TITLE
chore: update flake.lock & sources (2025-02-15)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "arr_scripts": {
         "cargoLocks": null,
-        "date": "2025-02-06",
+        "date": "2025-02-10",
         "extract": null,
         "name": "arr_scripts",
         "passthru": null,
@@ -13,12 +13,12 @@
             "name": null,
             "owner": "RandomNinjaAtk",
             "repo": "arr-scripts",
-            "rev": "e3e415569d829431db783e91669c7dd5eb325294",
-            "sha256": "sha256-1fX0Z2ZrLLNlVX4bzk5OU3FhwAG/YhLQBRE7Bb0Tfz4=",
+            "rev": "f6a7ce7be53e40d032220bc3203b0d811e90d341",
+            "sha256": "sha256-jFpk9/X/Og/FTjONkgqUYRmPSucF7OXZofz5qQS85GA=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "e3e415569d829431db783e91669c7dd5eb325294"
+        "version": "f6a7ce7be53e40d032220bc3203b0d811e90d341"
     },
     "bottom_catppuccin": {
         "cargoLocks": null,
@@ -154,12 +154,12 @@
             "name": null,
             "owner": "rafaelmardojai",
             "repo": "firefox-gnome-theme",
-            "rev": "v134",
-            "sha256": "sha256-S79Hqn2EtSxU4kp99t8tRschSifWD4p/51++0xNWUxw=",
+            "rev": "v135",
+            "sha256": "sha256-OtF9hFsFXLpCpz5Oy+I7yAE6GgenpFEzUXTc9AtoZQk=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "v134"
+        "version": "v135"
     },
     "foot_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,15 +3,15 @@
 {
   arr_scripts = {
     pname = "arr_scripts";
-    version = "e3e415569d829431db783e91669c7dd5eb325294";
+    version = "f6a7ce7be53e40d032220bc3203b0d811e90d341";
     src = fetchFromGitHub {
       owner = "RandomNinjaAtk";
       repo = "arr-scripts";
-      rev = "e3e415569d829431db783e91669c7dd5eb325294";
+      rev = "f6a7ce7be53e40d032220bc3203b0d811e90d341";
       fetchSubmodules = false;
-      sha256 = "sha256-1fX0Z2ZrLLNlVX4bzk5OU3FhwAG/YhLQBRE7Bb0Tfz4=";
+      sha256 = "sha256-jFpk9/X/Og/FTjONkgqUYRmPSucF7OXZofz5qQS85GA=";
     };
-    date = "2025-02-06";
+    date = "2025-02-10";
   };
   bottom_catppuccin = {
     pname = "bottom_catppuccin";
@@ -83,13 +83,13 @@
   };
   firefox-gnome-theme = {
     pname = "firefox-gnome-theme";
-    version = "v134";
+    version = "v135";
     src = fetchFromGitHub {
       owner = "rafaelmardojai";
       repo = "firefox-gnome-theme";
-      rev = "v134";
+      rev = "v135";
       fetchSubmodules = false;
-      sha256 = "sha256-S79Hqn2EtSxU4kp99t8tRschSifWD4p/51++0xNWUxw=";
+      sha256 = "sha256-OtF9hFsFXLpCpz5Oy+I7yAE6GgenpFEzUXTc9AtoZQk=";
     };
   };
   foot_catppuccin = {

--- a/flake.lock
+++ b/flake.lock
@@ -314,11 +314,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739051380,
-        "narHash": "sha256-p1QSLO8DJnANY+ppK7fjD8GqfCrEIDjso1CSRHsXL7Y=",
+        "lastModified": 1739571712,
+        "narHash": "sha256-0UdSDV/TBY+GuxXLbrLq3l2Fq02ciyKCIMy4qmnfJXQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5af1b9a0f193ab6138b89a8e0af8763c21bbf491",
+        "rev": "6d3163aea47fdb1fe19744e91306a2ea4f602292",
         "type": "github"
       },
       "original": {
@@ -415,11 +415,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1739065863,
-        "narHash": "sha256-3UJA8edR9xRa8hD0rjKXvUsmBqJIufz3u/QbKSPEGzU=",
+        "lastModified": 1739584108,
+        "narHash": "sha256-vnZZZNPDYofQOuSQODd0uz3ToZnZIYV5snQH37tCEOA=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "1c920119bc25bfc9fbe9879aecc6d9351b13ff9f",
+        "rev": "80eb37310c3d73b93d3b2e1005a2b742192f514e",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1739069964,
-        "narHash": "sha256-riauJMShjx/R2LrWUt7X5Gh7d0veVbgI5w5g0/zwQ6E=",
+        "lastModified": 1739587053,
+        "narHash": "sha256-5t51C/uCWxFCrLH9SqrTtt8dkrrHzC39RoFbYqkSGjQ=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "28fb2017077f66b050f031f8442475d1b51c908e",
+        "rev": "c5393c24280ca200ba6f4388c44253b33a7e8974",
         "type": "github"
       },
       "original": {
@@ -494,11 +494,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1738702386,
-        "narHash": "sha256-nJj8f78AYAxl/zqLiFGXn5Im1qjFKU8yBPKoWEeZN5M=",
+        "lastModified": 1739357830,
+        "narHash": "sha256-9xim3nJJUFbVbJCz48UP4fGRStVW5nv4VdbimbKxJ3I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "030ba1976b7c0e1a67d9716b17308ccdab5b381e",
+        "rev": "0ff09db9d034a04acd4e8908820ba0b410d7a33a",
         "type": "github"
       },
       "original": {
@@ -510,11 +510,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1738843498,
-        "narHash": "sha256-7x+Q4xgFj9UxZZO9aUDCR8h4vyYut4zPUvfj3i+jBHE=",
+        "lastModified": 1739484910,
+        "narHash": "sha256-wjWLzdM7PIq4ZAe7k3vyjtgVJn6b0UeodtRFlM/6W5U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5a32fa27df91dfc4b762671a0e0a859a8a0058f",
+        "rev": "0b73e36b1962620a8ac551a37229dd8662dac5c8",
         "type": "github"
       },
       "original": {
@@ -542,11 +542,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1738680400,
-        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
+        "lastModified": 1739446958,
+        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
+        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1739020877,
-        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
+        "lastModified": 1739446958,
+        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
+        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
         "type": "github"
       },
       "original": {
@@ -574,11 +574,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1739020877,
-        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
+        "lastModified": 1739446958,
+        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
+        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
         "type": "github"
       },
       "original": {
@@ -595,11 +595,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1739079164,
-        "narHash": "sha256-eYD8vVDNR10jL5JWpVdtAMW0ZXOWRXCxPhpc+Qsulaw=",
+        "lastModified": 1739634597,
+        "narHash": "sha256-Y7ygVQP/boTMSacck19bQU/gyCCzIsY12mT+ZGnt9Qo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a0ff289ab5a4ac2e6451ca3448be9e01633f37e",
+        "rev": "3c6b2c533b5492228320cd101a87a26795c628ef",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1739074574,
-        "narHash": "sha256-dLfT4/nIU3RzMHk7I5UigRehSWzq7wGkZxwuQdflO6s=",
+        "lastModified": 1739223162,
+        "narHash": "sha256-YrbYTM0CkZQG38Ysr2gF4BYdsQDNQtQ4YdQTDgw/zWM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "366191fe8e9375d280e9a6b0ed9823468b49f6e7",
+        "rev": "dea717737d04a2a3e877c082bfd2c7f91c1a33ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 07

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/5af1b9a0f193ab6138b89a8e0af8763c21bbf491' (2025-02-08)
  → 'github:nix-community/home-manager/6d3163aea47fdb1fe19744e91306a2ea4f602292' (2025-02-14)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/1c920119bc25bfc9fbe9879aecc6d9351b13ff9f' (2025-02-09)
  → 'github:nix-community/nix-vscode-extensions/80eb37310c3d73b93d3b2e1005a2b742192f514e' (2025-02-15)
• Updated input 'nixos-cosmic':
    'github:lilyinstarlight/nixos-cosmic/28fb2017077f66b050f031f8442475d1b51c908e' (2025-02-09)
  → 'github:lilyinstarlight/nixos-cosmic/c5393c24280ca200ba6f4388c44253b33a7e8974' (2025-02-15)
• Updated input 'nixos-cosmic/nixpkgs':
    'github:NixOS/nixpkgs/799ba5bffed04ced7067a91798353d360788b30d' (2025-02-04)
  → 'github:NixOS/nixpkgs/2ff53fe64443980e139eaa286017f53f88336dd0' (2025-02-13)
• Updated input 'nixos-cosmic/nixpkgs-stable':
    'github:NixOS/nixpkgs/030ba1976b7c0e1a67d9716b17308ccdab5b381e' (2025-02-04)
  → 'github:NixOS/nixpkgs/0ff09db9d034a04acd4e8908820ba0b410d7a33a' (2025-02-12)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a79cfe0ebd24952b580b1cf08cd906354996d547' (2025-02-08)
  → 'github:NixOS/nixpkgs/2ff53fe64443980e139eaa286017f53f88336dd0' (2025-02-13)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/f5a32fa27df91dfc4b762671a0e0a859a8a0058f' (2025-02-06)
  → 'github:NixOS/nixpkgs/0b73e36b1962620a8ac551a37229dd8662dac5c8' (2025-02-13)
• Updated input 'nur':
    'github:nix-community/NUR/8a0ff289ab5a4ac2e6451ca3448be9e01633f37e' (2025-02-09)
  → 'github:nix-community/NUR/3c6b2c533b5492228320cd101a87a26795c628ef' (2025-02-15)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/a79cfe0ebd24952b580b1cf08cd906354996d547' (2025-02-08)
  → 'github:nixos/nixpkgs/2ff53fe64443980e139eaa286017f53f88336dd0' (2025-02-13)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/366191fe8e9375d280e9a6b0ed9823468b49f6e7' (2025-02-09)
  → 'github:Gerg-L/spicetify-nix/dea717737d04a2a3e877c082bfd2c7f91c1a33ff' (2025-02-10)
```

Sources Changelog:
```
arr_scripts: e3e415569d829431db783e91669c7dd5eb325294 → f6a7ce7be53e40d032220bc3203b0d811e90d341
firefox-gnome-theme: v134 → v135
```
