### PR TITLE
chore: update flake.lock & sources (2025-04-05)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -91,12 +91,12 @@
             "name": null,
             "owner": "rafaelmardojai",
             "repo": "firefox-gnome-theme",
-            "rev": "v136",
-            "sha256": "sha256-1+NdJ67l7M/LG91Tn7ebInBS/HwOpjty+LQJK99PoH0=",
+            "rev": "v137",
+            "sha256": "sha256-oiHLDHXq7ymsMVYSg92dD1OLnKLQoU/Gf2F1GoONLCE=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "v136"
+        "version": "v137"
     },
     "joplin_catppuccin": {
         "cargoLocks": null,
@@ -121,7 +121,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2025-03-13",
+        "date": "2025-04-05",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -133,12 +133,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "0ef0c6065345426fb4872c9ee75a58c11f62d3f8",
-            "sha256": "sha256-lOMeXwNYIiX+/8unr+6blKkeWBJ2TRfJ2xGJ1Xo/qFw=",
+            "rev": "2fadd8696095bde39531e3815deea894a00b9b4a",
+            "sha256": "sha256-qd5SlOzyBHk3BGtL3sBGw22JonJ9Go3P32O1YURRlNk=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "0ef0c6065345426fb4872c9ee75a58c11f62d3f8"
+        "version": "2fadd8696095bde39531e3815deea894a00b9b4a"
     },
     "obs_catppuccin": {
         "cargoLocks": null,
@@ -184,7 +184,7 @@
     },
     "rofi-bluetooth": {
         "cargoLocks": null,
-        "date": "2023-02-03",
+        "date": "2025-04-03",
         "extract": null,
         "name": "rofi-bluetooth",
         "passthru": null,
@@ -196,12 +196,12 @@
             "name": null,
             "owner": "nickclyde",
             "repo": "rofi-bluetooth",
-            "rev": "9d91c048ff129819f4c6e9e48a17bd54343bbffb",
-            "sha256": "sha256-1Xe3QFThIvJDCUznDP5ZBzwZEMuqmxpDIV+BcVvQDG8=",
+            "rev": "034b05f52e2f48e4e1f6ae19eae9f30e4a9e6791",
+            "sha256": "sha256-o0Sr3/888L/2KzZZP/EcXx+8ZUzdHB/I/VIeVuJvJks=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "9d91c048ff129819f4c6e9e48a17bd54343bbffb"
+        "version": "034b05f52e2f48e4e1f6ae19eae9f30e4a9e6791"
     },
     "rofi_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -52,13 +52,13 @@
   };
   firefox-gnome-theme = {
     pname = "firefox-gnome-theme";
-    version = "v136";
+    version = "v137";
     src = fetchFromGitHub {
       owner = "rafaelmardojai";
       repo = "firefox-gnome-theme";
-      rev = "v136";
+      rev = "v137";
       fetchSubmodules = false;
-      sha256 = "sha256-1+NdJ67l7M/LG91Tn7ebInBS/HwOpjty+LQJK99PoH0=";
+      sha256 = "sha256-oiHLDHXq7ymsMVYSg92dD1OLnKLQoU/Gf2F1GoONLCE=";
     };
   };
   joplin_catppuccin = {
@@ -75,15 +75,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "0ef0c6065345426fb4872c9ee75a58c11f62d3f8";
+    version = "2fadd8696095bde39531e3815deea894a00b9b4a";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "0ef0c6065345426fb4872c9ee75a58c11f62d3f8";
+      rev = "2fadd8696095bde39531e3815deea894a00b9b4a";
       fetchSubmodules = false;
-      sha256 = "sha256-lOMeXwNYIiX+/8unr+6blKkeWBJ2TRfJ2xGJ1Xo/qFw=";
+      sha256 = "sha256-qd5SlOzyBHk3BGtL3sBGw22JonJ9Go3P32O1YURRlNk=";
     };
-    date = "2025-03-13";
+    date = "2025-04-05";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";
@@ -111,15 +111,15 @@
   };
   rofi-bluetooth = {
     pname = "rofi-bluetooth";
-    version = "9d91c048ff129819f4c6e9e48a17bd54343bbffb";
+    version = "034b05f52e2f48e4e1f6ae19eae9f30e4a9e6791";
     src = fetchFromGitHub {
       owner = "nickclyde";
       repo = "rofi-bluetooth";
-      rev = "9d91c048ff129819f4c6e9e48a17bd54343bbffb";
+      rev = "034b05f52e2f48e4e1f6ae19eae9f30e4a9e6791";
       fetchSubmodules = false;
-      sha256 = "sha256-1Xe3QFThIvJDCUznDP5ZBzwZEMuqmxpDIV+BcVvQDG8=";
+      sha256 = "sha256-o0Sr3/888L/2KzZZP/EcXx+8ZUzdHB/I/VIeVuJvJks=";
     };
-    date = "2023-02-03";
+    date = "2025-04-03";
   };
   rofi_catppuccin = {
     pname = "rofi_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1741352980,
-        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -564,11 +564,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743259333,
-        "narHash": "sha256-2Fi3K++co4IGbeOLGXdRA6VEfbzQzMgcuBaPTyjfj0s=",
+        "lastModified": 1743869639,
+        "narHash": "sha256-Xhe3whfRW/Ay05z9m1EZ1/AkbV1yo0tm1CbgjtCi4rQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1f679ed2a2ebe3894bad9f89fb0bd9f141c28a68",
+        "rev": "d094c6763c6ddb860580e7d3b4201f8f496a6836",
         "type": "github"
       },
       "original": {
@@ -604,11 +604,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1743179396,
-        "narHash": "sha256-+qEQKKqPwhtVyQJceiA51v2L1/j3Hyr0v7nnjnABB70=",
+        "lastModified": 1743833598,
+        "narHash": "sha256-ndewAvhdD8yKPHyHwP8gi9hJp+uTKK78/D7+ajLMkD0=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "94a00a49dae15c87e4234c9962295aed2b0dc45e",
+        "rev": "18c383b7546a3f8105b2b32d488ff212a582c481",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742701275,
-        "narHash": "sha256-AulwPVrS9859t+eJ61v24wH/nfBEIDSXYxlRo3fL/SA=",
+        "lastModified": 1743306489,
+        "narHash": "sha256-LROaIjSLo347cwcHRfSpqzEOa2FoLSeJwU4dOrGm55E=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "36dc43cb50d5d20f90a28d53abb33a32b0a2aae6",
+        "rev": "b3696bfb6c24aa61428839a99e8b40c53ac3a82d",
         "type": "github"
       },
       "original": {
@@ -704,11 +704,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1743213162,
-        "narHash": "sha256-9UU0x2fZORsX6PEpzkIAD/7+bwm+javJtZA/411ZmLg=",
+        "lastModified": 1743817938,
+        "narHash": "sha256-4mqj8t6YBymdfORyGaYB1HwL2mxgCyuHp3U5RSHdC/Q=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "1b2a53e3478225bc35d14ae75ea9e7b749c16d5b",
+        "rev": "2a7a2b80740dd1dbb8b4e1d5b2ae6ad9b7fbd5e3",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1743246566,
-        "narHash": "sha256-arEFUDLjADYIZ7T6PZX1yLOnfMoZ1ByebtmPuvV98+s=",
+        "lastModified": 1743851358,
+        "narHash": "sha256-Ae2HjVMjjzHZKLjJx7FBQuCV9HrMQfyjpRcLbdVYCgs=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "c709db4b95e58f410978bb49c87cb74214d03e78",
+        "rev": "91a65887c29a8221957315231f20bf92b37cdb83",
         "type": "github"
       },
       "original": {
@@ -756,11 +756,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1740877520,
-        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
         "type": "github"
       },
       "original": {
@@ -787,11 +787,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1742937945,
-        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
+        "lastModified": 1743703532,
+        "narHash": "sha256-s1KLDALEeqy+ttrvqV3jx9mBZEvmthQErTVOAzbjHZs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
+        "rev": "bdb91860de2f719b57eef819b5617762f7120c70",
         "type": "github"
       },
       "original": {
@@ -803,11 +803,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1742937945,
-        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
+        "lastModified": 1743703532,
+        "narHash": "sha256-s1KLDALEeqy+ttrvqV3jx9mBZEvmthQErTVOAzbjHZs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
+        "rev": "bdb91860de2f719b57eef819b5617762f7120c70",
         "type": "github"
       },
       "original": {
@@ -819,11 +819,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "lastModified": 1743095683,
+        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
         "type": "github"
       },
       "original": {
@@ -851,11 +851,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1743095683,
-        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
@@ -867,11 +867,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1743095683,
-        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
@@ -883,11 +883,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1743095683,
-        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1743263130,
-        "narHash": "sha256-nwHyO8vwtr765xuP4QTp0pTCUiwtyiwzAmgoRFZc4Lc=",
+        "lastModified": 1743867911,
+        "narHash": "sha256-E1JS+GEkoPo9fgOE5E+b5V7c1cq3OBDuaI9Kg6DRkHk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72a3b7f3ad2132f8f8e1eba6ace6f6c042e96ff5",
+        "rev": "67f21fa057f77a3c2450df19165db7d56e8896ae",
         "type": "github"
       },
       "original": {
@@ -1058,11 +1058,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743215516,
-        "narHash": "sha256-52qbrkG65U1hyrQWltgHTgH4nm0SJL+9TWv2UDCEPNI=",
+        "lastModified": 1743820323,
+        "narHash": "sha256-UXxJogXhPhBFaX4uxmMudcD/x3sEGFtoSc4busTcftY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "524463199fdee49338006b049bc376b965a2cfed",
+        "rev": "b4734ce867252f92cdc7d25f8cc3b7cef153e703",
         "type": "github"
       },
       "original": {
@@ -1079,11 +1079,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1742854930,
-        "narHash": "sha256-yry0JTKn3TotaCIgBjIl8rSsnqqxqT01rtJQUc0PeOA=",
+        "lastModified": 1743595372,
+        "narHash": "sha256-e3x1mhpPpYgyyin9j/VbrBpOT5PFpEfx2hkxVZuJZhg=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "32663bb5e4dce31d252b1ba02deb3631d220d74e",
+        "rev": "543f12dd14c62ddee79ab79fbfd8726f312b89ff",
         "type": "github"
       },
       "original": {
@@ -1114,11 +1114,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743075971,
-        "narHash": "sha256-8fSI6C19ZTcHgvoLK17wfEEVI08tgnZfSLgVe3E/22w=",
+        "lastModified": 1743775855,
+        "narHash": "sha256-ZhhiYvHlA9f/Ck1i76ilfapLS7abLPRlWJQRxJEDTnQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "2fb8321ea16c595e0208b22021ddaf1f471c634a",
+        "rev": "581fa67c818aaf91a1533149fb737d3e8c0949b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 14

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/f4330d22f1c5d2ba72d3d22df5597d123fdb60a9' (2025-03-07)
  → 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5' (2025-04-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/147dee35aab2193b174e4c0868bd80ead5ce755c' (2025-03-02)
  → 'github:nix-community/nixpkgs.lib/e4822aea2a6d1cdd36653c134cacfd64c97ff4fa' (2025-03-30)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1f679ed2a2ebe3894bad9f89fb0bd9f141c28a68' (2025-03-29)
  → 'github:nix-community/home-manager/d094c6763c6ddb860580e7d3b4201f8f496a6836' (2025-04-05)
• Updated input 'hyprpanel':
    'github:Jas-SinghFSU/HyprPanel/94a00a49dae15c87e4234c9962295aed2b0dc45e' (2025-03-28)
  → 'github:Jas-SinghFSU/HyprPanel/18c383b7546a3f8105b2b32d488ff212a582c481' (2025-04-05)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/36dc43cb50d5d20f90a28d53abb33a32b0a2aae6' (2025-03-23)
  → 'github:nix-community/nix-index-database/b3696bfb6c24aa61428839a99e8b40c53ac3a82d' (2025-03-30)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/a84ebe20c6bc2ecbcfb000a50776219f48d134cc' (2025-03-19)
  → 'github:NixOS/nixpkgs/5e5402ecbcb27af32284d4a62553c019a3a49ea6' (2025-03-27)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/1b2a53e3478225bc35d14ae75ea9e7b749c16d5b' (2025-03-29)
  → 'github:nix-community/nix-vscode-extensions/2a7a2b80740dd1dbb8b4e1d5b2ae6ad9b7fbd5e3' (2025-04-05)
• Updated input 'nixos-cosmic':
    'github:lilyinstarlight/nixos-cosmic/c709db4b95e58f410978bb49c87cb74214d03e78' (2025-03-29)
  → 'github:lilyinstarlight/nixos-cosmic/91a65887c29a8221957315231f20bf92b37cdb83' (2025-04-05)
• Updated input 'nixos-cosmic/nixpkgs':
    'github:NixOS/nixpkgs/5e5402ecbcb27af32284d4a62553c019a3a49ea6' (2025-03-27)
  → 'github:NixOS/nixpkgs/2c8d3f48d33929642c1c12cd243df4cc7d2ce434' (2025-04-02)
• Updated input 'nixos-cosmic/nixpkgs-stable':
    'github:NixOS/nixpkgs/d02d88f8de5b882ccdde0465d8fa2db3aa1169f7' (2025-03-25)
  → 'github:NixOS/nixpkgs/bdb91860de2f719b57eef819b5617762f7120c70' (2025-04-03)
• Updated input 'nixos-cosmic/rust-overlay':
    'github:oxalica/rust-overlay/524463199fdee49338006b049bc376b965a2cfed' (2025-03-29)
  → 'github:oxalica/rust-overlay/b4734ce867252f92cdc7d25f8cc3b7cef153e703' (2025-04-05)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/5e5402ecbcb27af32284d4a62553c019a3a49ea6' (2025-03-27)
  → 'github:NixOS/nixpkgs/2c8d3f48d33929642c1c12cd243df4cc7d2ce434' (2025-04-02)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/d02d88f8de5b882ccdde0465d8fa2db3aa1169f7' (2025-03-25)
  → 'github:NixOS/nixpkgs/bdb91860de2f719b57eef819b5617762f7120c70' (2025-04-03)
• Updated input 'nur':
    'github:nix-community/NUR/72a3b7f3ad2132f8f8e1eba6ace6f6c042e96ff5' (2025-03-29)
  → 'github:nix-community/NUR/67f21fa057f77a3c2450df19165db7d56e8896ae' (2025-04-05)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/5e5402ecbcb27af32284d4a62553c019a3a49ea6' (2025-03-27)
  → 'github:nixos/nixpkgs/2c8d3f48d33929642c1c12cd243df4cc7d2ce434' (2025-04-02)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/32663bb5e4dce31d252b1ba02deb3631d220d74e' (2025-03-24)
  → 'github:Gerg-L/spicetify-nix/543f12dd14c62ddee79ab79fbfd8726f312b89ff' (2025-04-02)
• Updated input 'stylix':
    'github:danth/stylix/2fb8321ea16c595e0208b22021ddaf1f471c634a' (2025-03-27)
  → 'github:danth/stylix/581fa67c818aaf91a1533149fb737d3e8c0949b8' (2025-04-04)
```

Sources Changelog:
```
firefox-gnome-theme: v136 → v137
nix-fast-build: 0ef0c6065345426fb4872c9ee75a58c11f62d3f8 → 2fadd8696095bde39531e3815deea894a00b9b4a
rofi-bluetooth: 9d91c048ff129819f4c6e9e48a17bd54343bbffb → 034b05f52e2f48e4e1f6ae19eae9f30e4a9e6791
```
