### PR TITLE
chore: update flake.lock & sources (2025-06-14)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -121,7 +121,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2025-06-06",
+        "date": "2025-06-09",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -133,12 +133,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "dcf6612bf5d7e804453a567a99a5a8c7b71abe70",
-            "sha256": "sha256-5EeSsqvXR9FBXl6OITDq+JCdpPuNYXdT/0xCV7dLi9w=",
+            "rev": "b1dae483ab7d4139a6297e02b6de9e5d30e43d48",
+            "sha256": "sha256-Nm0oMqFNRnJsiZYeNChmefmjeVCOzngikpSQhgs7iXI=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "dcf6612bf5d7e804453a567a99a5a8c7b71abe70"
+        "version": "b1dae483ab7d4139a6297e02b6de9e5d30e43d48"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -75,15 +75,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "dcf6612bf5d7e804453a567a99a5a8c7b71abe70";
+    version = "b1dae483ab7d4139a6297e02b6de9e5d30e43d48";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "dcf6612bf5d7e804453a567a99a5a8c7b71abe70";
+      rev = "b1dae483ab7d4139a6297e02b6de9e5d30e43d48";
       fetchSubmodules = false;
-      sha256 = "sha256-5EeSsqvXR9FBXl6OITDq+JCdpPuNYXdT/0xCV7dLi9w=";
+      sha256 = "sha256-Nm0oMqFNRnJsiZYeNChmefmjeVCOzngikpSQhgs7iXI=";
     };
-    date = "2025-06-06";
+    date = "2025-06-09";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -298,11 +298,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1748821116,
-        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747372754,
-        "narHash": "sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo+bnXU9D9k=",
+        "lastModified": 1749636823,
+        "narHash": "sha256-WUaIlOlPLyPgz9be7fqWJA5iG6rHcGRtLERSCfUDne4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
+        "rev": "623c56286de5a3193aa38891a6991b28f9bab056",
         "type": "github"
       },
       "original": {
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749243446,
-        "narHash": "sha256-P1gumhZN5N9q+39ndePHYrtwOwY1cGx+VoXGl+vTm7A=",
+        "lastModified": 1749821119,
+        "narHash": "sha256-X3WAS322EsebI4ohJcXhKpiyG1v+7wE4VOiXy1pxM/c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2d7d65f65b61fdfce23278e59ca266ddd0ef0a36",
+        "rev": "79dfd9aa295e53773aad45480b44c131da29f35b",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1748751003,
-        "narHash": "sha256-i4GZdKAK97S0ZMU3w4fqgEJr0cVywzqjugt2qZPrScs=",
+        "lastModified": 1749355504,
+        "narHash": "sha256-L17CdJMD+/FCBOHjREQLXbe2VUnc3rjffenBbu2Kwpc=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "2860bee699248d828c2ed9097a1cd82c2f991b43",
+        "rev": "40a6e15e44b11fbf8f2b1df9d64dbfc117625e94",
         "type": "github"
       },
       "original": {
@@ -704,11 +704,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1749261690,
-        "narHash": "sha256-cx/BC96wW+29joUehjHeERqEPxohHlMmPwYXXVORPZk=",
+        "lastModified": 1749866443,
+        "narHash": "sha256-wCgDTqR8hmnIpC0sqEg/XWPSU0EY8bVQeXCB3+IzCH0=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "5af3052a092b3b097f243d70a66b0484e000b423",
+        "rev": "9a421d58f287fc030be87a5a6c1f677da8b51a1a",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1749252229,
-        "narHash": "sha256-zIXU2Z+OBmkI+qjryUtVILP6qgZo+0bnIEy3UAw0CAE=",
+        "lastModified": 1749856624,
+        "narHash": "sha256-hO5vjZhVuZ3moZgDTU8ecdpIZIFf1GiKMjXHDsflYws=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "821627b7fe15013554cab4e9db4b8cb6fa9e8baf",
+        "rev": "edf3595b2a95149e2d426665c5253b47353fbccf",
         "type": "github"
       },
       "original": {
@@ -787,11 +787,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1748995628,
-        "narHash": "sha256-bFufQGSAEYQgjtc4wMrobS5HWN0hDP+ZX+zthYcml9U=",
+        "lastModified": 1749668643,
+        "narHash": "sha256-gaWJEWGBW/g1u6o5IM4Un0vluv86cigLuBnjsKILffc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8eb3b6a2366a7095939cd22f0dc0e9991313294b",
+        "rev": "1965fd20a39c8e441746bee66d550af78f0c0a7b",
         "type": "github"
       },
       "original": {
@@ -803,11 +803,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1748995628,
-        "narHash": "sha256-bFufQGSAEYQgjtc4wMrobS5HWN0hDP+ZX+zthYcml9U=",
+        "lastModified": 1749668643,
+        "narHash": "sha256-gaWJEWGBW/g1u6o5IM4Un0vluv86cigLuBnjsKILffc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8eb3b6a2366a7095939cd22f0dc0e9991313294b",
+        "rev": "1965fd20a39c8e441746bee66d550af78f0c0a7b",
         "type": "github"
       },
       "original": {
@@ -819,11 +819,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1748460289,
-        "narHash": "sha256-7doLyJBzCllvqX4gszYtmZUToxKvMUrg45EUWaUYmBg=",
+        "lastModified": 1749143949,
+        "narHash": "sha256-QuUtALJpVrPnPeozlUG/y+oIMSLdptHxb3GK6cpSVhA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "96ec055edbe5ee227f28cdbc3f1ddf1df5965102",
+        "rev": "d3d2d80a2191a73d1e86456a751b83aa13085d7d",
         "type": "github"
       },
       "original": {
@@ -851,11 +851,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1748929857,
-        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "lastModified": 1749285348,
+        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
         "type": "github"
       },
       "original": {
@@ -867,11 +867,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1749143949,
-        "narHash": "sha256-QuUtALJpVrPnPeozlUG/y+oIMSLdptHxb3GK6cpSVhA=",
+        "lastModified": 1749794982,
+        "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d3d2d80a2191a73d1e86456a751b83aa13085d7d",
+        "rev": "ee930f9755f58096ac6e8ca94a1887e0534e2d81",
         "type": "github"
       },
       "original": {
@@ -883,11 +883,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1749143949,
-        "narHash": "sha256-QuUtALJpVrPnPeozlUG/y+oIMSLdptHxb3GK6cpSVhA=",
+        "lastModified": 1749794982,
+        "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d3d2d80a2191a73d1e86456a751b83aa13085d7d",
+        "rev": "ee930f9755f58096ac6e8ca94a1887e0534e2d81",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1749310961,
-        "narHash": "sha256-d2kYAlGcW+MXv+HYf8D116TVw9z+EF1PKfyE0O9UD88=",
+        "lastModified": 1749907876,
+        "narHash": "sha256-Ib/XpzcNYtIGvfs4Fdz5QPGW5UILOSJ/wKzHfGkflcc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "500bfa3a22d3ee6514c1562d4fd1a91026b2b258",
+        "rev": "78e2be3e9720fd0fbba27f38a5be50e53708c1a5",
         "type": "github"
       },
       "original": {
@@ -1061,11 +1061,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749177458,
-        "narHash": "sha256-9HNq3EHZIvvxXQyEn0sYOywcESF1Xqw2Q8J1ZewcXuk=",
+        "lastModified": 1749782305,
+        "narHash": "sha256-h6jWS89SZyI5ACe/Ac2Yn7Qf+Uhb1yawbtpEqgV1h8E=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d58933b88cef7a05e9677e94352fd6fedba402cd",
+        "rev": "dc62b7639a9dcab4ab1246876fd0df8412a4a824",
         "type": "github"
       },
       "original": {
@@ -1082,11 +1082,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1748752728,
-        "narHash": "sha256-en008ncPUQjVx2i3PbM4RWeZkD9DNbJwIy0epppXe2o=",
+        "lastModified": 1749357231,
+        "narHash": "sha256-AbrPgGFVYR45TlYLHYTppayG0xzOG9XXhi+1j3Klbw8=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "0e03de40d5128eb2ad600c98f57cf5db2cdf3240",
+        "rev": "03783416f7416715c52166d4e8ba0492a7149397",
         "type": "github"
       },
       "original": {
@@ -1117,11 +1117,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1749236315,
-        "narHash": "sha256-Ndtdvwz8D4WOYHl5mj9d5F5iC8WPH6uPNF7RcU3QzmE=",
+        "lastModified": 1749905587,
+        "narHash": "sha256-sZpQM+InPCYwJQiTxs/PCCupwbYNaSCFi2Hvpl1/pOo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "29d006198ee05143cca8b4b89f37025823da1bcc",
+        "rev": "77a8b26520f48305f3b1bacffaa8740dde8afa2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 24

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/49f0870db23e8c1ca0b5259734a02cd9e1e371a1' (2025-06-01)
  → 'github:hercules-ci/flake-parts/9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569' (2025-06-08)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/80479b6ec16fefd9c1db3ea13aeb038c60530f46' (2025-05-16)
  → 'github:cachix/git-hooks.nix/623c56286de5a3193aa38891a6991b28f9bab056' (2025-06-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/2d7d65f65b61fdfce23278e59ca266ddd0ef0a36' (2025-06-06)
  → 'github:nix-community/home-manager/79dfd9aa295e53773aad45480b44c131da29f35b' (2025-06-13)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/2860bee699248d828c2ed9097a1cd82c2f991b43' (2025-06-01)
  → 'github:nix-community/nix-index-database/40a6e15e44b11fbf8f2b1df9d64dbfc117625e94' (2025-06-08)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/96ec055edbe5ee227f28cdbc3f1ddf1df5965102' (2025-05-28)
  → 'github:NixOS/nixpkgs/d3d2d80a2191a73d1e86456a751b83aa13085d7d' (2025-06-05)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/5af3052a092b3b097f243d70a66b0484e000b423' (2025-06-07)
  → 'github:nix-community/nix-vscode-extensions/9a421d58f287fc030be87a5a6c1f677da8b51a1a' (2025-06-14)
• Updated input 'nixos-cosmic':
    'github:lilyinstarlight/nixos-cosmic/821627b7fe15013554cab4e9db4b8cb6fa9e8baf' (2025-06-06)
  → 'github:lilyinstarlight/nixos-cosmic/edf3595b2a95149e2d426665c5253b47353fbccf' (2025-06-13)
• Updated input 'nixos-cosmic/nixpkgs':
    'github:NixOS/nixpkgs/c2a03962b8e24e669fb37b7df10e7c79531ff1a4' (2025-06-03)
  → 'github:NixOS/nixpkgs/3e3afe5174c561dee0df6f2c2b2236990146329f' (2025-06-07)
• Updated input 'nixos-cosmic/nixpkgs-stable':
    'github:NixOS/nixpkgs/8eb3b6a2366a7095939cd22f0dc0e9991313294b' (2025-06-04)
  → 'github:NixOS/nixpkgs/1965fd20a39c8e441746bee66d550af78f0c0a7b' (2025-06-11)
• Updated input 'nixos-cosmic/rust-overlay':
    'github:oxalica/rust-overlay/d58933b88cef7a05e9677e94352fd6fedba402cd' (2025-06-06)
  → 'github:oxalica/rust-overlay/dc62b7639a9dcab4ab1246876fd0df8412a4a824' (2025-06-13)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/d3d2d80a2191a73d1e86456a751b83aa13085d7d' (2025-06-05)
  → 'github:NixOS/nixpkgs/ee930f9755f58096ac6e8ca94a1887e0534e2d81' (2025-06-13)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/8eb3b6a2366a7095939cd22f0dc0e9991313294b' (2025-06-04)
  → 'github:NixOS/nixpkgs/1965fd20a39c8e441746bee66d550af78f0c0a7b' (2025-06-11)
• Updated input 'nur':
    'github:nix-community/NUR/500bfa3a22d3ee6514c1562d4fd1a91026b2b258' (2025-06-07)
  → 'github:nix-community/NUR/78e2be3e9720fd0fbba27f38a5be50e53708c1a5' (2025-06-14)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/d3d2d80a2191a73d1e86456a751b83aa13085d7d' (2025-06-05)
  → 'github:nixos/nixpkgs/ee930f9755f58096ac6e8ca94a1887e0534e2d81' (2025-06-13)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/0e03de40d5128eb2ad600c98f57cf5db2cdf3240' (2025-06-01)
  → 'github:Gerg-L/spicetify-nix/03783416f7416715c52166d4e8ba0492a7149397' (2025-06-08)
• Updated input 'stylix':
    'github:danth/stylix/29d006198ee05143cca8b4b89f37025823da1bcc' (2025-06-06)
  → 'github:danth/stylix/77a8b26520f48305f3b1bacffaa8740dde8afa2a' (2025-06-14)
```

Sources Changelog:
```
nix-fast-build: dcf6612bf5d7e804453a567a99a5a8c7b71abe70 → b1dae483ab7d4139a6297e02b6de9e5d30e43d48
```
