### PR TITLE
chore: update flake.lock & sources (2025-02-22)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "arr_scripts": {
         "cargoLocks": null,
-        "date": "2025-02-06",
+        "date": "2025-02-19",
         "extract": null,
         "name": "arr_scripts",
         "passthru": null,
@@ -13,12 +13,12 @@
             "name": null,
             "owner": "RandomNinjaAtk",
             "repo": "arr-scripts",
-            "rev": "e3e415569d829431db783e91669c7dd5eb325294",
-            "sha256": "sha256-1fX0Z2ZrLLNlVX4bzk5OU3FhwAG/YhLQBRE7Bb0Tfz4=",
+            "rev": "63373875a49fe147fe1fbf15d1c995aed1dcf08f",
+            "sha256": "sha256-SqVLMNOycPit8imsa8ryhn0RJo5OR9rYf8VshioabfI=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "e3e415569d829431db783e91669c7dd5eb325294"
+        "version": "63373875a49fe147fe1fbf15d1c995aed1dcf08f"
     },
     "bottom_catppuccin": {
         "cargoLocks": null,
@@ -106,7 +106,7 @@
     },
     "eza_themes": {
         "cargoLocks": null,
-        "date": "2025-01-24",
+        "date": "2025-02-19",
         "extract": null,
         "name": "eza_themes",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "eza-community",
             "repo": "eza-themes",
-            "rev": "a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71",
-            "sha256": "sha256-d+bbjgI1JrOGenqZ2aIRK8itkTUV2L4L3vtEN9tEgf8=",
+            "rev": "57149851f07b3ee6ca94f5fe3d9d552f73f8b8b4",
+            "sha256": "sha256-vu6QLz0RvPavpD2VED25D2PJlHgQ8Yis+DnL+BPlvHw=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71"
+        "version": "57149851f07b3ee6ca94f5fe3d9d552f73f8b8b4"
     },
     "filen": {
         "cargoLocks": null,
@@ -154,12 +154,12 @@
             "name": null,
             "owner": "rafaelmardojai",
             "repo": "firefox-gnome-theme",
-            "rev": "v134",
-            "sha256": "sha256-S79Hqn2EtSxU4kp99t8tRschSifWD4p/51++0xNWUxw=",
+            "rev": "v135",
+            "sha256": "sha256-OtF9hFsFXLpCpz5Oy+I7yAE6GgenpFEzUXTc9AtoZQk=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "v134"
+        "version": "v135"
     },
     "foot_catppuccin": {
         "cargoLocks": null,
@@ -361,7 +361,7 @@
     },
     "rofi_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-06-20",
+        "date": "2025-02-20",
         "extract": null,
         "name": "rofi_catppuccin",
         "passthru": null,
@@ -373,12 +373,12 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "rofi",
-            "rev": "b636a00fd40a7899a8206195464ae8b7f0450a6d",
-            "sha256": "sha256-zA8Zum19pDTgn0KdQ0gD2kqCOXK4OCHBidFpGwrJOqg=",
+            "rev": "c24a212a6b07c2d45f32d01d7f10b4d88ddc9f45",
+            "sha256": "sha256-WGYEA4Q7UvSaRDjP/DiEtfXjvmWbewtdyJWRpjhbZgg=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "b636a00fd40a7899a8206195464ae8b7f0450a6d"
+        "version": "c24a212a6b07c2d45f32d01d7f10b4d88ddc9f45"
     },
     "starship_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,15 +3,15 @@
 {
   arr_scripts = {
     pname = "arr_scripts";
-    version = "e3e415569d829431db783e91669c7dd5eb325294";
+    version = "63373875a49fe147fe1fbf15d1c995aed1dcf08f";
     src = fetchFromGitHub {
       owner = "RandomNinjaAtk";
       repo = "arr-scripts";
-      rev = "e3e415569d829431db783e91669c7dd5eb325294";
+      rev = "63373875a49fe147fe1fbf15d1c995aed1dcf08f";
       fetchSubmodules = false;
-      sha256 = "sha256-1fX0Z2ZrLLNlVX4bzk5OU3FhwAG/YhLQBRE7Bb0Tfz4=";
+      sha256 = "sha256-SqVLMNOycPit8imsa8ryhn0RJo5OR9rYf8VshioabfI=";
     };
-    date = "2025-02-06";
+    date = "2025-02-19";
   };
   bottom_catppuccin = {
     pname = "bottom_catppuccin";
@@ -63,15 +63,15 @@
   };
   eza_themes = {
     pname = "eza_themes";
-    version = "a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71";
+    version = "57149851f07b3ee6ca94f5fe3d9d552f73f8b8b4";
     src = fetchFromGitHub {
       owner = "eza-community";
       repo = "eza-themes";
-      rev = "a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71";
+      rev = "57149851f07b3ee6ca94f5fe3d9d552f73f8b8b4";
       fetchSubmodules = false;
-      sha256 = "sha256-d+bbjgI1JrOGenqZ2aIRK8itkTUV2L4L3vtEN9tEgf8=";
+      sha256 = "sha256-vu6QLz0RvPavpD2VED25D2PJlHgQ8Yis+DnL+BPlvHw=";
     };
-    date = "2025-01-24";
+    date = "2025-02-19";
   };
   filen = {
     pname = "filen";
@@ -83,13 +83,13 @@
   };
   firefox-gnome-theme = {
     pname = "firefox-gnome-theme";
-    version = "v134";
+    version = "v135";
     src = fetchFromGitHub {
       owner = "rafaelmardojai";
       repo = "firefox-gnome-theme";
-      rev = "v134";
+      rev = "v135";
       fetchSubmodules = false;
-      sha256 = "sha256-S79Hqn2EtSxU4kp99t8tRschSifWD4p/51++0xNWUxw=";
+      sha256 = "sha256-OtF9hFsFXLpCpz5Oy+I7yAE6GgenpFEzUXTc9AtoZQk=";
     };
   };
   foot_catppuccin = {
@@ -206,15 +206,15 @@
   };
   rofi_catppuccin = {
     pname = "rofi_catppuccin";
-    version = "b636a00fd40a7899a8206195464ae8b7f0450a6d";
+    version = "c24a212a6b07c2d45f32d01d7f10b4d88ddc9f45";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "rofi";
-      rev = "b636a00fd40a7899a8206195464ae8b7f0450a6d";
+      rev = "c24a212a6b07c2d45f32d01d7f10b4d88ddc9f45";
       fetchSubmodules = false;
-      sha256 = "sha256-zA8Zum19pDTgn0KdQ0gD2kqCOXK4OCHBidFpGwrJOqg=";
+      sha256 = "sha256-WGYEA4Q7UvSaRDjP/DiEtfXjvmWbewtdyJWRpjhbZgg=";
     };
-    date = "2024-06-20";
+    date = "2025-02-20";
   };
   starship_catppuccin = {
     pname = "starship_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -314,11 +314,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739676861,
-        "narHash": "sha256-X86ptHMNVuu1Z9leL0YV2E/oxD2IgPYrYANPcvFYpNo=",
+        "lastModified": 1740241381,
+        "narHash": "sha256-vDRP/kEEN+3EHOTP/Xl3Vs1xabmmTCCO9x0ImVTdc8k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "eb44c1601ed99896525e983bc9b15eb8b4d5879e",
+        "rev": "4949081d1ee37ebb1ca9fbef289955d85aace405",
         "type": "github"
       },
       "original": {
@@ -415,11 +415,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1739670916,
-        "narHash": "sha256-Tdzu06QlI8DsYdXNe96c9eu0clj9Wkd1cKo6em/0xPU=",
+        "lastModified": 1740188781,
+        "narHash": "sha256-3FDg6k9kQXq5M6ZHc2f9KsPydvWBtqacU9lWA7nIFYI=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "370af219cf4ad7660e3ad4577849fb0478edb33c",
+        "rev": "ba52a14c907e0cece9734e0ff59c3c742b6b1075",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1739669831,
-        "narHash": "sha256-3hqUQmzo/RyH51W02RnEBWBdWzma+gUd6MuQ9oAJd/c=",
+        "lastModified": 1740192028,
+        "narHash": "sha256-aEaTAYI8TxLo8xXSJBUMMHwOEzsmyRspkoanZJbJTtQ=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "51f16d9cd5ab24afa8b940d0e5c83965c46ef430",
+        "rev": "f3accf6aa7235dc5b9530a8d6c2077603bb0c5de",
         "type": "github"
       },
       "original": {
@@ -494,11 +494,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1739484910,
-        "narHash": "sha256-wjWLzdM7PIq4ZAe7k3vyjtgVJn6b0UeodtRFlM/6W5U=",
+        "lastModified": 1739923778,
+        "narHash": "sha256-BqUY8tz0AQ4to2Z4+uaKczh81zsGZSYxjgvtw+fvIfM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0b73e36b1962620a8ac551a37229dd8662dac5c8",
+        "rev": "36864ed72f234b9540da4cf7a0c49e351d30d3f1",
         "type": "github"
       },
       "original": {
@@ -510,11 +510,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1739484910,
-        "narHash": "sha256-wjWLzdM7PIq4ZAe7k3vyjtgVJn6b0UeodtRFlM/6W5U=",
+        "lastModified": 1739923778,
+        "narHash": "sha256-BqUY8tz0AQ4to2Z4+uaKczh81zsGZSYxjgvtw+fvIfM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0b73e36b1962620a8ac551a37229dd8662dac5c8",
+        "rev": "36864ed72f234b9540da4cf7a0c49e351d30d3f1",
         "type": "github"
       },
       "original": {
@@ -542,11 +542,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1739446958,
-        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
+        "lastModified": 1739866667,
+        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
+        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1739446958,
-        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
+        "lastModified": 1739866667,
+        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
+        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
         "type": "github"
       },
       "original": {
@@ -574,11 +574,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1739446958,
-        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
+        "lastModified": 1739866667,
+        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
+        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
         "type": "github"
       },
       "original": {
@@ -595,11 +595,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1739695757,
-        "narHash": "sha256-lgyLxnY4Gml80+FEiUQxr7/eRfCD4uiif62wx0fBQ4I=",
+        "lastModified": 1740239278,
+        "narHash": "sha256-GlUE97PyIjetONiFU3Pyif/6AGLtg+mG0+W4GuA7XEI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e1f86baa19ac560266d5e726d512563c5ace1480",
+        "rev": "70ee01650bed9f1c9fc28897dc993e76f32566a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 08

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/eb44c1601ed99896525e983bc9b15eb8b4d5879e' (2025-02-16)
  → 'github:nix-community/home-manager/4949081d1ee37ebb1ca9fbef289955d85aace405' (2025-02-22)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/370af219cf4ad7660e3ad4577849fb0478edb33c' (2025-02-16)
  → 'github:nix-community/nix-vscode-extensions/ba52a14c907e0cece9734e0ff59c3c742b6b1075' (2025-02-22)
• Updated input 'nixos-cosmic':
    'github:lilyinstarlight/nixos-cosmic/51f16d9cd5ab24afa8b940d0e5c83965c46ef430' (2025-02-16)
  → 'github:lilyinstarlight/nixos-cosmic/f3accf6aa7235dc5b9530a8d6c2077603bb0c5de' (2025-02-22)
• Updated input 'nixos-cosmic/nixpkgs':
    'github:NixOS/nixpkgs/2ff53fe64443980e139eaa286017f53f88336dd0' (2025-02-13)
  → 'github:NixOS/nixpkgs/73cf49b8ad837ade2de76f87eb53fc85ed5d4680' (2025-02-18)
• Updated input 'nixos-cosmic/nixpkgs-stable':
    'github:NixOS/nixpkgs/0b73e36b1962620a8ac551a37229dd8662dac5c8' (2025-02-13)
  → 'github:NixOS/nixpkgs/36864ed72f234b9540da4cf7a0c49e351d30d3f1' (2025-02-19)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/2ff53fe64443980e139eaa286017f53f88336dd0' (2025-02-13)
  → 'github:NixOS/nixpkgs/73cf49b8ad837ade2de76f87eb53fc85ed5d4680' (2025-02-18)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/0b73e36b1962620a8ac551a37229dd8662dac5c8' (2025-02-13)
  → 'github:NixOS/nixpkgs/36864ed72f234b9540da4cf7a0c49e351d30d3f1' (2025-02-19)
• Updated input 'nur':
    'github:nix-community/NUR/e1f86baa19ac560266d5e726d512563c5ace1480' (2025-02-16)
  → 'github:nix-community/NUR/70ee01650bed9f1c9fc28897dc993e76f32566a5' (2025-02-22)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/2ff53fe64443980e139eaa286017f53f88336dd0' (2025-02-13)
  → 'github:nixos/nixpkgs/73cf49b8ad837ade2de76f87eb53fc85ed5d4680' (2025-02-18)
```

Sources Changelog:
```
rofi_catppuccin: b636a00fd40a7899a8206195464ae8b7f0450a6d → c24a212a6b07c2d45f32d01d7f10b4d88ddc9f45
arr_scripts: e3e415569d829431db783e91669c7dd5eb325294 → 63373875a49fe147fe1fbf15d1c995aed1dcf08f
firefox-gnome-theme: v134 → v135
eza_themes: a99a5f1bbb5fec2c0bfa945ec8e2aabcb6f24d71 → 57149851f07b3ee6ca94f5fe3d9d552f73f8b8b4
```
