### PR TITLE
chore: update flake.lock & sources (2025-05-24)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -121,7 +121,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2025-05-17",
+        "date": "2025-05-24",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -133,12 +133,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "765c14ec198730fd1b0648078da6d6dfe9e11d51",
-            "sha256": "sha256-9rJA5yrv4tkhRZdDaCE4sX8MRzLMUk0HSU6koXGD1P8=",
+            "rev": "5f5ff111255393c6ff3bca40fbd627f039aa8eb8",
+            "sha256": "sha256-yk2H78SmFgSSxEHzBWFtIgwZrE57wQODUMUvTou6scQ=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "765c14ec198730fd1b0648078da6d6dfe9e11d51"
+        "version": "5f5ff111255393c6ff3bca40fbd627f039aa8eb8"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -75,15 +75,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "765c14ec198730fd1b0648078da6d6dfe9e11d51";
+    version = "5f5ff111255393c6ff3bca40fbd627f039aa8eb8";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "765c14ec198730fd1b0648078da6d6dfe9e11d51";
+      rev = "5f5ff111255393c6ff3bca40fbd627f039aa8eb8";
       fetchSubmodules = false;
-      sha256 = "sha256-9rJA5yrv4tkhRZdDaCE4sX8MRzLMUk0HSU6koXGD1P8=";
+      sha256 = "sha256-yk2H78SmFgSSxEHzBWFtIgwZrE57wQODUMUvTou6scQ=";
     };
-    date = "2025-05-17";
+    date = "2025-05-24";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1745630506,
-        "narHash": "sha256-bHCFgGeu8XjWlVuaWzi3QONjDW3coZDqSHvnd4l7xus=",
+        "lastModified": 1747575206,
+        "narHash": "sha256-NwmAFuDUO/PFcgaGGr4j3ozG9Pe5hZ/ogitWhY+D81k=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "96e078c646b711aee04b82ba01aefbff87004ded",
+        "rev": "4835b1dc898959d8547a871ef484930675cb47f1",
         "type": "github"
       },
       "original": {
@@ -521,16 +521,16 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "lastModified": 1732369855,
-        "narHash": "sha256-JhUWbcYPjHO3Xs3x9/Z9RuqXbcp5yhPluGjwsdE2GMg=",
+        "lastModified": 1744584021,
+        "narHash": "sha256-0RJ4mJzf+klKF4Fuoc8VN8dpQQtZnKksFmR2jhWE1Ew=",
         "owner": "GNOME",
         "repo": "gnome-shell",
-        "rev": "dadd58f630eeea41d645ee225a63f719390829dc",
+        "rev": "52c517c8f6c199a1d6f5118fae500ef69ea845ae",
         "type": "github"
       },
       "original": {
         "owner": "GNOME",
-        "ref": "47.2",
+        "ref": "48.1",
         "repo": "gnome-shell",
         "type": "github"
       }
@@ -542,11 +542,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747439237,
-        "narHash": "sha256-5rCGrnkglKKj4cav1U3HC+SIUNJh08pqOK4spQv9RjA=",
+        "lastModified": 1747978958,
+        "narHash": "sha256-pQQnbxWpY3IiZqgelXHIe/OAE/Yv4NSQq7fch7M6nXQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ae755329092c87369b9e9a1510a8cf1ce2b1c708",
+        "rev": "7419250703fd5eb50e99bdfb07a86671939103ea",
         "type": "github"
       },
       "original": {
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747279714,
-        "narHash": "sha256-UdxlE8yyrKiGq3bgGyJ78AdFwh+fuRAruKtyFY5Zq5I=",
+        "lastModified": 1747763032,
+        "narHash": "sha256-9j3oCbemeH7bTVXJ3pDWxOptbxDx2SdK1jY2AHpjQiw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "954615c510c9faa3ee7fb6607ff72e55905e69f2",
+        "rev": "29dda415f5b2178278283856c6f9f7b48a2a4353",
         "type": "github"
       },
       "original": {
@@ -582,11 +582,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1747029715,
-        "narHash": "sha256-F75IlhzUF+VTPOq+u2Exj+6PjHWPkLcBWDnhO+Vvch4=",
+        "lastModified": 1747531721,
+        "narHash": "sha256-kx7hCuML0sMcjbyjbpplNWsJjLoUfiy23JiS9aG4UWw=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "2bb1449fb6ad60a736ce6fb4de2037d7655545ed",
+        "rev": "c203ffe80f4e7b68e22ba3fde0598622500f5add",
         "type": "github"
       },
       "original": {
@@ -663,11 +663,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1747470409,
-        "narHash": "sha256-R9TP2//BDKyjNzuZybplIZm7HQEnwL8khs7EmmTPYP4=",
+        "lastModified": 1747540584,
+        "narHash": "sha256-cxCQ413JTUuRv9Ygd8DABJ1D6kuB/nTfQqC0Lu9C0ls=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "c1f63a0c3bf1b2fe05124ccb099333163e2184a7",
+        "rev": "ec179dd13fb7b4c6844f55be91436f7857226dce",
         "type": "github"
       },
       "original": {
@@ -682,11 +682,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1747446936,
-        "narHash": "sha256-O5HLvg27oWAUHaZvAK8p30whJLlZSAUWMu7RZwWwX/0=",
+        "lastModified": 1748051778,
+        "narHash": "sha256-pl9Z5MqH7/ZzsOWp15gEr59xno+qvD55spV93eiYt8M=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "c23c72f97fc61391f9022f5f426c1b737b2d639a",
+        "rev": "f1f3c539c5a9513bece912574f4aaf6f0d9937f2",
         "type": "github"
       },
       "original": {
@@ -703,11 +703,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1747491978,
-        "narHash": "sha256-Jn7um1fnf2bI9N8gvG5jIHvIJxxLaXd+2+wHXyW0Frs=",
+        "lastModified": 1748084900,
+        "narHash": "sha256-XxVAY/U3qloh2gCy8T8aBj6lXu6DOAX5wH7cTg1QSkE=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "2a7be063557ffc19ab1d8ab18bfd1721df8355c5",
+        "rev": "d01c1a4044129f6eddb944f4d71a84e07c139eba",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1747335874,
-        "narHash": "sha256-IKKIXTSYJMmUtE+Kav5Rob8SgLPnfnq4Qu8LyT4gdqQ=",
+        "lastModified": 1747862697,
+        "narHash": "sha256-U4HaNZ1W26cbOVm0Eb5OdGSnfQVWQKbLSPrSSa78KC0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ba8b70ee098bc5654c459d6a95dfc498b91ff858",
+        "rev": "2baa12ff69913392faf0ace833bc54bba297ea95",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1747335874,
-        "narHash": "sha256-IKKIXTSYJMmUtE+Kav5Rob8SgLPnfnq4Qu8LyT4gdqQ=",
+        "lastModified": 1747862697,
+        "narHash": "sha256-U4HaNZ1W26cbOVm0Eb5OdGSnfQVWQKbLSPrSSa78KC0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ba8b70ee098bc5654c459d6a95dfc498b91ff858",
+        "rev": "2baa12ff69913392faf0ace833bc54bba297ea95",
         "type": "github"
       },
       "original": {
@@ -797,11 +797,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1746663147,
-        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
+        "lastModified": 1747327360,
+        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
+        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
         "type": "github"
       },
       "original": {
@@ -829,11 +829,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1747327360,
-        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
         "type": "github"
       },
       "original": {
@@ -845,11 +845,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1747327360,
-        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
         "type": "github"
       },
       "original": {
@@ -861,11 +861,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1747327360,
-        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
         "type": "github"
       },
       "original": {
@@ -877,11 +877,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1745930157,
-        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
+        "lastModified": 1747542820,
+        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
+        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
         "type": "github"
       },
       "original": {
@@ -898,11 +898,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747496753,
-        "narHash": "sha256-ndhvbPh4IN8iSjZv7LWAYtih51fyyjYO+f5HMltyriE=",
+        "lastModified": 1748102975,
+        "narHash": "sha256-zQzJr6UCGWTgqilMO8DJcsZpUhYDEz00hSvMTUVOMm8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c5e5d707419de9e849e1b6ca3013c83f07228e92",
+        "rev": "39b6399ac8e5307a7d39d6cc6800dea06c3366e5",
         "type": "github"
       },
       "original": {
@@ -1039,11 +1039,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747449297,
-        "narHash": "sha256-veyXchTz6eWwvuW5X49UluHkheHkFcqHJSwGuKBhrmQ=",
+        "lastModified": 1748054080,
+        "narHash": "sha256-rwFiLLNCwkj9bqePtH1sMqzs1xmohE0Ojq249piMzF4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f44db7d7cea4528288780c6347756173a8248225",
+        "rev": "2221d8d53c128beb69346fa3ab36da3f19bb1691",
         "type": "github"
       },
       "original": {
@@ -1060,11 +1060,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1747355848,
-        "narHash": "sha256-WpOTfGuObhpaI38+uHgaOwnMAjHMrdLrfs6D35fKwjk=",
+        "lastModified": 1747607404,
+        "narHash": "sha256-xj2Ji+rE+oYjf0BsTDT7K/StnYuZQK9MTbX8U1DUcC0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "a2bc0d49449fc61ca2eb364d6189179059394483",
+        "rev": "8c1be0e5e9a7f35ccd6f7b10bcfa08f2734dad91",
         "type": "github"
       },
       "original": {
@@ -1095,11 +1095,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747441332,
-        "narHash": "sha256-On+cwR/dMW9s+YWsYifIaRs18nNyK5HVFJav6HsRrU8=",
+        "lastModified": 1748028561,
+        "narHash": "sha256-IgtJU6n9vR3nBUdcXrc7K9E+Y/G/4P6hFifGRr1tXMU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "101d23dfacbb2704c40639ae9b6ac1d41de7143a",
+        "rev": "34b5930894d8315401d93bd8a9a6635e1cd28eff",
         "type": "github"
       },
       "original": {
@@ -1218,17 +1218,16 @@
     "tinted-kitty": {
       "flake": false,
       "locked": {
-        "lastModified": 1716423189,
-        "narHash": "sha256-2xF3sH7UIwegn+2gKzMpFi3pk5DlIlM18+vj17Uf82U=",
+        "lastModified": 1735730497,
+        "narHash": "sha256-4KtB+FiUzIeK/4aHCKce3V9HwRvYaxX+F1edUrfgzb8=",
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "eb39e141db14baef052893285df9f266df041ff8",
+        "rev": "de6f888497f2c6b2279361bfc790f164bfd0f3fa",
         "type": "github"
       },
       "original": {
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "eb39e141db14baef052893285df9f266df041ff8",
         "type": "github"
       }
     },


### PR DESCRIPTION
Automated Pull Request for Week 21

Flakes Changelog:
```
• Updated input 'agenix':
    'github:ryantm/agenix/96e078c646b711aee04b82ba01aefbff87004ded' (2025-04-26)
  → 'github:ryantm/agenix/4835b1dc898959d8547a871ef484930675cb47f1' (2025-05-18)
• Updated input 'home-manager':
    'github:nix-community/home-manager/ae755329092c87369b9e9a1510a8cf1ce2b1c708' (2025-05-16)
  → 'github:nix-community/home-manager/7419250703fd5eb50e99bdfb07a86671939103ea' (2025-05-23)
• Updated input 'hyprpanel':
    'github:Jas-SinghFSU/HyprPanel/2bb1449fb6ad60a736ce6fb4de2037d7655545ed' (2025-05-12)
  → 'github:Jas-SinghFSU/HyprPanel/c203ffe80f4e7b68e22ba3fde0598622500f5add' (2025-05-18)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/c1f63a0c3bf1b2fe05124ccb099333163e2184a7' (2025-05-17)
  → 'github:nix-community/nix-index-database/ec179dd13fb7b4c6844f55be91436f7857226dce' (2025-05-18)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/dda3dcd3fe03e991015e9a74b22d35950f264a54' (2025-05-08)
  → 'github:NixOS/nixpkgs/e06158e58f3adee28b139e9c2bcfcc41f8625b46' (2025-05-15)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/c23c72f97fc61391f9022f5f426c1b737b2d639a' (2025-05-17)
  → 'github:nix-community/nix-vscode-extensions/f1f3c539c5a9513bece912574f4aaf6f0d9937f2' (2025-05-24)
• Updated input 'nixos-cosmic':
    'github:lilyinstarlight/nixos-cosmic/2a7be063557ffc19ab1d8ab18bfd1721df8355c5' (2025-05-17)
  → 'github:lilyinstarlight/nixos-cosmic/d01c1a4044129f6eddb944f4d71a84e07c139eba' (2025-05-24)
• Updated input 'nixos-cosmic/nixpkgs':
    'github:NixOS/nixpkgs/e06158e58f3adee28b139e9c2bcfcc41f8625b46' (2025-05-15)
  → 'github:NixOS/nixpkgs/2795c506fe8fb7b03c36ccb51f75b6df0ab2553f' (2025-05-20)
• Updated input 'nixos-cosmic/nixpkgs-stable':
    'github:NixOS/nixpkgs/ba8b70ee098bc5654c459d6a95dfc498b91ff858' (2025-05-15)
  → 'github:NixOS/nixpkgs/2baa12ff69913392faf0ace833bc54bba297ea95' (2025-05-21)
• Updated input 'nixos-cosmic/rust-overlay':
    'github:oxalica/rust-overlay/f44db7d7cea4528288780c6347756173a8248225' (2025-05-17)
  → 'github:oxalica/rust-overlay/2221d8d53c128beb69346fa3ab36da3f19bb1691' (2025-05-24)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/e06158e58f3adee28b139e9c2bcfcc41f8625b46' (2025-05-15)
  → 'github:NixOS/nixpkgs/2795c506fe8fb7b03c36ccb51f75b6df0ab2553f' (2025-05-20)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/ba8b70ee098bc5654c459d6a95dfc498b91ff858' (2025-05-15)
  → 'github:NixOS/nixpkgs/2baa12ff69913392faf0ace833bc54bba297ea95' (2025-05-21)
• Updated input 'nur':
    'github:nix-community/NUR/c5e5d707419de9e849e1b6ca3013c83f07228e92' (2025-05-17)
  → 'github:nix-community/NUR/39b6399ac8e5307a7d39d6cc6800dea06c3366e5' (2025-05-24)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/e06158e58f3adee28b139e9c2bcfcc41f8625b46' (2025-05-15)
  → 'github:nixos/nixpkgs/2795c506fe8fb7b03c36ccb51f75b6df0ab2553f' (2025-05-20)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/a2bc0d49449fc61ca2eb364d6189179059394483' (2025-05-16)
  → 'github:Gerg-L/spicetify-nix/8c1be0e5e9a7f35ccd6f7b10bcfa08f2734dad91' (2025-05-18)
• Updated input 'stylix':
    'github:danth/stylix/101d23dfacbb2704c40639ae9b6ac1d41de7143a' (2025-05-17)
  → 'github:danth/stylix/34b5930894d8315401d93bd8a9a6635e1cd28eff' (2025-05-23)
• Updated input 'stylix/gnome-shell':
    'github:GNOME/gnome-shell/dadd58f630eeea41d645ee225a63f719390829dc' (2024-11-23)
  → 'github:GNOME/gnome-shell/52c517c8f6c199a1d6f5118fae500ef69ea845ae' (2025-04-13)
• Updated input 'stylix/home-manager':
    'github:nix-community/home-manager/954615c510c9faa3ee7fb6607ff72e55905e69f2' (2025-05-15)
  → 'github:nix-community/home-manager/29dda415f5b2178278283856c6f9f7b48a2a4353' (2025-05-20)
• Updated input 'stylix/nixpkgs':
    'github:NixOS/nixpkgs/46e634be05ce9dc6d4db8e664515ba10b78151ae' (2025-04-29)
  → 'github:NixOS/nixpkgs/292fa7d4f6519c074f0a50394dbbe69859bb6043' (2025-05-18)
• Updated input 'stylix/tinted-kitty':
    'github:tinted-theming/tinted-kitty/eb39e141db14baef052893285df9f266df041ff8' (2024-05-23)
  → 'github:tinted-theming/tinted-kitty/de6f888497f2c6b2279361bfc790f164bfd0f3fa' (2025-01-01)
```

Sources Changelog:
```
nix-fast-build: 765c14ec198730fd1b0648078da6d6dfe9e11d51 → 5f5ff111255393c6ff3bca40fbd627f039aa8eb8
```
