### PR TITLE
chore: update flake.lock & sources (2025-04-19)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -121,7 +121,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2025-04-12",
+        "date": "2025-04-18",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -133,12 +133,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "b01f2559cdcef1f9c42ce3cac324256bd2b7955d",
-            "sha256": "sha256-4nnuB5Vunhq7HzMfqCXpOH8YZ2v8h0k6FQkYi93YdI0=",
+            "rev": "188b1f5c400c2349b6c4a1d130dc893d2b29f60c",
+            "sha256": "sha256-qiczbsj5lRZc/f0jHxADD0M32hxlPbrhNhWz3zx3MBg=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "b01f2559cdcef1f9c42ce3cac324256bd2b7955d"
+        "version": "188b1f5c400c2349b6c4a1d130dc893d2b29f60c"
     },
     "obs_catppuccin": {
         "cargoLocks": null,
@@ -184,7 +184,7 @@
     },
     "rofi-bluetooth": {
         "cargoLocks": null,
-        "date": "2025-04-03",
+        "date": "2025-04-14",
         "extract": null,
         "name": "rofi-bluetooth",
         "passthru": null,
@@ -196,12 +196,12 @@
             "name": null,
             "owner": "nickclyde",
             "repo": "rofi-bluetooth",
-            "rev": "034b05f52e2f48e4e1f6ae19eae9f30e4a9e6791",
-            "sha256": "sha256-o0Sr3/888L/2KzZZP/EcXx+8ZUzdHB/I/VIeVuJvJks=",
+            "rev": "0cca4d4aa1c82c9373ce5da781d73683a29484c6",
+            "sha256": "sha256-ggYoCWRuCi1WKcwb+0zVwq3WvSqJQBitI+/XTpOc6uw=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "034b05f52e2f48e4e1f6ae19eae9f30e4a9e6791"
+        "version": "0cca4d4aa1c82c9373ce5da781d73683a29484c6"
     },
     "rofi_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -75,15 +75,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "b01f2559cdcef1f9c42ce3cac324256bd2b7955d";
+    version = "188b1f5c400c2349b6c4a1d130dc893d2b29f60c";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "b01f2559cdcef1f9c42ce3cac324256bd2b7955d";
+      rev = "188b1f5c400c2349b6c4a1d130dc893d2b29f60c";
       fetchSubmodules = false;
-      sha256 = "sha256-4nnuB5Vunhq7HzMfqCXpOH8YZ2v8h0k6FQkYi93YdI0=";
+      sha256 = "sha256-qiczbsj5lRZc/f0jHxADD0M32hxlPbrhNhWz3zx3MBg=";
     };
-    date = "2025-04-12";
+    date = "2025-04-18";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";
@@ -111,15 +111,15 @@
   };
   rofi-bluetooth = {
     pname = "rofi-bluetooth";
-    version = "034b05f52e2f48e4e1f6ae19eae9f30e4a9e6791";
+    version = "0cca4d4aa1c82c9373ce5da781d73683a29484c6";
     src = fetchFromGitHub {
       owner = "nickclyde";
       repo = "rofi-bluetooth";
-      rev = "034b05f52e2f48e4e1f6ae19eae9f30e4a9e6791";
+      rev = "0cca4d4aa1c82c9373ce5da781d73683a29484c6";
       fetchSubmodules = false;
-      sha256 = "sha256-o0Sr3/888L/2KzZZP/EcXx+8ZUzdHB/I/VIeVuJvJks=";
+      sha256 = "sha256-ggYoCWRuCi1WKcwb+0zVwq3WvSqJQBitI+/XTpOc6uw=";
     };
-    date = "2025-04-03";
+    date = "2025-04-14";
   };
   rofi_catppuccin = {
     pname = "rofi_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -564,11 +564,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744400600,
-        "narHash": "sha256-qYhUgA98mhq1QK13r9qVY+sG1ri6FBgyp+GApX6wS20=",
+        "lastModified": 1745071558,
+        "narHash": "sha256-bvcatss0xodcdxXm0LUSLPd2jjrhqO3yFSu3stOfQXg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b74b22bb6167e8dff083ec6988c98798bf8954d3",
+        "rev": "9676e8a52a177d80c8a42f66566362a6d74ecf78",
         "type": "github"
       },
       "original": {
@@ -604,11 +604,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1744259355,
-        "narHash": "sha256-gykRJw309t5NLuYXzWw9WhJFKTc4OASmc16M9jD/Vpw=",
+        "lastModified": 1744513377,
+        "narHash": "sha256-2ocy+qAVxTBmaK8MpAy7mpKIH+DYEzwf+KzXZX83oZ4=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "1d4d2dcc20ebd707d5e45c7e357acc1267a498d7",
+        "rev": "42943b3def85d8787d703778951944c8e791202b",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743911143,
-        "narHash": "sha256-4j4JPwr0TXHH4ZyorXN5yIcmqIQr0WYacsuPA4ktONo=",
+        "lastModified": 1744518957,
+        "narHash": "sha256-RLBSWQfTL0v+7uyskC5kP6slLK1jvIuhaAh8QvB75m4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "a36f6a7148aec2c77d78e4466215cceb2f5f4bfb",
+        "rev": "4fc9ea78c962904f4ea11046f3db37c62e8a02fd",
         "type": "github"
       },
       "original": {
@@ -704,11 +704,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1744422829,
-        "narHash": "sha256-rvWFZG02MQuzKLueDQryCLEljRV0Ot4uo44hoKC3CHg=",
+        "lastModified": 1745027517,
+        "narHash": "sha256-sMQC7M0Y9HdPcD7L8pAl5uwfHZr8H+GjGPo7Ii7AUjU=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "eda6606c9e4790ebe074d18ef074906a750f0d53",
+        "rev": "39613bfde3de6dc2fa1ff208e46287f935618179",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1744456153,
-        "narHash": "sha256-xTaAboh9p0Mz0UEgcKe+B1zVKoRFG7RQR+gf7ypMQVA=",
+        "lastModified": 1745073405,
+        "narHash": "sha256-kr3tEqmGYr7gJYzGZa20aG1/hRZ7OGbKC1C0EuyEMrY=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "a76a451a2c97aa37a7741bdf8244ad91205776b8",
+        "rev": "f5f0ab37d6935c232336f10b136f11a88c634b54",
         "type": "github"
       },
       "original": {
@@ -787,11 +787,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1744309437,
-        "narHash": "sha256-QZnNHM823am8apCqKSPdtnzPGTy2ZB4zIXOVoBp5+W0=",
+        "lastModified": 1744440957,
+        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9ebe33a928b5d529c895202263a5ce46bdf12f7",
+        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
         "type": "github"
       },
       "original": {
@@ -803,11 +803,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1744309437,
-        "narHash": "sha256-QZnNHM823am8apCqKSPdtnzPGTy2ZB4zIXOVoBp5+W0=",
+        "lastModified": 1744440957,
+        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9ebe33a928b5d529c895202263a5ce46bdf12f7",
+        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
         "type": "github"
       },
       "original": {
@@ -819,11 +819,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1743827369,
-        "narHash": "sha256-rpqepOZ8Eo1zg+KJeWoq1HAOgoMCDloqv5r2EAa9TSA=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "42a1c966be226125b48c384171c44c651c236c22",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       },
       "original": {
@@ -851,11 +851,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1744232761,
-        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
+        "lastModified": 1744932701,
+        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
         "type": "github"
       },
       "original": {
@@ -867,11 +867,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1744232761,
-        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
+        "lastModified": 1744932701,
+        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
         "type": "github"
       },
       "original": {
@@ -883,11 +883,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1744232761,
-        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
+        "lastModified": 1744932701,
+        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1744474042,
-        "narHash": "sha256-CDLAzJ5lqgPbp6gc/+x3m5ojmBust/wxLGM5XD9W818=",
+        "lastModified": 1745071326,
+        "narHash": "sha256-sXQJJhZGRaXbf1h/Q69wq2ngwZz35m4+Qu3UN6FYpNM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "96bc1373445beb864dd3564e09f0ca0b9d623a5a",
+        "rev": "9887318d5eae081b596a72bb9bdde8b5271ed8ab",
         "type": "github"
       },
       "original": {
@@ -1058,11 +1058,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744425163,
-        "narHash": "sha256-iFcqIbyY25uhtRrQal5vFTxt0q59vDf++nY8du5hof4=",
+        "lastModified": 1745029910,
+        "narHash": "sha256-9CtbfTTQWMoOkXejxc5D+K3z/39wkQQt2YfYJW50tnI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4bb0b6dfc5bafa8b4e8dbe1170f051c437b2cb79",
+        "rev": "50fefac8cdfd1587ac6d8678f6181e7d348201d2",
         "type": "github"
       },
       "original": {
@@ -1079,11 +1079,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1744423915,
-        "narHash": "sha256-6Hd8VyrOlmjlDBgPpx9NwX4+/uO4gEDIyjqbQLyniwE=",
+        "lastModified": 1745073200,
+        "narHash": "sha256-9BdXrdvR4ewdRMbvTRKABrJfuhcH1xxin2OR89MhMNY=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "4c4b9611c71d586ea818fa5b8dcbd81129f62560",
+        "rev": "c9093f2d516c5b62461844c06bf362db8e230ff9",
         "type": "github"
       },
       "original": {
@@ -1114,11 +1114,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1744270948,
-        "narHash": "sha256-+1psY8uBaDdkqV/P3G40SzulPvUcb9VHisqQnDozC0U=",
+        "lastModified": 1744910471,
+        "narHash": "sha256-HItOUMA2whFnPMJuyN2XHq9TZttgrgOAZcoUXsaD4Js=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ce45f19e8acb43e5f02888d873d451e2f994546b",
+        "rev": "8d5cd725ad591890c0cd804bf68cc842b8afca51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 16

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/b74b22bb6167e8dff083ec6988c98798bf8954d3' (2025-04-11)
  → 'github:nix-community/home-manager/9676e8a52a177d80c8a42f66566362a6d74ecf78' (2025-04-19)
• Updated input 'hyprpanel':
    'github:Jas-SinghFSU/HyprPanel/1d4d2dcc20ebd707d5e45c7e357acc1267a498d7' (2025-04-10)
  → 'github:Jas-SinghFSU/HyprPanel/42943b3def85d8787d703778951944c8e791202b' (2025-04-13)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/a36f6a7148aec2c77d78e4466215cceb2f5f4bfb' (2025-04-06)
  → 'github:nix-community/nix-index-database/4fc9ea78c962904f4ea11046f3db37c62e8a02fd' (2025-04-13)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/42a1c966be226125b48c384171c44c651c236c22' (2025-04-05)
  → 'github:NixOS/nixpkgs/2631b0b7abcea6e640ce31cd78ea58910d31e650' (2025-04-12)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/eda6606c9e4790ebe074d18ef074906a750f0d53' (2025-04-12)
  → 'github:nix-community/nix-vscode-extensions/39613bfde3de6dc2fa1ff208e46287f935618179' (2025-04-19)
• Updated input 'nixos-cosmic':
    'github:lilyinstarlight/nixos-cosmic/a76a451a2c97aa37a7741bdf8244ad91205776b8' (2025-04-12)
  → 'github:lilyinstarlight/nixos-cosmic/f5f0ab37d6935c232336f10b136f11a88c634b54' (2025-04-19)
• Updated input 'nixos-cosmic/nixpkgs':
    'github:NixOS/nixpkgs/f675531bc7e6657c10a18b565cfebd8aa9e24c14' (2025-04-09)
  → 'github:NixOS/nixpkgs/b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef' (2025-04-17)
• Updated input 'nixos-cosmic/nixpkgs-stable':
    'github:NixOS/nixpkgs/f9ebe33a928b5d529c895202263a5ce46bdf12f7' (2025-04-10)
  → 'github:NixOS/nixpkgs/26d499fc9f1d567283d5d56fcf367edd815dba1d' (2025-04-12)
• Updated input 'nixos-cosmic/rust-overlay':
    'github:oxalica/rust-overlay/4bb0b6dfc5bafa8b4e8dbe1170f051c437b2cb79' (2025-04-12)
  → 'github:oxalica/rust-overlay/50fefac8cdfd1587ac6d8678f6181e7d348201d2' (2025-04-19)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/f675531bc7e6657c10a18b565cfebd8aa9e24c14' (2025-04-09)
  → 'github:NixOS/nixpkgs/b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef' (2025-04-17)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/f9ebe33a928b5d529c895202263a5ce46bdf12f7' (2025-04-10)
  → 'github:NixOS/nixpkgs/26d499fc9f1d567283d5d56fcf367edd815dba1d' (2025-04-12)
• Updated input 'nur':
    'github:nix-community/NUR/96bc1373445beb864dd3564e09f0ca0b9d623a5a' (2025-04-12)
  → 'github:nix-community/NUR/9887318d5eae081b596a72bb9bdde8b5271ed8ab' (2025-04-19)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/f675531bc7e6657c10a18b565cfebd8aa9e24c14' (2025-04-09)
  → 'github:nixos/nixpkgs/b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef' (2025-04-17)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/4c4b9611c71d586ea818fa5b8dcbd81129f62560' (2025-04-12)
  → 'github:Gerg-L/spicetify-nix/c9093f2d516c5b62461844c06bf362db8e230ff9' (2025-04-19)
• Updated input 'stylix':
    'github:danth/stylix/ce45f19e8acb43e5f02888d873d451e2f994546b' (2025-04-10)
  → 'github:danth/stylix/8d5cd725ad591890c0cd804bf68cc842b8afca51' (2025-04-17)
```

Sources Changelog:
```
nix-fast-build: b01f2559cdcef1f9c42ce3cac324256bd2b7955d → 188b1f5c400c2349b6c4a1d130dc893d2b29f60c
rofi-bluetooth: 034b05f52e2f48e4e1f6ae19eae9f30e4a9e6791 → 0cca4d4aa1c82c9373ce5da781d73683a29484c6
```
