### PR TITLE
chore: update flake.lock & sources (2025-05-03)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -121,7 +121,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2025-04-18",
+        "date": "2025-05-02",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -133,12 +133,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "188b1f5c400c2349b6c4a1d130dc893d2b29f60c",
-            "sha256": "sha256-qiczbsj5lRZc/f0jHxADD0M32hxlPbrhNhWz3zx3MBg=",
+            "rev": "6bbdca2161834b917fe58b64c97156e99b39a839",
+            "sha256": "sha256-oPWNWwlv2odnrtX7s2J8WL+8ER2sTz2xphS+UKoWi0c=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "188b1f5c400c2349b6c4a1d130dc893d2b29f60c"
+        "version": "6bbdca2161834b917fe58b64c97156e99b39a839"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -75,15 +75,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "188b1f5c400c2349b6c4a1d130dc893d2b29f60c";
+    version = "6bbdca2161834b917fe58b64c97156e99b39a839";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "188b1f5c400c2349b6c4a1d130dc893d2b29f60c";
+      rev = "6bbdca2161834b917fe58b64c97156e99b39a839";
       fetchSubmodules = false;
-      sha256 = "sha256-qiczbsj5lRZc/f0jHxADD0M32hxlPbrhNhWz3zx3MBg=";
+      sha256 = "sha256-oPWNWwlv2odnrtX7s2J8WL+8ER2sTz2xphS+UKoWi0c=";
     };
-    date = "2025-04-18";
+    date = "2025-05-02";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -244,11 +244,11 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1717312683,
-        "narHash": "sha256-FrlieJH50AuvagamEvWMIE6D2OAnERuDboFDYAED/dE=",
+        "lastModified": 1746162366,
+        "narHash": "sha256-5SSSZ/oQkwfcAz/o/6TlejlVGqeK08wyREBQ5qFFPhM=",
         "owner": "nix-community",
         "repo": "flake-compat",
-        "rev": "38fd3954cf65ce6faf3d0d45cd26059e059f07ea",
+        "rev": "0f158086a2ecdbb138cd0429410e44994f1b7e4b",
         "type": "github"
       },
       "original": {
@@ -564,11 +564,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745627989,
-        "narHash": "sha256-mOCdFmxocBPae7wg7RYWOtJzWMJk34u9493ItY0dVqw=",
+        "lastModified": 1746287478,
+        "narHash": "sha256-z3HiHR2CNAdwyZTWPM2kkzhE1gD1G6ExPxkaiQfNh7s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4d2d32231797bfa7213ae5e8ac89d25f8caaae82",
+        "rev": "75268f62525920c4936404a056f37b91e299c97e",
         "type": "github"
       },
       "original": {
@@ -585,11 +585,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745439012,
-        "narHash": "sha256-TwbdiH28QK7Da2JQTqFHdb+UCJq6QbF2mtf+RxHVzEA=",
+        "lastModified": 1746040799,
+        "narHash": "sha256-osgPX/SzIpkR50vev/rqoTEAVkEcOWXoQXmbzsaI4KU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d31710fb2cd536b1966fee2af74e99a0816a61a8",
+        "rev": "5f217e5a319f6c186283b530f8c975e66c028433",
         "type": "github"
       },
       "original": {
@@ -604,11 +604,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1744513377,
-        "narHash": "sha256-2ocy+qAVxTBmaK8MpAy7mpKIH+DYEzwf+KzXZX83oZ4=",
+        "lastModified": 1745885816,
+        "narHash": "sha256-yuIb6/gGcII+2YgtTLcYdga0pcL63B18xQ/oitOhg7k=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "42943b3def85d8787d703778951944c8e791202b",
+        "rev": "0c82ce9704c8063be8d8f60443071c91943eb68c",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1745120797,
-        "narHash": "sha256-owQ0VQ+7cSanTVPxaZMWEzI22Q4bGnuvhVjLAJBNQ3E=",
+        "lastModified": 1746054057,
+        "narHash": "sha256-iR+idGZJ191cY6NBXyVjh9QH8GVWTkvZw/w+1Igy45A=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "69716041f881a2af935021c1182ed5b0cc04d40e",
+        "rev": "13ba07d54c6ccc5af30a501df669bf3fe3dd4db8",
         "type": "github"
       },
       "original": {
@@ -704,11 +704,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1745632325,
-        "narHash": "sha256-0i5Gkz0sPN/l4hL0PidIq43cLRpO/UsGcYiPm7e12uQ=",
+        "lastModified": 1746237288,
+        "narHash": "sha256-WQtv6pHrqM74ziWX0mNAAea6MyTfM/4zAcBjNyGCHLE=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "3ce03dadc2c5976a8f0f08c12d1e391006d7fa55",
+        "rev": "4e52024534f1059a470fa64c654553097139802f",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1745665695,
-        "narHash": "sha256-oUFoPmT2/ww1bIU0Vmifx9BdarVqlv9MyEIxUTqYJnM=",
+        "lastModified": 1746270539,
+        "narHash": "sha256-TEJGIS4DALrsnU4599WR+XUD67EEY8LeOXcHnMreKw0=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "48280c3737fee2db3a1226c297c86428417f552d",
+        "rev": "4a755a6886b93fd8410782172e2356fef0eadccc",
         "type": "github"
       },
       "original": {
@@ -787,11 +787,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1745487689,
-        "narHash": "sha256-FQoi3R0NjQeBAsEOo49b5tbDPcJSMWc3QhhaIi9eddw=",
+        "lastModified": 1746183838,
+        "narHash": "sha256-kwaaguGkAqTZ1oK0yXeQ3ayYjs8u/W7eEfrFpFfIDFA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5630cf13cceac06cefe9fc607e8dfa8fb342dde3",
+        "rev": "bf3287dac860542719fe7554e21e686108716879",
         "type": "github"
       },
       "original": {
@@ -803,11 +803,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1745487689,
-        "narHash": "sha256-FQoi3R0NjQeBAsEOo49b5tbDPcJSMWc3QhhaIi9eddw=",
+        "lastModified": 1746183838,
+        "narHash": "sha256-kwaaguGkAqTZ1oK0yXeQ3ayYjs8u/W7eEfrFpFfIDFA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5630cf13cceac06cefe9fc607e8dfa8fb342dde3",
+        "rev": "bf3287dac860542719fe7554e21e686108716879",
         "type": "github"
       },
       "original": {
@@ -819,11 +819,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1744932701,
-        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
+        "lastModified": 1745526057,
+        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
         "type": "github"
       },
       "original": {
@@ -851,11 +851,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1745526057,
-        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
+        "lastModified": 1746141548,
+        "narHash": "sha256-IgBWhX7A2oJmZFIrpRuMnw5RAufVnfvOgHWgIdds+hc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
+        "rev": "f02fddb8acef29a8b32f10a335d44828d7825b78",
         "type": "github"
       },
       "original": {
@@ -867,11 +867,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1745526057,
-        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
+        "lastModified": 1746141548,
+        "narHash": "sha256-IgBWhX7A2oJmZFIrpRuMnw5RAufVnfvOgHWgIdds+hc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
+        "rev": "f02fddb8acef29a8b32f10a335d44828d7825b78",
         "type": "github"
       },
       "original": {
@@ -883,11 +883,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1745526057,
-        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
+        "lastModified": 1746141548,
+        "narHash": "sha256-IgBWhX7A2oJmZFIrpRuMnw5RAufVnfvOgHWgIdds+hc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
+        "rev": "f02fddb8acef29a8b32f10a335d44828d7825b78",
         "type": "github"
       },
       "original": {
@@ -899,11 +899,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1745234285,
-        "narHash": "sha256-GfpyMzxwkfgRVN0cTGQSkTC0OHhEkv3Jf6Tcjm//qZ0=",
+        "lastModified": 1745930157,
+        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c11863f1e964833214b767f4a369c6e6a7aba141",
+        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1745682319,
-        "narHash": "sha256-IlE76lRii+1dkx9HgW3rPV74xhzwxOpkKwlKTQ8HK0g=",
+        "lastModified": 1746290006,
+        "narHash": "sha256-LKvcXXMvyekIr+kOi1Yb641HQNtUuXR1EBtquduZDPY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab9706bb0ab297103c804f1367585aaa3455a92b",
+        "rev": "ad9a7c554a3cacc9bfc168afe847cfc4c8fab966",
         "type": "github"
       },
       "original": {
@@ -943,11 +943,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745459908,
-        "narHash": "sha256-bWqgohVf/py9EW3bLS/dYbenD2p9N2/Qsw1+CJk1S04=",
+        "lastModified": 1746056780,
+        "narHash": "sha256-/emueQGaoT4vu0QjU9LDOG5roxRSfdY0K2KkxuzazcM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dbc4ba3233b2bf951521177bf0ee0a7679959035",
+        "rev": "d476cd0972dd6242d76374fcc277e6735715c167",
         "type": "github"
       },
       "original": {
@@ -1058,11 +1058,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745634793,
-        "narHash": "sha256-8AuOyfLNlcbLy0AqERSNUUoDdY+3THZI7+9VrXUfGqg=",
+        "lastModified": 1746239644,
+        "narHash": "sha256-wMvMBMlpS1H8CQdSSgpLeoCWS67ciEkN/GVCcwk7Apc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f1aeaeb91ba9c88f235ab82bd23d7a4931fe736c",
+        "rev": "bd32e88bef6da0e021a42fb4120a8df2150e9b8c",
         "type": "github"
       },
       "original": {
@@ -1079,11 +1079,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1745151211,
-        "narHash": "sha256-qFXfTdO1yvW6DmUPfVLIJgDHfkSd5yimZWvBMrlP/ow=",
+        "lastModified": 1746287507,
+        "narHash": "sha256-XzxmpEUbCXcBS7H00QmTAQf9xrMdvaFHrprkwb4i9CU=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "1dd4328f82115887901a685ecd9fa6e1d1db2d0c",
+        "rev": "c09c8cbc0d650d451e4b48d00c63831437dae1b2",
         "type": "github"
       },
       "original": {
@@ -1114,11 +1114,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745618823,
-        "narHash": "sha256-WGKSI0+CY3Ep2YnRASmBRU8oMIvTW4ngFyjA0dVcKgQ=",
+        "lastModified": 1746223791,
+        "narHash": "sha256-R/DWYbY+Yr/QULujNlozfBUU2s9nZPoRikjIGPTYcR8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "11ceb2fde1901dc227421bbbef2d0800339f5126",
+        "rev": "953e7247ac340e5036f8af47eaccf1a23f1a0257",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 18

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/4d2d32231797bfa7213ae5e8ac89d25f8caaae82' (2025-04-26)
  → 'github:nix-community/home-manager/75268f62525920c4936404a056f37b91e299c97e' (2025-05-03)
• Updated input 'hyprpanel':
    'github:Jas-SinghFSU/HyprPanel/42943b3def85d8787d703778951944c8e791202b' (2025-04-13)
  → 'github:Jas-SinghFSU/HyprPanel/0c82ce9704c8063be8d8f60443071c91943eb68c' (2025-04-29)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/69716041f881a2af935021c1182ed5b0cc04d40e' (2025-04-20)
  → 'github:nix-community/nix-index-database/13ba07d54c6ccc5af30a501df669bf3fe3dd4db8' (2025-04-30)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef' (2025-04-17)
  → 'github:NixOS/nixpkgs/f771eb401a46846c1aebd20552521b233dd7e18b' (2025-04-24)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/3ce03dadc2c5976a8f0f08c12d1e391006d7fa55' (2025-04-26)
  → 'github:nix-community/nix-vscode-extensions/4e52024534f1059a470fa64c654553097139802f' (2025-05-03)
• Updated input 'nixos-cosmic':
    'github:lilyinstarlight/nixos-cosmic/48280c3737fee2db3a1226c297c86428417f552d' (2025-04-26)
  → 'github:lilyinstarlight/nixos-cosmic/4a755a6886b93fd8410782172e2356fef0eadccc' (2025-05-03)
• Updated input 'nixos-cosmic/flake-compat':
    'github:nix-community/flake-compat/38fd3954cf65ce6faf3d0d45cd26059e059f07ea' (2024-06-02)
  → 'github:nix-community/flake-compat/0f158086a2ecdbb138cd0429410e44994f1b7e4b' (2025-05-02)
• Updated input 'nixos-cosmic/nixpkgs':
    'github:NixOS/nixpkgs/f771eb401a46846c1aebd20552521b233dd7e18b' (2025-04-24)
  → 'github:NixOS/nixpkgs/f02fddb8acef29a8b32f10a335d44828d7825b78' (2025-05-01)
• Updated input 'nixos-cosmic/nixpkgs-stable':
    'github:NixOS/nixpkgs/5630cf13cceac06cefe9fc607e8dfa8fb342dde3' (2025-04-24)
  → 'github:NixOS/nixpkgs/bf3287dac860542719fe7554e21e686108716879' (2025-05-02)
• Updated input 'nixos-cosmic/rust-overlay':
    'github:oxalica/rust-overlay/f1aeaeb91ba9c88f235ab82bd23d7a4931fe736c' (2025-04-26)
  → 'github:oxalica/rust-overlay/bd32e88bef6da0e021a42fb4120a8df2150e9b8c' (2025-05-03)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/f771eb401a46846c1aebd20552521b233dd7e18b' (2025-04-24)
  → 'github:NixOS/nixpkgs/f02fddb8acef29a8b32f10a335d44828d7825b78' (2025-05-01)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/5630cf13cceac06cefe9fc607e8dfa8fb342dde3' (2025-04-24)
  → 'github:NixOS/nixpkgs/bf3287dac860542719fe7554e21e686108716879' (2025-05-02)
• Updated input 'nur':
    'github:nix-community/NUR/ab9706bb0ab297103c804f1367585aaa3455a92b' (2025-04-26)
  → 'github:nix-community/NUR/ad9a7c554a3cacc9bfc168afe847cfc4c8fab966' (2025-05-03)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/f771eb401a46846c1aebd20552521b233dd7e18b' (2025-04-24)
  → 'github:nixos/nixpkgs/f02fddb8acef29a8b32f10a335d44828d7825b78' (2025-05-01)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/1dd4328f82115887901a685ecd9fa6e1d1db2d0c' (2025-04-20)
  → 'github:Gerg-L/spicetify-nix/c09c8cbc0d650d451e4b48d00c63831437dae1b2' (2025-05-03)
• Updated input 'stylix':
    'github:danth/stylix/11ceb2fde1901dc227421bbbef2d0800339f5126' (2025-04-25)
  → 'github:danth/stylix/953e7247ac340e5036f8af47eaccf1a23f1a0257' (2025-05-02)
• Updated input 'stylix/home-manager':
    'github:nix-community/home-manager/d31710fb2cd536b1966fee2af74e99a0816a61a8' (2025-04-23)
  → 'github:nix-community/home-manager/5f217e5a319f6c186283b530f8c975e66c028433' (2025-04-30)
• Updated input 'stylix/nixpkgs':
    'github:NixOS/nixpkgs/c11863f1e964833214b767f4a369c6e6a7aba141' (2025-04-21)
  → 'github:NixOS/nixpkgs/46e634be05ce9dc6d4db8e664515ba10b78151ae' (2025-04-29)
• Updated input 'stylix/nur':
    'github:nix-community/NUR/dbc4ba3233b2bf951521177bf0ee0a7679959035' (2025-04-24)
  → 'github:nix-community/NUR/d476cd0972dd6242d76374fcc277e6735715c167' (2025-04-30)
```

Sources Changelog:
```
nix-fast-build: 188b1f5c400c2349b6c4a1d130dc893d2b29f60c → 6bbdca2161834b917fe58b64c97156e99b39a839
```
