### PR TITLE
chore: update flake.lock & sources (2025-05-10)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -121,7 +121,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2025-05-02",
+        "date": "2025-05-10",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -133,12 +133,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "6bbdca2161834b917fe58b64c97156e99b39a839",
-            "sha256": "sha256-oPWNWwlv2odnrtX7s2J8WL+8ER2sTz2xphS+UKoWi0c=",
+            "rev": "a803b722190a857768b06b4a804aee53c26ee49b",
+            "sha256": "sha256-44GrKkww1p4XOANN2WpXonMsnP8+SPi4wrvERWCSb7g=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "6bbdca2161834b917fe58b64c97156e99b39a839"
+        "version": "a803b722190a857768b06b4a804aee53c26ee49b"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -75,15 +75,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "6bbdca2161834b917fe58b64c97156e99b39a839";
+    version = "a803b722190a857768b06b4a804aee53c26ee49b";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "6bbdca2161834b917fe58b64c97156e99b39a839";
+      rev = "a803b722190a857768b06b4a804aee53c26ee49b";
       fetchSubmodules = false;
-      sha256 = "sha256-oPWNWwlv2odnrtX7s2J8WL+8ER2sTz2xphS+UKoWi0c=";
+      sha256 = "sha256-44GrKkww1p4XOANN2WpXonMsnP8+SPi4wrvERWCSb7g=";
     };
-    date = "2025-05-02";
+    date = "2025-05-10";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -436,11 +436,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742649964,
-        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
+        "lastModified": 1746537231,
+        "narHash": "sha256-Wb2xeSyOsCoTCTj7LOoD6cdKLEROyFAArnYoS+noCWo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
+        "rev": "fa466640195d38ec97cf0493d6d6882bc4d14969",
         "type": "github"
       },
       "original": {
@@ -564,11 +564,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746287478,
-        "narHash": "sha256-z3HiHR2CNAdwyZTWPM2kkzhE1gD1G6ExPxkaiQfNh7s=",
+        "lastModified": 1746892839,
+        "narHash": "sha256-0b9us0bIOgA1j/s/6zlxVyP3m97yAh0U+YwKayJ6mmU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "75268f62525920c4936404a056f37b91e299c97e",
+        "rev": "12e67385964d9c9304daa81d0ad5ba3b01fdd35e",
         "type": "github"
       },
       "original": {
@@ -585,11 +585,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746040799,
-        "narHash": "sha256-osgPX/SzIpkR50vev/rqoTEAVkEcOWXoQXmbzsaI4KU=",
+        "lastModified": 1746369725,
+        "narHash": "sha256-m3ai7LLFYsymMK0uVywCceWfUhP0k3CALyFOfcJACqE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5f217e5a319f6c186283b530f8c975e66c028433",
+        "rev": "1a1793f6d940d22c6e49753548c5b6cb7dc5545d",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1746054057,
-        "narHash": "sha256-iR+idGZJ191cY6NBXyVjh9QH8GVWTkvZw/w+1Igy45A=",
+        "lastModified": 1746330942,
+        "narHash": "sha256-ShizFaJCAST23tSrHHtFFGF0fwd72AG+KhPZFFQX/0o=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "13ba07d54c6ccc5af30a501df669bf3fe3dd4db8",
+        "rev": "137fd2bd726fff343874f85601b51769b48685cc",
         "type": "github"
       },
       "original": {
@@ -704,11 +704,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1746237288,
-        "narHash": "sha256-WQtv6pHrqM74ziWX0mNAAea6MyTfM/4zAcBjNyGCHLE=",
+        "lastModified": 1746842090,
+        "narHash": "sha256-W/WqQ8VGZ4tlV6BAFGY6BDEc5ShAm4i3pv5c3s3YlUI=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "4e52024534f1059a470fa64c654553097139802f",
+        "rev": "5603fb6fb99f68dfc244429c79a7b706ed9a2fd7",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1746270539,
-        "narHash": "sha256-TEJGIS4DALrsnU4599WR+XUD67EEY8LeOXcHnMreKw0=",
+        "lastModified": 1746875335,
+        "narHash": "sha256-hPoOSOPSK9UHZJQ87WO9s7eZbVJYvwfYv1PSPUtIQNo=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "4a755a6886b93fd8410782172e2356fef0eadccc",
+        "rev": "0e3779afdf0ef51958071b151fc11dc74bb8971c",
         "type": "github"
       },
       "original": {
@@ -787,11 +787,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1746183838,
-        "narHash": "sha256-kwaaguGkAqTZ1oK0yXeQ3ayYjs8u/W7eEfrFpFfIDFA=",
+        "lastModified": 1746557022,
+        "narHash": "sha256-QkNoyEf6TbaTW5UZYX0OkwIJ/ZMeKSSoOMnSDPQuol0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf3287dac860542719fe7554e21e686108716879",
+        "rev": "1d3aeb5a193b9ff13f63f4d9cc169fb88129f860",
         "type": "github"
       },
       "original": {
@@ -803,11 +803,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1746183838,
-        "narHash": "sha256-kwaaguGkAqTZ1oK0yXeQ3ayYjs8u/W7eEfrFpFfIDFA=",
+        "lastModified": 1746557022,
+        "narHash": "sha256-QkNoyEf6TbaTW5UZYX0OkwIJ/ZMeKSSoOMnSDPQuol0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf3287dac860542719fe7554e21e686108716879",
+        "rev": "1d3aeb5a193b9ff13f63f4d9cc169fb88129f860",
         "type": "github"
       },
       "original": {
@@ -819,11 +819,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1745526057,
-        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
+        "lastModified": 1746232882,
+        "narHash": "sha256-MHmBH2rS8KkRRdoU/feC/dKbdlMkcNkB5mwkuipVHeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
+        "rev": "7a2622e2c0dbad5c4493cb268aba12896e28b008",
         "type": "github"
       },
       "original": {
@@ -851,11 +851,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1746141548,
-        "narHash": "sha256-IgBWhX7A2oJmZFIrpRuMnw5RAufVnfvOgHWgIdds+hc=",
+        "lastModified": 1746663147,
+        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f02fddb8acef29a8b32f10a335d44828d7825b78",
+        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
         "type": "github"
       },
       "original": {
@@ -867,11 +867,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1746141548,
-        "narHash": "sha256-IgBWhX7A2oJmZFIrpRuMnw5RAufVnfvOgHWgIdds+hc=",
+        "lastModified": 1746663147,
+        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f02fddb8acef29a8b32f10a335d44828d7825b78",
+        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
         "type": "github"
       },
       "original": {
@@ -883,11 +883,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1746141548,
-        "narHash": "sha256-IgBWhX7A2oJmZFIrpRuMnw5RAufVnfvOgHWgIdds+hc=",
+        "lastModified": 1746663147,
+        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f02fddb8acef29a8b32f10a335d44828d7825b78",
+        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746290006,
-        "narHash": "sha256-LKvcXXMvyekIr+kOi1Yb641HQNtUuXR1EBtquduZDPY=",
+        "lastModified": 1746891953,
+        "narHash": "sha256-b6HsBJE89zHycJsySw9+OBU0poOKHZa5Cx5eTBK0PMs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ad9a7c554a3cacc9bfc168afe847cfc4c8fab966",
+        "rev": "446ac67ac64b09be155b53a203dd0051755b48a6",
         "type": "github"
       },
       "original": {
@@ -1058,11 +1058,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746239644,
-        "narHash": "sha256-wMvMBMlpS1H8CQdSSgpLeoCWS67ciEkN/GVCcwk7Apc=",
+        "lastModified": 1746844454,
+        "narHash": "sha256-GcUWDQUDRYrD34ol90KGUpjbVcOfUNbv0s955jPecko=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bd32e88bef6da0e021a42fb4120a8df2150e9b8c",
+        "rev": "be092436d4c0c303b654e4007453b69c0e33009e",
         "type": "github"
       },
       "original": {
@@ -1079,11 +1079,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1746287507,
-        "narHash": "sha256-XzxmpEUbCXcBS7H00QmTAQf9xrMdvaFHrprkwb4i9CU=",
+        "lastModified": 1746738008,
+        "narHash": "sha256-bIMysaVhNyjuFgt8QpnGZv0T4YMao26Vz5R/xfYAJO0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "c09c8cbc0d650d451e4b48d00c63831437dae1b2",
+        "rev": "a43fae27f33f8d3e793a6ca2946190cb24a00b03",
         "type": "github"
       },
       "original": {
@@ -1114,11 +1114,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746223791,
-        "narHash": "sha256-R/DWYbY+Yr/QULujNlozfBUU2s9nZPoRikjIGPTYcR8=",
+        "lastModified": 1746875263,
+        "narHash": "sha256-WhcWBF8c7l9LoLQ18n9NjuvCBF5WJ6c2DemDTZgGKsI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "953e7247ac340e5036f8af47eaccf1a23f1a0257",
+        "rev": "1c71f3bde228f7b17c1aad75f2b97276daf8db42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 19

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/dcf5072734cb576d2b0c59b2ac44f5050b5eac82' (2025-03-22)
  → 'github:cachix/git-hooks.nix/fa466640195d38ec97cf0493d6d6882bc4d14969' (2025-05-06)
• Updated input 'home-manager':
    'github:nix-community/home-manager/75268f62525920c4936404a056f37b91e299c97e' (2025-05-03)
  → 'github:nix-community/home-manager/12e67385964d9c9304daa81d0ad5ba3b01fdd35e' (2025-05-10)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/13ba07d54c6ccc5af30a501df669bf3fe3dd4db8' (2025-04-30)
  → 'github:nix-community/nix-index-database/137fd2bd726fff343874f85601b51769b48685cc' (2025-05-04)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/f771eb401a46846c1aebd20552521b233dd7e18b' (2025-04-24)
  → 'github:NixOS/nixpkgs/7a2622e2c0dbad5c4493cb268aba12896e28b008' (2025-05-03)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/4e52024534f1059a470fa64c654553097139802f' (2025-05-03)
  → 'github:nix-community/nix-vscode-extensions/5603fb6fb99f68dfc244429c79a7b706ed9a2fd7' (2025-05-10)
• Updated input 'nixos-cosmic':
    'github:lilyinstarlight/nixos-cosmic/4a755a6886b93fd8410782172e2356fef0eadccc' (2025-05-03)
  → 'github:lilyinstarlight/nixos-cosmic/0e3779afdf0ef51958071b151fc11dc74bb8971c' (2025-05-10)
• Updated input 'nixos-cosmic/nixpkgs':
    'github:NixOS/nixpkgs/f02fddb8acef29a8b32f10a335d44828d7825b78' (2025-05-01)
  → 'github:NixOS/nixpkgs/dda3dcd3fe03e991015e9a74b22d35950f264a54' (2025-05-08)
• Updated input 'nixos-cosmic/nixpkgs-stable':
    'github:NixOS/nixpkgs/bf3287dac860542719fe7554e21e686108716879' (2025-05-02)
  → 'github:NixOS/nixpkgs/1d3aeb5a193b9ff13f63f4d9cc169fb88129f860' (2025-05-06)
• Updated input 'nixos-cosmic/rust-overlay':
    'github:oxalica/rust-overlay/bd32e88bef6da0e021a42fb4120a8df2150e9b8c' (2025-05-03)
  → 'github:oxalica/rust-overlay/be092436d4c0c303b654e4007453b69c0e33009e' (2025-05-10)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/f02fddb8acef29a8b32f10a335d44828d7825b78' (2025-05-01)
  → 'github:NixOS/nixpkgs/dda3dcd3fe03e991015e9a74b22d35950f264a54' (2025-05-08)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/bf3287dac860542719fe7554e21e686108716879' (2025-05-02)
  → 'github:NixOS/nixpkgs/1d3aeb5a193b9ff13f63f4d9cc169fb88129f860' (2025-05-06)
• Updated input 'nur':
    'github:nix-community/NUR/ad9a7c554a3cacc9bfc168afe847cfc4c8fab966' (2025-05-03)
  → 'github:nix-community/NUR/446ac67ac64b09be155b53a203dd0051755b48a6' (2025-05-10)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/f02fddb8acef29a8b32f10a335d44828d7825b78' (2025-05-01)
  → 'github:nixos/nixpkgs/dda3dcd3fe03e991015e9a74b22d35950f264a54' (2025-05-08)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/c09c8cbc0d650d451e4b48d00c63831437dae1b2' (2025-05-03)
  → 'github:Gerg-L/spicetify-nix/a43fae27f33f8d3e793a6ca2946190cb24a00b03' (2025-05-08)
• Updated input 'stylix':
    'github:danth/stylix/953e7247ac340e5036f8af47eaccf1a23f1a0257' (2025-05-02)
  → 'github:danth/stylix/1c71f3bde228f7b17c1aad75f2b97276daf8db42' (2025-05-10)
• Updated input 'stylix/home-manager':
    'github:nix-community/home-manager/5f217e5a319f6c186283b530f8c975e66c028433' (2025-04-30)
  → 'github:nix-community/home-manager/1a1793f6d940d22c6e49753548c5b6cb7dc5545d' (2025-05-04)
```

Sources Changelog:
```
nix-fast-build: 6bbdca2161834b917fe58b64c97156e99b39a839 → a803b722190a857768b06b4a804aee53c26ee49b
```
