### PR TITLE
chore: update flake.lock & sources (2025-05-31)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -121,7 +121,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2025-05-24",
+        "date": "2025-05-26",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -133,12 +133,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "5f5ff111255393c6ff3bca40fbd627f039aa8eb8",
-            "sha256": "sha256-yk2H78SmFgSSxEHzBWFtIgwZrE57wQODUMUvTou6scQ=",
+            "rev": "0f595c2db69ad8bf1caf2619a10684f1a5914136",
+            "sha256": "sha256-Chlh5AeNhqShHnTcybTX5uwue6IhDAD3dR4747hxhnI=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "5f5ff111255393c6ff3bca40fbd627f039aa8eb8"
+        "version": "0f595c2db69ad8bf1caf2619a10684f1a5914136"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -75,15 +75,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "5f5ff111255393c6ff3bca40fbd627f039aa8eb8";
+    version = "0f595c2db69ad8bf1caf2619a10684f1a5914136";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "5f5ff111255393c6ff3bca40fbd627f039aa8eb8";
+      rev = "0f595c2db69ad8bf1caf2619a10684f1a5914136";
       fetchSubmodules = false;
-      sha256 = "sha256-yk2H78SmFgSSxEHzBWFtIgwZrE57wQODUMUvTou6scQ=";
+      sha256 = "sha256-Chlh5AeNhqShHnTcybTX5uwue6IhDAD3dR4747hxhnI=";
     };
-    date = "2025-05-24";
+    date = "2025-05-26";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -542,11 +542,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747978958,
-        "narHash": "sha256-pQQnbxWpY3IiZqgelXHIe/OAE/Yv4NSQq7fch7M6nXQ=",
+        "lastModified": 1748668774,
+        "narHash": "sha256-fYk/vk4ClmvHIgnGv/5GNRiDLtNCwXo9aLq36L/x+P4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7419250703fd5eb50e99bdfb07a86671939103ea",
+        "rev": "60e4624302d956fe94d3f7d96a560d14d70591b9",
         "type": "github"
       },
       "original": {
@@ -582,11 +582,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1747531721,
-        "narHash": "sha256-kx7hCuML0sMcjbyjbpplNWsJjLoUfiy23JiS9aG4UWw=",
+        "lastModified": 1748443200,
+        "narHash": "sha256-2ga8+CO/guhtNKh2bloGG94hJyvJGo0KBLAYBWrByhE=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "c203ffe80f4e7b68e22ba3fde0598622500f5add",
+        "rev": "49dbce17307b2f32a71864b16692ce75ffc8fa8d",
         "type": "github"
       },
       "original": {
@@ -663,11 +663,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1747540584,
-        "narHash": "sha256-cxCQ413JTUuRv9Ygd8DABJ1D6kuB/nTfQqC0Lu9C0ls=",
+        "lastModified": 1748145500,
+        "narHash": "sha256-t9fx0l61WOxtWxXCqlXPWSuG/0XMF9DtE2T7KXgMqJw=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "ec179dd13fb7b4c6844f55be91436f7857226dce",
+        "rev": "a98adbf54d663395df0b9929f6481d4d80fc8927",
         "type": "github"
       },
       "original": {
@@ -682,11 +682,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1748051778,
-        "narHash": "sha256-pl9Z5MqH7/ZzsOWp15gEr59xno+qvD55spV93eiYt8M=",
+        "lastModified": 1748656810,
+        "narHash": "sha256-oLy1QBWqpg/KIBwalt395Oq02BzZLDI4lKsF/XpDVxM=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "f1f3c539c5a9513bece912574f4aaf6f0d9937f2",
+        "rev": "e082782f89fbca5c6bd346e70aa306f124fcae16",
         "type": "github"
       },
       "original": {
@@ -703,11 +703,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1748084900,
-        "narHash": "sha256-XxVAY/U3qloh2gCy8T8aBj6lXu6DOAX5wH7cTg1QSkE=",
+        "lastModified": 1748697856,
+        "narHash": "sha256-RiPbZm8NbbCXVPi6WZDWabGpOA6X98nSk0GPTaPlmVA=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "d01c1a4044129f6eddb944f4d71a84e07c139eba",
+        "rev": "a0b5cb4cf16f0a5f90e3b683b6be50f39ea407bf",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1747862697,
-        "narHash": "sha256-U4HaNZ1W26cbOVm0Eb5OdGSnfQVWQKbLSPrSSa78KC0=",
+        "lastModified": 1748421225,
+        "narHash": "sha256-XXILOc80tvlvEQgYpYFnze8MkQQmp3eQxFbTzb3m/R0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2baa12ff69913392faf0ace833bc54bba297ea95",
+        "rev": "78add7b7abb61689e34fc23070a8f55e1d26185b",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1747862697,
-        "narHash": "sha256-U4HaNZ1W26cbOVm0Eb5OdGSnfQVWQKbLSPrSSa78KC0=",
+        "lastModified": 1748421225,
+        "narHash": "sha256-XXILOc80tvlvEQgYpYFnze8MkQQmp3eQxFbTzb3m/R0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2baa12ff69913392faf0ace833bc54bba297ea95",
+        "rev": "78add7b7abb61689e34fc23070a8f55e1d26185b",
         "type": "github"
       },
       "original": {
@@ -797,11 +797,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1747327360,
-        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
+        "lastModified": 1748026106,
+        "narHash": "sha256-6m1Y3/4pVw1RWTsrkAK2VMYSzG4MMIj7sqUy7o8th1o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
+        "rev": "063f43f2dbdef86376cc29ad646c45c46e93234c",
         "type": "github"
       },
       "original": {
@@ -829,11 +829,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1748460289,
+        "narHash": "sha256-7doLyJBzCllvqX4gszYtmZUToxKvMUrg45EUWaUYmBg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "96ec055edbe5ee227f28cdbc3f1ddf1df5965102",
         "type": "github"
       },
       "original": {
@@ -845,11 +845,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1748460289,
+        "narHash": "sha256-7doLyJBzCllvqX4gszYtmZUToxKvMUrg45EUWaUYmBg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "96ec055edbe5ee227f28cdbc3f1ddf1df5965102",
         "type": "github"
       },
       "original": {
@@ -861,11 +861,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1748460289,
+        "narHash": "sha256-7doLyJBzCllvqX4gszYtmZUToxKvMUrg45EUWaUYmBg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "96ec055edbe5ee227f28cdbc3f1ddf1df5965102",
         "type": "github"
       },
       "original": {
@@ -898,11 +898,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1748102975,
-        "narHash": "sha256-zQzJr6UCGWTgqilMO8DJcsZpUhYDEz00hSvMTUVOMm8=",
+        "lastModified": 1748708306,
+        "narHash": "sha256-wi+7mfLA0IQBtklOF/OC7Zhh3Riv6MH5zYtATlWDjTQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39b6399ac8e5307a7d39d6cc6800dea06c3366e5",
+        "rev": "7ef9c6546269642f3a8645bd273388d5761c42da",
         "type": "github"
       },
       "original": {
@@ -947,11 +947,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742765550,
-        "narHash": "sha256-2vVIh2JrL6GAGfgCeY9e6iNKrBjs0Hw3bGQEAbwVs68=",
+        "lastModified": 1748196248,
+        "narHash": "sha256-1iHjsH6/5UOerJEoZKE+Gx1BgAoge/YcnUsOA4wQ/BU=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "b70be387276e632fe51232887f9e04e2b6ef8c16",
+        "rev": "b7697abe89967839b273a863a3805345ea54ab56",
         "type": "github"
       },
       "original": {
@@ -1039,11 +1039,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748054080,
-        "narHash": "sha256-rwFiLLNCwkj9bqePtH1sMqzs1xmohE0Ojq249piMzF4=",
+        "lastModified": 1748658947,
+        "narHash": "sha256-F+nGITu6D7RswJlm8qCuU1PCuOSgDeAqaDKWW1n1jmQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2221d8d53c128beb69346fa3ab36da3f19bb1691",
+        "rev": "fc82ce758cc5df6a6d5d24e75710321cdbdc787a",
         "type": "github"
       },
       "original": {
@@ -1060,11 +1060,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1747607404,
-        "narHash": "sha256-xj2Ji+rE+oYjf0BsTDT7K/StnYuZQK9MTbX8U1DUcC0=",
+        "lastModified": 1748147548,
+        "narHash": "sha256-9IaAQkgyF4PFtVyui8vF6oJah0iVcO9DaOefjdTMthE=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "8c1be0e5e9a7f35ccd6f7b10bcfa08f2734dad91",
+        "rev": "f0595e3b59260457042450749eaec00a5a47db35",
         "type": "github"
       },
       "original": {
@@ -1095,11 +1095,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748028561,
-        "narHash": "sha256-IgtJU6n9vR3nBUdcXrc7K9E+Y/G/4P6hFifGRr1tXMU=",
+        "lastModified": 1748699906,
+        "narHash": "sha256-pu2UKagKKysJ7EYeOcm8vWoZq1lcxfwfu3/C1Y3OFz8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "34b5930894d8315401d93bd8a9a6635e1cd28eff",
+        "rev": "8762da957b8b04b8b73248144f1c0ff7a88924b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 22

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/7419250703fd5eb50e99bdfb07a86671939103ea' (2025-05-23)
  → 'github:nix-community/home-manager/60e4624302d956fe94d3f7d96a560d14d70591b9' (2025-05-31)
• Updated input 'hyprpanel':
    'github:Jas-SinghFSU/HyprPanel/c203ffe80f4e7b68e22ba3fde0598622500f5add' (2025-05-18)
  → 'github:Jas-SinghFSU/HyprPanel/49dbce17307b2f32a71864b16692ce75ffc8fa8d' (2025-05-28)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/ec179dd13fb7b4c6844f55be91436f7857226dce' (2025-05-18)
  → 'github:nix-community/nix-index-database/a98adbf54d663395df0b9929f6481d4d80fc8927' (2025-05-25)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/e06158e58f3adee28b139e9c2bcfcc41f8625b46' (2025-05-15)
  → 'github:NixOS/nixpkgs/063f43f2dbdef86376cc29ad646c45c46e93234c' (2025-05-23)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/f1f3c539c5a9513bece912574f4aaf6f0d9937f2' (2025-05-24)
  → 'github:nix-community/nix-vscode-extensions/e082782f89fbca5c6bd346e70aa306f124fcae16' (2025-05-31)
• Updated input 'nixos-cosmic':
    'github:lilyinstarlight/nixos-cosmic/d01c1a4044129f6eddb944f4d71a84e07c139eba' (2025-05-24)
  → 'github:lilyinstarlight/nixos-cosmic/a0b5cb4cf16f0a5f90e3b683b6be50f39ea407bf' (2025-05-31)
• Updated input 'nixos-cosmic/nixpkgs':
    'github:NixOS/nixpkgs/2795c506fe8fb7b03c36ccb51f75b6df0ab2553f' (2025-05-20)
  → 'github:NixOS/nixpkgs/96ec055edbe5ee227f28cdbc3f1ddf1df5965102' (2025-05-28)
• Updated input 'nixos-cosmic/nixpkgs-stable':
    'github:NixOS/nixpkgs/2baa12ff69913392faf0ace833bc54bba297ea95' (2025-05-21)
  → 'github:NixOS/nixpkgs/78add7b7abb61689e34fc23070a8f55e1d26185b' (2025-05-28)
• Updated input 'nixos-cosmic/rust-overlay':
    'github:oxalica/rust-overlay/2221d8d53c128beb69346fa3ab36da3f19bb1691' (2025-05-24)
  → 'github:oxalica/rust-overlay/fc82ce758cc5df6a6d5d24e75710321cdbdc787a' (2025-05-31)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/2795c506fe8fb7b03c36ccb51f75b6df0ab2553f' (2025-05-20)
  → 'github:NixOS/nixpkgs/96ec055edbe5ee227f28cdbc3f1ddf1df5965102' (2025-05-28)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/2baa12ff69913392faf0ace833bc54bba297ea95' (2025-05-21)
  → 'github:NixOS/nixpkgs/78add7b7abb61689e34fc23070a8f55e1d26185b' (2025-05-28)
• Updated input 'nur':
    'github:nix-community/NUR/39b6399ac8e5307a7d39d6cc6800dea06c3366e5' (2025-05-24)
  → 'github:nix-community/NUR/7ef9c6546269642f3a8645bd273388d5761c42da' (2025-05-31)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/2795c506fe8fb7b03c36ccb51f75b6df0ab2553f' (2025-05-20)
  → 'github:nixos/nixpkgs/96ec055edbe5ee227f28cdbc3f1ddf1df5965102' (2025-05-28)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/b70be387276e632fe51232887f9e04e2b6ef8c16' (2025-03-23)
  → 'github:nix-community/plasma-manager/b7697abe89967839b273a863a3805345ea54ab56' (2025-05-25)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/8c1be0e5e9a7f35ccd6f7b10bcfa08f2734dad91' (2025-05-18)
  → 'github:Gerg-L/spicetify-nix/f0595e3b59260457042450749eaec00a5a47db35' (2025-05-25)
• Updated input 'stylix':
    'github:danth/stylix/34b5930894d8315401d93bd8a9a6635e1cd28eff' (2025-05-23)
  → 'github:danth/stylix/8762da957b8b04b8b73248144f1c0ff7a88924b5' (2025-05-31)
```

Sources Changelog:
```
nix-fast-build: 5f5ff111255393c6ff3bca40fbd627f039aa8eb8 → 0f595c2db69ad8bf1caf2619a10684f1a5914136
```
