### PR TITLE
chore: update flake.lock & sources (2025-03-29)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -142,7 +142,7 @@
     },
     "obs_catppuccin": {
         "cargoLocks": null,
-        "date": "2025-03-10",
+        "date": "2025-03-23",
         "extract": null,
         "name": "obs_catppuccin",
         "passthru": null,
@@ -154,12 +154,12 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "obs",
-            "rev": "a994c89a88578d003796b51df67e3623bd864449",
-            "sha256": "sha256-jeQrbdtIFSvDIrVIFrgV0emDHu1mH6SWt5BSUmK0et4=",
+            "rev": "58a80435caf1ff4f62b94592f508fba4c3776c97",
+            "sha256": "sha256-2CuaMd+9GHK18M971+pVltPC9h59LYDXEAEkEq+tRw8=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "a994c89a88578d003796b51df67e3623bd864449"
+        "version": "58a80435caf1ff4f62b94592f508fba4c3776c97"
     },
     "prismlauncher_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -87,15 +87,15 @@
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";
-    version = "a994c89a88578d003796b51df67e3623bd864449";
+    version = "58a80435caf1ff4f62b94592f508fba4c3776c97";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "obs";
-      rev = "a994c89a88578d003796b51df67e3623bd864449";
+      rev = "58a80435caf1ff4f62b94592f508fba4c3776c97";
       fetchSubmodules = false;
-      sha256 = "sha256-jeQrbdtIFSvDIrVIFrgV0emDHu1mH6SWt5BSUmK0et4=";
+      sha256 = "sha256-2CuaMd+9GHK18M971+pVltPC9h59LYDXEAEkEq+tRw8=";
     };
-    date = "2025-03-10";
+    date = "2025-03-23";
   };
   prismlauncher_catppuccin = {
     pname = "prismlauncher_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -564,11 +564,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742588233,
-        "narHash": "sha256-Fi5g8H5FXMSRqy+mU6gPG0v+C9pzjYbkkiePtz8+PpA=",
+        "lastModified": 1743259333,
+        "narHash": "sha256-2Fi3K++co4IGbeOLGXdRA6VEfbzQzMgcuBaPTyjfj0s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "296ddc64627f4a6a4eb447852d7346b9dd16197d",
+        "rev": "1f679ed2a2ebe3894bad9f89fb0bd9f141c28a68",
         "type": "github"
       },
       "original": {
@@ -604,11 +604,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742402033,
-        "narHash": "sha256-aaBdTUJIAo9LBPpjNX96AoAi0H+O/oW8o+7SCVBAzXI=",
+        "lastModified": 1743179396,
+        "narHash": "sha256-+qEQKKqPwhtVyQJceiA51v2L1/j3Hyr0v7nnjnABB70=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "3a5ad2a1db420f0238895f2cb1ff64acd0d2cc54",
+        "rev": "94a00a49dae15c87e4234c9962295aed2b0dc45e",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742174123,
-        "narHash": "sha256-pDNzMoR6m1ZSJToZQ6XDTLVSdzIzmFl1b8Pc3f7iV6Y=",
+        "lastModified": 1742701275,
+        "narHash": "sha256-AulwPVrS9859t+eJ61v24wH/nfBEIDSXYxlRo3fL/SA=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c",
+        "rev": "36dc43cb50d5d20f90a28d53abb33a32b0a2aae6",
         "type": "github"
       },
       "original": {
@@ -704,11 +704,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1742608212,
-        "narHash": "sha256-t0+4dSHdFoseTG8OiA3qfw0GglXeGINwxTayTQPIlHA=",
+        "lastModified": 1743213162,
+        "narHash": "sha256-9UU0x2fZORsX6PEpzkIAD/7+bwm+javJtZA/411ZmLg=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "4ea55231137b25c591f2952726e026ef40d077da",
+        "rev": "1b2a53e3478225bc35d14ae75ea9e7b749c16d5b",
         "type": "github"
       },
       "original": {
@@ -721,14 +721,15 @@
       "inputs": {
         "flake-compat": "flake-compat_3",
         "nixpkgs": "nixpkgs_4",
-        "nixpkgs-stable": "nixpkgs-stable_2"
+        "nixpkgs-stable": "nixpkgs-stable_2",
+        "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1742641703,
-        "narHash": "sha256-hoN8blvJco8OSZmPj8izwQaQUdydVi+5FO4/nWd1MNU=",
+        "lastModified": 1743246566,
+        "narHash": "sha256-arEFUDLjADYIZ7T6PZX1yLOnfMoZ1ByebtmPuvV98+s=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "216557e6cd229dbe7d73a497c227824a3c579cd7",
+        "rev": "c709db4b95e58f410978bb49c87cb74214d03e78",
         "type": "github"
       },
       "original": {
@@ -786,11 +787,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1742512142,
-        "narHash": "sha256-8XfURTDxOm6+33swQJu/hx6xw1Tznl8vJJN5HwVqckg=",
+        "lastModified": 1742937945,
+        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7105ae3957700a9646cc4b766f5815b23ed0c682",
+        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
         "type": "github"
       },
       "original": {
@@ -802,11 +803,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1742512142,
-        "narHash": "sha256-8XfURTDxOm6+33swQJu/hx6xw1Tznl8vJJN5HwVqckg=",
+        "lastModified": 1742937945,
+        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7105ae3957700a9646cc4b766f5815b23ed0c682",
+        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
         "type": "github"
       },
       "original": {
@@ -818,11 +819,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1741851582,
-        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
+        "lastModified": 1742422364,
+        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
+        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
         "type": "github"
       },
       "original": {
@@ -850,11 +851,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "lastModified": 1743095683,
+        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
         "type": "github"
       },
       "original": {
@@ -866,11 +867,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "lastModified": 1743095683,
+        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
         "type": "github"
       },
       "original": {
@@ -882,11 +883,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "lastModified": 1743095683,
+        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
         "type": "github"
       },
       "original": {
@@ -919,11 +920,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1742658226,
-        "narHash": "sha256-tYcolOHFC26Je4KI2B0m6VbvqTvtvFwQpVoQkuVfqW4=",
+        "lastModified": 1743263130,
+        "narHash": "sha256-nwHyO8vwtr765xuP4QTp0pTCUiwtyiwzAmgoRFZc4Lc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af69c990800493c42fac30d3f646c72fd9ce0654",
+        "rev": "72a3b7f3ad2132f8f8e1eba6ace6f6c042e96ff5",
         "type": "github"
       },
       "original": {
@@ -965,11 +966,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740569341,
-        "narHash": "sha256-WV8nY2IOfWdzBF5syVgCcgOchg/qQtpYh6LECYS9XkY=",
+        "lastModified": 1742765550,
+        "narHash": "sha256-2vVIh2JrL6GAGfgCeY9e6iNKrBjs0Hw3bGQEAbwVs68=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "5eeb0172fb74392053b66a8149e61b5e191b2845",
+        "rev": "b70be387276e632fe51232887f9e04e2b6ef8c16",
         "type": "github"
       },
       "original": {
@@ -1049,6 +1050,27 @@
         "type": "github"
       }
     },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixos-cosmic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1743215516,
+        "narHash": "sha256-52qbrkG65U1hyrQWltgHTgH4nm0SJL+9TWv2UDCEPNI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "524463199fdee49338006b049bc376b965a2cfed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
     "spicetify-nix": {
       "inputs": {
         "nixpkgs": [
@@ -1057,11 +1079,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1742512598,
-        "narHash": "sha256-nFPhSSxrPrpkmFR6vQq8OpUS+lGIAxDCUKg+5/qcnR8=",
+        "lastModified": 1742854930,
+        "narHash": "sha256-yry0JTKn3TotaCIgBjIl8rSsnqqxqT01rtJQUc0PeOA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "610654a0afe56766e639077d9d267148667a25e8",
+        "rev": "32663bb5e4dce31d252b1ba02deb3631d220d74e",
         "type": "github"
       },
       "original": {
@@ -1092,11 +1114,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1742591463,
-        "narHash": "sha256-CguaHULcm4RuIGN+i4u80dYZujFgZaeOTiShFxCwFhw=",
+        "lastModified": 1743075971,
+        "narHash": "sha256-8fSI6C19ZTcHgvoLK17wfEEVI08tgnZfSLgVe3E/22w=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "113643f332e1f70d90991722f8c4e5a0ace6fd06",
+        "rev": "2fb8321ea16c595e0208b22021ddaf1f471c634a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 13

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/296ddc64627f4a6a4eb447852d7346b9dd16197d' (2025-03-21)
  → 'github:nix-community/home-manager/1f679ed2a2ebe3894bad9f89fb0bd9f141c28a68' (2025-03-29)
• Updated input 'hyprpanel':
    'github:Jas-SinghFSU/HyprPanel/3a5ad2a1db420f0238895f2cb1ff64acd0d2cc54' (2025-03-19)
  → 'github:Jas-SinghFSU/HyprPanel/94a00a49dae15c87e4234c9962295aed2b0dc45e' (2025-03-28)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c' (2025-03-17)
  → 'github:nix-community/nix-index-database/36dc43cb50d5d20f90a28d53abb33a32b0a2aae6' (2025-03-23)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/6607cf789e541e7873d40d3a8f7815ea92204f32' (2025-03-13)
  → 'github:NixOS/nixpkgs/a84ebe20c6bc2ecbcfb000a50776219f48d134cc' (2025-03-19)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/4ea55231137b25c591f2952726e026ef40d077da' (2025-03-22)
  → 'github:nix-community/nix-vscode-extensions/1b2a53e3478225bc35d14ae75ea9e7b749c16d5b' (2025-03-29)
• Updated input 'nixos-cosmic':
    'github:lilyinstarlight/nixos-cosmic/216557e6cd229dbe7d73a497c227824a3c579cd7' (2025-03-22)
  → 'github:lilyinstarlight/nixos-cosmic/c709db4b95e58f410978bb49c87cb74214d03e78' (2025-03-29)
• Updated input 'nixos-cosmic/nixpkgs':
    'github:NixOS/nixpkgs/a84ebe20c6bc2ecbcfb000a50776219f48d134cc' (2025-03-19)
  → 'github:NixOS/nixpkgs/5e5402ecbcb27af32284d4a62553c019a3a49ea6' (2025-03-27)
• Updated input 'nixos-cosmic/nixpkgs-stable':
    'github:NixOS/nixpkgs/7105ae3957700a9646cc4b766f5815b23ed0c682' (2025-03-20)
  → 'github:NixOS/nixpkgs/d02d88f8de5b882ccdde0465d8fa2db3aa1169f7' (2025-03-25)
    'github:oxalica/rust-overlay/524463199fdee49338006b049bc376b965a2cfed' (2025-03-29)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a84ebe20c6bc2ecbcfb000a50776219f48d134cc' (2025-03-19)
  → 'github:NixOS/nixpkgs/5e5402ecbcb27af32284d4a62553c019a3a49ea6' (2025-03-27)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/7105ae3957700a9646cc4b766f5815b23ed0c682' (2025-03-20)
  → 'github:NixOS/nixpkgs/d02d88f8de5b882ccdde0465d8fa2db3aa1169f7' (2025-03-25)
• Updated input 'nur':
    'github:nix-community/NUR/af69c990800493c42fac30d3f646c72fd9ce0654' (2025-03-22)
  → 'github:nix-community/NUR/72a3b7f3ad2132f8f8e1eba6ace6f6c042e96ff5' (2025-03-29)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/a84ebe20c6bc2ecbcfb000a50776219f48d134cc' (2025-03-19)
  → 'github:nixos/nixpkgs/5e5402ecbcb27af32284d4a62553c019a3a49ea6' (2025-03-27)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/5eeb0172fb74392053b66a8149e61b5e191b2845' (2025-02-26)
  → 'github:nix-community/plasma-manager/b70be387276e632fe51232887f9e04e2b6ef8c16' (2025-03-23)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/610654a0afe56766e639077d9d267148667a25e8' (2025-03-20)
  → 'github:Gerg-L/spicetify-nix/32663bb5e4dce31d252b1ba02deb3631d220d74e' (2025-03-24)
• Updated input 'stylix':
    'github:danth/stylix/113643f332e1f70d90991722f8c4e5a0ace6fd06' (2025-03-21)
  → 'github:danth/stylix/2fb8321ea16c595e0208b22021ddaf1f471c634a' (2025-03-27)
```

Sources Changelog:
```
obs_catppuccin: a994c89a88578d003796b51df67e3623bd864449 → 58a80435caf1ff4f62b94592f508fba4c3776c97
```
