### PR TITLE
chore: update flake.lock & sources (2025-03-01)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "arr_scripts": {
         "cargoLocks": null,
-        "date": "2025-02-19",
+        "date": "2025-02-27",
         "extract": null,
         "name": "arr_scripts",
         "passthru": null,
@@ -13,12 +13,12 @@
             "name": null,
             "owner": "RandomNinjaAtk",
             "repo": "arr-scripts",
-            "rev": "63373875a49fe147fe1fbf15d1c995aed1dcf08f",
-            "sha256": "sha256-SqVLMNOycPit8imsa8ryhn0RJo5OR9rYf8VshioabfI=",
+            "rev": "fd34c3169f29b723623d73f95709fe52cecafeb7",
+            "sha256": "sha256-4kud7jvzSZqHN/cajP2N2AFDGPjo/L/XpH0oeSNZDRM=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "63373875a49fe147fe1fbf15d1c995aed1dcf08f"
+        "version": "fd34c3169f29b723623d73f95709fe52cecafeb7"
     },
     "bottom_catppuccin": {
         "cargoLocks": null,
@@ -256,7 +256,7 @@
     },
     "joplin_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-06-21",
+        "date": "2025-02-27",
         "extract": null,
         "name": "joplin_catppuccin",
         "passthru": null,
@@ -268,12 +268,12 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "joplin",
-            "rev": "b0a886ce7ba71b48fdbf72ad27f3446400ebcdb9",
-            "sha256": "sha256-H19iaemj7XWsd3r7OBvQinrNKMiYGl53ArIp49gZExs=",
+            "rev": "93a1425f906f2e358d764930ab04d13c1c4458d6",
+            "sha256": "sha256-gZ4h9/b7FK/jNY0R7+PWgiD2ELqskCFHG2IkTIthkLI=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "b0a886ce7ba71b48fdbf72ad27f3446400ebcdb9"
+        "version": "93a1425f906f2e358d764930ab04d13c1c4458d6"
     },
     "nix-fast-build": {
         "cargoLocks": null,
@@ -298,7 +298,7 @@
     },
     "obs_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-09-14",
+        "date": "2025-02-23",
         "extract": null,
         "name": "obs_catppuccin",
         "passthru": null,
@@ -310,12 +310,12 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "obs",
-            "rev": "d90002a5315db3a43c39dc52c2a91a99c9330e1f",
-            "sha256": "sha256-rU4WTj+2E/+OblAeK0+nzJhisz2V2/KwHBiJVBRj+LQ=",
+            "rev": "f8a11f3e53d18c176bea9feb466712a117286a42",
+            "sha256": "sha256-92vB2Mmpj4ir5UWJBqb/EKNLJcZ6ixZakDrFAe2pu9w=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "d90002a5315db3a43c39dc52c2a91a99c9330e1f"
+        "version": "f8a11f3e53d18c176bea9feb466712a117286a42"
     },
     "prismlauncher_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,15 +3,15 @@
 {
   arr_scripts = {
     pname = "arr_scripts";
-    version = "63373875a49fe147fe1fbf15d1c995aed1dcf08f";
+    version = "fd34c3169f29b723623d73f95709fe52cecafeb7";
     src = fetchFromGitHub {
       owner = "RandomNinjaAtk";
       repo = "arr-scripts";
-      rev = "63373875a49fe147fe1fbf15d1c995aed1dcf08f";
+      rev = "fd34c3169f29b723623d73f95709fe52cecafeb7";
       fetchSubmodules = false;
-      sha256 = "sha256-SqVLMNOycPit8imsa8ryhn0RJo5OR9rYf8VshioabfI=";
+      sha256 = "sha256-4kud7jvzSZqHN/cajP2N2AFDGPjo/L/XpH0oeSNZDRM=";
     };
-    date = "2025-02-19";
+    date = "2025-02-27";
   };
   bottom_catppuccin = {
     pname = "bottom_catppuccin";
@@ -146,15 +146,15 @@
   };
   joplin_catppuccin = {
     pname = "joplin_catppuccin";
-    version = "b0a886ce7ba71b48fdbf72ad27f3446400ebcdb9";
+    version = "93a1425f906f2e358d764930ab04d13c1c4458d6";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "joplin";
-      rev = "b0a886ce7ba71b48fdbf72ad27f3446400ebcdb9";
+      rev = "93a1425f906f2e358d764930ab04d13c1c4458d6";
       fetchSubmodules = false;
-      sha256 = "sha256-H19iaemj7XWsd3r7OBvQinrNKMiYGl53ArIp49gZExs=";
+      sha256 = "sha256-gZ4h9/b7FK/jNY0R7+PWgiD2ELqskCFHG2IkTIthkLI=";
     };
-    date = "2024-06-21";
+    date = "2025-02-27";
   };
   nix-fast-build = {
     pname = "nix-fast-build";
@@ -170,15 +170,15 @@
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";
-    version = "d90002a5315db3a43c39dc52c2a91a99c9330e1f";
+    version = "f8a11f3e53d18c176bea9feb466712a117286a42";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "obs";
-      rev = "d90002a5315db3a43c39dc52c2a91a99c9330e1f";
+      rev = "f8a11f3e53d18c176bea9feb466712a117286a42";
       fetchSubmodules = false;
-      sha256 = "sha256-rU4WTj+2E/+OblAeK0+nzJhisz2V2/KwHBiJVBRj+LQ=";
+      sha256 = "sha256-92vB2Mmpj4ir5UWJBqb/EKNLJcZ6ixZakDrFAe2pu9w=";
     };
-    date = "2024-09-14";
+    date = "2025-02-23";
   };
   prismlauncher_catppuccin = {
     pname = "prismlauncher_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -251,11 +251,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737465171,
-        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
+        "lastModified": 1740844297,
+        "narHash": "sha256-t7nPEm+7YXnW94gSlXkvfcxZ4aLn2a0xq7UpTmy7Jlk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
+        "rev": "a548245dc9fc0297f802746a48d6ce4a46f2d258",
         "type": "github"
       },
       "original": {
@@ -314,11 +314,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740243507,
-        "narHash": "sha256-ahy6qscPiZlpOgGVKT33h3c91Jxsb/eNfI21p8QJSqg=",
+        "lastModified": 1740845322,
+        "narHash": "sha256-AXEgFj3C0YJhu9k1OhbRhiA6FnDr81dQZ65U3DhaWpw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e860bd49eaa577089de22d370f6126ee4f6e7914",
+        "rev": "fcac3d6d88302a5e64f6cb8014ac785e08874c8d",
         "type": "github"
       },
       "original": {
@@ -395,11 +395,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1739676768,
-        "narHash": "sha256-U1HQ7nzhJyVVXUgjU028UCkbLQLEIkg42+G7iIiBmlU=",
+        "lastModified": 1740281615,
+        "narHash": "sha256-dZWcbAQ1sF8oVv+zjSKkPVY0ebwENQEkz5vc6muXbKY=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "ae15068e79e22b76c344f0d7f8aed1bb1c5b0b63",
+        "rev": "465792533d03e6bb9dc849d58ab9d5e31fac9023",
         "type": "github"
       },
       "original": {
@@ -415,11 +415,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1740188781,
-        "narHash": "sha256-3FDg6k9kQXq5M6ZHc2f9KsPydvWBtqacU9lWA7nIFYI=",
+        "lastModified": 1740827838,
+        "narHash": "sha256-xHWVg/CgaJqID4BUxqqJ47ESXRzWOxRNhJ9+jBXKuLc=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "ba52a14c907e0cece9734e0ff59c3c742b6b1075",
+        "rev": "02d071ae1fadb1a63c6122d307ca5eb7e6b4feb9",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1740192028,
-        "narHash": "sha256-aEaTAYI8TxLo8xXSJBUMMHwOEzsmyRspkoanZJbJTtQ=",
+        "lastModified": 1740828362,
+        "narHash": "sha256-ctbeVj9aSDNB24hokEN8RBy/JxddpLp+UB03SDaMeaI=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "f3accf6aa7235dc5b9530a8d6c2077603bb0c5de",
+        "rev": "04a3663de9d08d435de114111f1a091b84df0722",
         "type": "github"
       },
       "original": {
@@ -450,11 +450,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739446958,
-        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
+        "lastModified": 1739866667,
+        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
+        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
         "type": "github"
       },
       "original": {
@@ -494,11 +494,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1739923778,
-        "narHash": "sha256-BqUY8tz0AQ4to2Z4+uaKczh81zsGZSYxjgvtw+fvIfM=",
+        "lastModified": 1740743217,
+        "narHash": "sha256-brsCRzLqimpyhORma84c3W2xPbIidZlIc3JGIuQVSNI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "36864ed72f234b9540da4cf7a0c49e351d30d3f1",
+        "rev": "b27ba4eb322d9d2bf2dc9ada9fd59442f50c8d7c",
         "type": "github"
       },
       "original": {
@@ -510,11 +510,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1739923778,
-        "narHash": "sha256-BqUY8tz0AQ4to2Z4+uaKczh81zsGZSYxjgvtw+fvIfM=",
+        "lastModified": 1740743217,
+        "narHash": "sha256-brsCRzLqimpyhORma84c3W2xPbIidZlIc3JGIuQVSNI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "36864ed72f234b9540da4cf7a0c49e351d30d3f1",
+        "rev": "b27ba4eb322d9d2bf2dc9ada9fd59442f50c8d7c",
         "type": "github"
       },
       "original": {
@@ -526,11 +526,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1713805509,
-        "narHash": "sha256-YgSEan4CcrjivCNO5ZNzhg7/8ViLkZ4CB/GrGBVSudo=",
+        "lastModified": 1740547748,
+        "narHash": "sha256-Ly2fBL1LscV+KyCqPRufUBuiw+zmWrlJzpWOWbahplg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e1dc66fe68972a76679644a5577828b6a7e8be4",
+        "rev": "3a05eebede89661660945da1f151959900903b6a",
         "type": "github"
       },
       "original": {
@@ -542,11 +542,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1739866667,
-        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
+        "lastModified": 1740695751,
+        "narHash": "sha256-D+R+kFxy1KsheiIzkkx/6L63wEHBYX21OIwlFV8JvDs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
+        "rev": "6313551cd05425cd5b3e63fe47dbc324eabb15e4",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1739866667,
-        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
+        "lastModified": 1740695751,
+        "narHash": "sha256-D+R+kFxy1KsheiIzkkx/6L63wEHBYX21OIwlFV8JvDs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
+        "rev": "6313551cd05425cd5b3e63fe47dbc324eabb15e4",
         "type": "github"
       },
       "original": {
@@ -574,11 +574,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1739866667,
-        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
+        "lastModified": 1740695751,
+        "narHash": "sha256-D+R+kFxy1KsheiIzkkx/6L63wEHBYX21OIwlFV8JvDs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
+        "rev": "6313551cd05425cd5b3e63fe47dbc324eabb15e4",
         "type": "github"
       },
       "original": {
@@ -595,11 +595,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1740242566,
-        "narHash": "sha256-c7mPFQdBfVuxdst0PJfcaMRLx6rQENfDLMQZSL5NlOY=",
+        "lastModified": 1740846162,
+        "narHash": "sha256-KZ3Nrl8CEOWIIWUStUz9cZhpa/AL2ggR8rbuGK2Yvr0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "98e0db390aa7bea4790458bbb1187fa497e2f0d5",
+        "rev": "e732503d07b547eb8790bb2893c91c1f162b770c",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1739679385,
-        "narHash": "sha256-Pu6gN/indwmI5OIKS5Q+Ffr7/yaOfDDWn5av4gshuNM=",
+        "lastModified": 1740284169,
+        "narHash": "sha256-Ne+3kEyOFD2sNfw3cnKk+Zi/tTk+WkmnsfE7PDLNEXU=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "8bac1688d527ec3b107353b8ea55b929af5193d4",
+        "rev": "fd31f20e2bd2bf3894d729590bf578c02c252239",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 09

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/9364dc02281ce2d37a1f55b6e51f7c0f65a75f17' (2025-01-21)
  → 'github:cachix/git-hooks.nix/a548245dc9fc0297f802746a48d6ce4a46f2d258' (2025-03-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e860bd49eaa577089de22d370f6126ee4f6e7914' (2025-02-22)
  → 'github:nix-community/home-manager/fcac3d6d88302a5e64f6cb8014ac785e08874c8d' (2025-03-01)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/ae15068e79e22b76c344f0d7f8aed1bb1c5b0b63' (2025-02-16)
  → 'github:nix-community/nix-index-database/465792533d03e6bb9dc849d58ab9d5e31fac9023' (2025-02-23)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/2ff53fe64443980e139eaa286017f53f88336dd0' (2025-02-13)
  → 'github:NixOS/nixpkgs/73cf49b8ad837ade2de76f87eb53fc85ed5d4680' (2025-02-18)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/ba52a14c907e0cece9734e0ff59c3c742b6b1075' (2025-02-22)
  → 'github:nix-community/nix-vscode-extensions/02d071ae1fadb1a63c6122d307ca5eb7e6b4feb9' (2025-03-01)
• Updated input 'nix-vscode-extensions/nixpkgs':
    'github:NixOS/nixpkgs/1e1dc66fe68972a76679644a5577828b6a7e8be4' (2024-04-22)
  → 'github:NixOS/nixpkgs/3a05eebede89661660945da1f151959900903b6a' (2025-02-26)
• Updated input 'nixos-cosmic':
    'github:lilyinstarlight/nixos-cosmic/f3accf6aa7235dc5b9530a8d6c2077603bb0c5de' (2025-02-22)
  → 'github:lilyinstarlight/nixos-cosmic/04a3663de9d08d435de114111f1a091b84df0722' (2025-03-01)
• Updated input 'nixos-cosmic/nixpkgs':
    'github:NixOS/nixpkgs/73cf49b8ad837ade2de76f87eb53fc85ed5d4680' (2025-02-18)
  → 'github:NixOS/nixpkgs/6313551cd05425cd5b3e63fe47dbc324eabb15e4' (2025-02-27)
• Updated input 'nixos-cosmic/nixpkgs-stable':
    'github:NixOS/nixpkgs/36864ed72f234b9540da4cf7a0c49e351d30d3f1' (2025-02-19)
  → 'github:NixOS/nixpkgs/b27ba4eb322d9d2bf2dc9ada9fd59442f50c8d7c' (2025-02-28)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/73cf49b8ad837ade2de76f87eb53fc85ed5d4680' (2025-02-18)
  → 'github:NixOS/nixpkgs/6313551cd05425cd5b3e63fe47dbc324eabb15e4' (2025-02-27)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/36864ed72f234b9540da4cf7a0c49e351d30d3f1' (2025-02-19)
  → 'github:NixOS/nixpkgs/b27ba4eb322d9d2bf2dc9ada9fd59442f50c8d7c' (2025-02-28)
• Updated input 'nur':
    'github:nix-community/NUR/98e0db390aa7bea4790458bbb1187fa497e2f0d5' (2025-02-22)
  → 'github:nix-community/NUR/e732503d07b547eb8790bb2893c91c1f162b770c' (2025-03-01)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/73cf49b8ad837ade2de76f87eb53fc85ed5d4680' (2025-02-18)
  → 'github:nixos/nixpkgs/6313551cd05425cd5b3e63fe47dbc324eabb15e4' (2025-02-27)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/8bac1688d527ec3b107353b8ea55b929af5193d4' (2025-02-16)
  → 'github:Gerg-L/spicetify-nix/fd31f20e2bd2bf3894d729590bf578c02c252239' (2025-02-23)
```

Sources Changelog:
```
arr_scripts: 63373875a49fe147fe1fbf15d1c995aed1dcf08f → fd34c3169f29b723623d73f95709fe52cecafeb7
obs_catppuccin: d90002a5315db3a43c39dc52c2a91a99c9330e1f → f8a11f3e53d18c176bea9feb466712a117286a42
joplin_catppuccin: b0a886ce7ba71b48fdbf72ad27f3446400ebcdb9 → 93a1425f906f2e358d764930ab04d13c1c4458d6
```
