### PR TITLE
chore: update flake.lock & sources (2025-04-12)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -121,7 +121,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2025-04-05",
+        "date": "2025-04-12",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -133,12 +133,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "2fadd8696095bde39531e3815deea894a00b9b4a",
-            "sha256": "sha256-qd5SlOzyBHk3BGtL3sBGw22JonJ9Go3P32O1YURRlNk=",
+            "rev": "b01f2559cdcef1f9c42ce3cac324256bd2b7955d",
+            "sha256": "sha256-4nnuB5Vunhq7HzMfqCXpOH8YZ2v8h0k6FQkYi93YdI0=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "2fadd8696095bde39531e3815deea894a00b9b4a"
+        "version": "b01f2559cdcef1f9c42ce3cac324256bd2b7955d"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -75,15 +75,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "2fadd8696095bde39531e3815deea894a00b9b4a";
+    version = "b01f2559cdcef1f9c42ce3cac324256bd2b7955d";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "2fadd8696095bde39531e3815deea894a00b9b4a";
+      rev = "b01f2559cdcef1f9c42ce3cac324256bd2b7955d";
       fetchSubmodules = false;
-      sha256 = "sha256-qd5SlOzyBHk3BGtL3sBGw22JonJ9Go3P32O1YURRlNk=";
+      sha256 = "sha256-4nnuB5Vunhq7HzMfqCXpOH8YZ2v8h0k6FQkYi93YdI0=";
     };
-    date = "2025-04-05";
+    date = "2025-04-12";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -196,11 +196,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1741628778,
-        "narHash": "sha256-RsvHGNTmO2e/eVfgYK7g+eYEdwwh7SbZa+gZkT24MEA=",
+        "lastModified": 1743774811,
+        "narHash": "sha256-oiHLDHXq7ymsMVYSg92dD1OLnKLQoU/Gf2F1GoONLCE=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "5a81d390bb64afd4e81221749ec4bffcbeb5fa80",
+        "rev": "df53a7a31872faf5ca53dd0730038a62ec63ca9e",
         "type": "github"
       },
       "original": {
@@ -462,11 +462,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741379162,
-        "narHash": "sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc=",
+        "lastModified": 1742649964,
+        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "b5a62751225b2f62ff3147d0a334055ebadcd5cc",
+        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
         "type": "github"
       },
       "original": {
@@ -564,11 +564,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743869639,
-        "narHash": "sha256-Xhe3whfRW/Ay05z9m1EZ1/AkbV1yo0tm1CbgjtCi4rQ=",
+        "lastModified": 1744400600,
+        "narHash": "sha256-qYhUgA98mhq1QK13r9qVY+sG1ri6FBgyp+GApX6wS20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d094c6763c6ddb860580e7d3b4201f8f496a6836",
+        "rev": "b74b22bb6167e8dff083ec6988c98798bf8954d3",
         "type": "github"
       },
       "original": {
@@ -585,11 +585,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741635347,
-        "narHash": "sha256-2aYfV44h18alHXopyfL4D9GsnpE5XlSVkp4MGe586VU=",
+        "lastModified": 1743869639,
+        "narHash": "sha256-Xhe3whfRW/Ay05z9m1EZ1/AkbV1yo0tm1CbgjtCi4rQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7fb8678716c158642ac42f9ff7a18c0800fea551",
+        "rev": "d094c6763c6ddb860580e7d3b4201f8f496a6836",
         "type": "github"
       },
       "original": {
@@ -604,11 +604,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1743833598,
-        "narHash": "sha256-ndewAvhdD8yKPHyHwP8gi9hJp+uTKK78/D7+ajLMkD0=",
+        "lastModified": 1744259355,
+        "narHash": "sha256-gykRJw309t5NLuYXzWw9WhJFKTc4OASmc16M9jD/Vpw=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "18c383b7546a3f8105b2b32d488ff212a582c481",
+        "rev": "1d4d2dcc20ebd707d5e45c7e357acc1267a498d7",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743306489,
-        "narHash": "sha256-LROaIjSLo347cwcHRfSpqzEOa2FoLSeJwU4dOrGm55E=",
+        "lastModified": 1743911143,
+        "narHash": "sha256-4j4JPwr0TXHH4ZyorXN5yIcmqIQr0WYacsuPA4ktONo=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "b3696bfb6c24aa61428839a99e8b40c53ac3a82d",
+        "rev": "a36f6a7148aec2c77d78e4466215cceb2f5f4bfb",
         "type": "github"
       },
       "original": {
@@ -704,11 +704,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1743817938,
-        "narHash": "sha256-4mqj8t6YBymdfORyGaYB1HwL2mxgCyuHp3U5RSHdC/Q=",
+        "lastModified": 1744422829,
+        "narHash": "sha256-rvWFZG02MQuzKLueDQryCLEljRV0Ot4uo44hoKC3CHg=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "2a7a2b80740dd1dbb8b4e1d5b2ae6ad9b7fbd5e3",
+        "rev": "eda6606c9e4790ebe074d18ef074906a750f0d53",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1743851358,
-        "narHash": "sha256-Ae2HjVMjjzHZKLjJx7FBQuCV9HrMQfyjpRcLbdVYCgs=",
+        "lastModified": 1744456153,
+        "narHash": "sha256-xTaAboh9p0Mz0UEgcKe+B1zVKoRFG7RQR+gf7ypMQVA=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "91a65887c29a8221957315231f20bf92b37cdb83",
+        "rev": "a76a451a2c97aa37a7741bdf8244ad91205776b8",
         "type": "github"
       },
       "original": {
@@ -787,11 +787,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1743703532,
-        "narHash": "sha256-s1KLDALEeqy+ttrvqV3jx9mBZEvmthQErTVOAzbjHZs=",
+        "lastModified": 1744309437,
+        "narHash": "sha256-QZnNHM823am8apCqKSPdtnzPGTy2ZB4zIXOVoBp5+W0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bdb91860de2f719b57eef819b5617762f7120c70",
+        "rev": "f9ebe33a928b5d529c895202263a5ce46bdf12f7",
         "type": "github"
       },
       "original": {
@@ -803,11 +803,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1743703532,
-        "narHash": "sha256-s1KLDALEeqy+ttrvqV3jx9mBZEvmthQErTVOAzbjHZs=",
+        "lastModified": 1744309437,
+        "narHash": "sha256-QZnNHM823am8apCqKSPdtnzPGTy2ZB4zIXOVoBp5+W0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bdb91860de2f719b57eef819b5617762f7120c70",
+        "rev": "f9ebe33a928b5d529c895202263a5ce46bdf12f7",
         "type": "github"
       },
       "original": {
@@ -819,11 +819,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1743095683,
-        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
+        "lastModified": 1743827369,
+        "narHash": "sha256-rpqepOZ8Eo1zg+KJeWoq1HAOgoMCDloqv5r2EAa9TSA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
+        "rev": "42a1c966be226125b48c384171c44c651c236c22",
         "type": "github"
       },
       "original": {
@@ -851,11 +851,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1743583204,
-        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
+        "lastModified": 1744232761,
+        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
+        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
         "type": "github"
       },
       "original": {
@@ -867,11 +867,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1743583204,
-        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
+        "lastModified": 1744232761,
+        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
+        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
         "type": "github"
       },
       "original": {
@@ -883,11 +883,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1743583204,
-        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
+        "lastModified": 1744232761,
+        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
+        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
         "type": "github"
       },
       "original": {
@@ -899,11 +899,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1741513245,
-        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1743867911,
-        "narHash": "sha256-E1JS+GEkoPo9fgOE5E+b5V7c1cq3OBDuaI9Kg6DRkHk=",
+        "lastModified": 1744474042,
+        "narHash": "sha256-CDLAzJ5lqgPbp6gc/+x3m5ojmBust/wxLGM5XD9W818=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "67f21fa057f77a3c2450df19165db7d56e8896ae",
+        "rev": "96bc1373445beb864dd3564e09f0ca0b9d623a5a",
         "type": "github"
       },
       "original": {
@@ -943,11 +943,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741693509,
-        "narHash": "sha256-emkxnsZstiJWmGACimyAYqIKz2Qz5We5h1oBVDyQjLw=",
+        "lastModified": 1743884191,
+        "narHash": "sha256-foVcginhVvjg8ZnTzY5wwMeZ4wjJ8yX66PW5kgyivPE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5479646b2574837f1899da78bdf9a48b75a9fb27",
+        "rev": "fde90f5f52e13eed110a0e53a2818a2b09e4d37c",
         "type": "github"
       },
       "original": {
@@ -1058,11 +1058,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743820323,
-        "narHash": "sha256-UXxJogXhPhBFaX4uxmMudcD/x3sEGFtoSc4busTcftY=",
+        "lastModified": 1744425163,
+        "narHash": "sha256-iFcqIbyY25uhtRrQal5vFTxt0q59vDf++nY8du5hof4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b4734ce867252f92cdc7d25f8cc3b7cef153e703",
+        "rev": "4bb0b6dfc5bafa8b4e8dbe1170f051c437b2cb79",
         "type": "github"
       },
       "original": {
@@ -1079,11 +1079,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1743595372,
-        "narHash": "sha256-e3x1mhpPpYgyyin9j/VbrBpOT5PFpEfx2hkxVZuJZhg=",
+        "lastModified": 1744423915,
+        "narHash": "sha256-6Hd8VyrOlmjlDBgPpx9NwX4+/uO4gEDIyjqbQLyniwE=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "543f12dd14c62ddee79ab79fbfd8726f312b89ff",
+        "rev": "4c4b9611c71d586ea818fa5b8dcbd81129f62560",
         "type": "github"
       },
       "original": {
@@ -1114,11 +1114,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743775855,
-        "narHash": "sha256-ZhhiYvHlA9f/Ck1i76ilfapLS7abLPRlWJQRxJEDTnQ=",
+        "lastModified": 1744270948,
+        "narHash": "sha256-+1psY8uBaDdkqV/P3G40SzulPvUcb9VHisqQnDozC0U=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "581fa67c818aaf91a1533149fb737d3e8c0949b8",
+        "rev": "ce45f19e8acb43e5f02888d873d451e2f994546b",
         "type": "github"
       },
       "original": {
@@ -1254,11 +1254,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1741468895,
-        "narHash": "sha256-YKM1RJbL68Yp2vESBqeZQBjTETXo8mCTTzLZyckCfZk=",
+        "lastModified": 1742851696,
+        "narHash": "sha256-sR4K+OVFKeUOvNIqcCr5Br7NLxOBEwoAgsIyjsZmb8s=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "47c8c7726e98069cade5827e5fb2bfee02ce6991",
+        "rev": "c37771c4ae8ff1667e27ddcf24991ebeb94a4e77",
         "type": "github"
       },
       "original": {
@@ -1270,11 +1270,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1740877430,
-        "narHash": "sha256-zWcCXgdC4/owfH/eEXx26y5BLzTrefjtSLFHWVD5KxU=",
+        "lastModified": 1743296873,
+        "narHash": "sha256-8IQulrb1OBSxMwdKijO9fB70ON//V32dpK9Uioy7FzY=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "d48ee86394cbe45b112ba23ab63e33656090edb4",
+        "rev": "af5152c8d7546dfb4ff6df94080bf5ff54f64e3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 15

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/d094c6763c6ddb860580e7d3b4201f8f496a6836' (2025-04-05)
  → 'github:nix-community/home-manager/b74b22bb6167e8dff083ec6988c98798bf8954d3' (2025-04-11)
• Updated input 'hyprpanel':
    'github:Jas-SinghFSU/HyprPanel/18c383b7546a3f8105b2b32d488ff212a582c481' (2025-04-05)
  → 'github:Jas-SinghFSU/HyprPanel/1d4d2dcc20ebd707d5e45c7e357acc1267a498d7' (2025-04-10)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/b3696bfb6c24aa61428839a99e8b40c53ac3a82d' (2025-03-30)
  → 'github:nix-community/nix-index-database/a36f6a7148aec2c77d78e4466215cceb2f5f4bfb' (2025-04-06)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/5e5402ecbcb27af32284d4a62553c019a3a49ea6' (2025-03-27)
  → 'github:NixOS/nixpkgs/42a1c966be226125b48c384171c44c651c236c22' (2025-04-05)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/2a7a2b80740dd1dbb8b4e1d5b2ae6ad9b7fbd5e3' (2025-04-05)
  → 'github:nix-community/nix-vscode-extensions/eda6606c9e4790ebe074d18ef074906a750f0d53' (2025-04-12)
• Updated input 'nixos-cosmic':
    'github:lilyinstarlight/nixos-cosmic/91a65887c29a8221957315231f20bf92b37cdb83' (2025-04-05)
  → 'github:lilyinstarlight/nixos-cosmic/a76a451a2c97aa37a7741bdf8244ad91205776b8' (2025-04-12)
• Updated input 'nixos-cosmic/nixpkgs':
    'github:NixOS/nixpkgs/2c8d3f48d33929642c1c12cd243df4cc7d2ce434' (2025-04-02)
  → 'github:NixOS/nixpkgs/f675531bc7e6657c10a18b565cfebd8aa9e24c14' (2025-04-09)
• Updated input 'nixos-cosmic/nixpkgs-stable':
    'github:NixOS/nixpkgs/bdb91860de2f719b57eef819b5617762f7120c70' (2025-04-03)
  → 'github:NixOS/nixpkgs/f9ebe33a928b5d529c895202263a5ce46bdf12f7' (2025-04-10)
• Updated input 'nixos-cosmic/rust-overlay':
    'github:oxalica/rust-overlay/b4734ce867252f92cdc7d25f8cc3b7cef153e703' (2025-04-05)
  → 'github:oxalica/rust-overlay/4bb0b6dfc5bafa8b4e8dbe1170f051c437b2cb79' (2025-04-12)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/2c8d3f48d33929642c1c12cd243df4cc7d2ce434' (2025-04-02)
  → 'github:NixOS/nixpkgs/f675531bc7e6657c10a18b565cfebd8aa9e24c14' (2025-04-09)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/bdb91860de2f719b57eef819b5617762f7120c70' (2025-04-03)
  → 'github:NixOS/nixpkgs/f9ebe33a928b5d529c895202263a5ce46bdf12f7' (2025-04-10)
• Updated input 'nur':
    'github:nix-community/NUR/67f21fa057f77a3c2450df19165db7d56e8896ae' (2025-04-05)
  → 'github:nix-community/NUR/96bc1373445beb864dd3564e09f0ca0b9d623a5a' (2025-04-12)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/2c8d3f48d33929642c1c12cd243df4cc7d2ce434' (2025-04-02)
  → 'github:nixos/nixpkgs/f675531bc7e6657c10a18b565cfebd8aa9e24c14' (2025-04-09)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/543f12dd14c62ddee79ab79fbfd8726f312b89ff' (2025-04-02)
  → 'github:Gerg-L/spicetify-nix/4c4b9611c71d586ea818fa5b8dcbd81129f62560' (2025-04-12)
• Updated input 'stylix':
    'github:danth/stylix/581fa67c818aaf91a1533149fb737d3e8c0949b8' (2025-04-04)
  → 'github:danth/stylix/ce45f19e8acb43e5f02888d873d451e2f994546b' (2025-04-10)
• Updated input 'stylix/firefox-gnome-theme':
    'github:rafaelmardojai/firefox-gnome-theme/5a81d390bb64afd4e81221749ec4bffcbeb5fa80' (2025-03-10)
  → 'github:rafaelmardojai/firefox-gnome-theme/df53a7a31872faf5ca53dd0730038a62ec63ca9e' (2025-04-04)
• Updated input 'stylix/git-hooks':
    'github:cachix/git-hooks.nix/b5a62751225b2f62ff3147d0a334055ebadcd5cc' (2025-03-07)
  → 'github:cachix/git-hooks.nix/dcf5072734cb576d2b0c59b2ac44f5050b5eac82' (2025-03-22)
• Updated input 'stylix/home-manager':
    'github:nix-community/home-manager/7fb8678716c158642ac42f9ff7a18c0800fea551' (2025-03-10)
  → 'github:nix-community/home-manager/d094c6763c6ddb860580e7d3b4201f8f496a6836' (2025-04-05)
• Updated input 'stylix/nixpkgs':
    'github:NixOS/nixpkgs/e3e32b642a31e6714ec1b712de8c91a3352ce7e1' (2025-03-09)
  → 'github:NixOS/nixpkgs/2c8d3f48d33929642c1c12cd243df4cc7d2ce434' (2025-04-02)
• Updated input 'stylix/nur':
    'github:nix-community/NUR/5479646b2574837f1899da78bdf9a48b75a9fb27' (2025-03-11)
  → 'github:nix-community/NUR/fde90f5f52e13eed110a0e53a2818a2b09e4d37c' (2025-04-05)
• Updated input 'stylix/tinted-schemes':
    'github:tinted-theming/schemes/47c8c7726e98069cade5827e5fb2bfee02ce6991' (2025-03-08)
  → 'github:tinted-theming/schemes/c37771c4ae8ff1667e27ddcf24991ebeb94a4e77' (2025-03-24)
• Updated input 'stylix/tinted-tmux':
    'github:tinted-theming/tinted-tmux/d48ee86394cbe45b112ba23ab63e33656090edb4' (2025-03-02)
  → 'github:tinted-theming/tinted-tmux/af5152c8d7546dfb4ff6df94080bf5ff54f64e3a' (2025-03-30)
```

Sources Changelog:
```
nix-fast-build: 2fadd8696095bde39531e3815deea894a00b9b4a → b01f2559cdcef1f9c42ce3cac324256bd2b7955d
```
