### PR TITLE
chore: update flake.lock & sources (2025-09-03)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -43,7 +43,7 @@
     },
     "eza_themes": {
         "cargoLocks": null,
-        "date": "2025-02-19",
+        "date": "2025-08-03",
         "extract": null,
         "name": "eza_themes",
         "passthru": null,
@@ -55,12 +55,12 @@
             "name": null,
             "owner": "eza-community",
             "repo": "eza-themes",
-            "rev": "57149851f07b3ee6ca94f5fe3d9d552f73f8b8b4",
-            "sha256": "sha256-vu6QLz0RvPavpD2VED25D2PJlHgQ8Yis+DnL+BPlvHw=",
+            "rev": "17095bff4792eecd7f4f1ed8301b15000331c906",
+            "sha256": "sha256-2WTbCQlhwMo5cOn3KwtNiIst0tNfASfZnPNsNBs+gcU=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "57149851f07b3ee6ca94f5fe3d9d552f73f8b8b4"
+        "version": "17095bff4792eecd7f4f1ed8301b15000331c906"
     },
     "filen": {
         "cargoLocks": null,
@@ -91,12 +91,12 @@
             "name": null,
             "owner": "rafaelmardojai",
             "repo": "firefox-gnome-theme",
-            "rev": "v140",
-            "sha256": "sha256-/pTDAny47X1og2pSAoMY/GfJ9teSOEQZAENhszPJMKo=",
+            "rev": "v142",
+            "sha256": "sha256-kyxuK5Fras7QYiJmUomqdq8NlgWV66hmNvxcJnGCpUE=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "v140"
+        "version": "v142"
     },
     "joplin_catppuccin": {
         "cargoLocks": null,
@@ -121,7 +121,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2025-07-19",
+        "date": "2025-08-31",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -133,16 +133,16 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "663f68f1f5a283e8a6d5b929104f7b4b084c47bd",
-            "sha256": "sha256-SHEo4FrCcWiX0q2FzDIotscihn5kI1InoagdZfWGDxA=",
+            "rev": "135fd0edf1dff4128f6f38822dbb24f333b8073f",
+            "sha256": "sha256-ai5enFBtuTqdAnJs2fG4TatnvmJtAPEgMf3oA726FBc=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "663f68f1f5a283e8a6d5b929104f7b4b084c47bd"
+        "version": "135fd0edf1dff4128f6f38822dbb24f333b8073f"
     },
     "obs_catppuccin": {
         "cargoLocks": null,
-        "date": "2025-03-23",
+        "date": "2025-07-29",
         "extract": null,
         "name": "obs_catppuccin",
         "passthru": null,
@@ -154,12 +154,12 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "obs",
-            "rev": "58a80435caf1ff4f62b94592f508fba4c3776c97",
-            "sha256": "sha256-2CuaMd+9GHK18M971+pVltPC9h59LYDXEAEkEq+tRw8=",
+            "rev": "05c55ffe499c183c98be469147f602c3f8e84b87",
+            "sha256": "sha256-ezz3euxO5lxyVaVFDPjNowpivAm9tRGHt8SbflAdkA8=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "58a80435caf1ff4f62b94592f508fba4c3776c97"
+        "version": "05c55ffe499c183c98be469147f602c3f8e84b87"
     },
     "prismlauncher_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -32,15 +32,15 @@
   };
   eza_themes = {
     pname = "eza_themes";
-    version = "57149851f07b3ee6ca94f5fe3d9d552f73f8b8b4";
+    version = "17095bff4792eecd7f4f1ed8301b15000331c906";
     src = fetchFromGitHub {
       owner = "eza-community";
       repo = "eza-themes";
-      rev = "57149851f07b3ee6ca94f5fe3d9d552f73f8b8b4";
+      rev = "17095bff4792eecd7f4f1ed8301b15000331c906";
       fetchSubmodules = false;
-      sha256 = "sha256-vu6QLz0RvPavpD2VED25D2PJlHgQ8Yis+DnL+BPlvHw=";
+      sha256 = "sha256-2WTbCQlhwMo5cOn3KwtNiIst0tNfASfZnPNsNBs+gcU=";
     };
-    date = "2025-02-19";
+    date = "2025-08-03";
   };
   filen = {
     pname = "filen";
@@ -52,13 +52,13 @@
   };
   firefox-gnome-theme = {
     pname = "firefox-gnome-theme";
-    version = "v140";
+    version = "v142";
     src = fetchFromGitHub {
       owner = "rafaelmardojai";
       repo = "firefox-gnome-theme";
-      rev = "v140";
+      rev = "v142";
       fetchSubmodules = false;
-      sha256 = "sha256-/pTDAny47X1og2pSAoMY/GfJ9teSOEQZAENhszPJMKo=";
+      sha256 = "sha256-kyxuK5Fras7QYiJmUomqdq8NlgWV66hmNvxcJnGCpUE=";
     };
   };
   joplin_catppuccin = {
@@ -75,27 +75,27 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "663f68f1f5a283e8a6d5b929104f7b4b084c47bd";
+    version = "135fd0edf1dff4128f6f38822dbb24f333b8073f";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "663f68f1f5a283e8a6d5b929104f7b4b084c47bd";
+      rev = "135fd0edf1dff4128f6f38822dbb24f333b8073f";
       fetchSubmodules = false;
-      sha256 = "sha256-SHEo4FrCcWiX0q2FzDIotscihn5kI1InoagdZfWGDxA=";
+      sha256 = "sha256-ai5enFBtuTqdAnJs2fG4TatnvmJtAPEgMf3oA726FBc=";
     };
-    date = "2025-07-19";
+    date = "2025-08-31";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";
-    version = "58a80435caf1ff4f62b94592f508fba4c3776c97";
+    version = "05c55ffe499c183c98be469147f602c3f8e84b87";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "obs";
-      rev = "58a80435caf1ff4f62b94592f508fba4c3776c97";
+      rev = "05c55ffe499c183c98be469147f602c3f8e84b87";
       fetchSubmodules = false;
-      sha256 = "sha256-2CuaMd+9GHK18M971+pVltPC9h59LYDXEAEkEq+tRw8=";
+      sha256 = "sha256-ezz3euxO5lxyVaVFDPjNowpivAm9tRGHt8SbflAdkA8=";
     };
-    date = "2025-03-23";
+    date = "2025-07-29";
   };
   prismlauncher_catppuccin = {
     pname = "prismlauncher_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1750173260,
-        "narHash": "sha256-9P1FziAwl5+3edkfFcr5HeGtQUtrSdk/MksX39GieoA=",
+        "lastModified": 1754433428,
+        "narHash": "sha256-NA/FT2hVhKDftbHSwVnoRTFhes62+7dxZbxj5Gxvghs=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "531beac616433bac6f9e2a19feb8e99a22a66baf",
+        "rev": "9edb1787864c4f59ae5074ad498b6272b3ec308d",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
     "base16-helix": {
       "flake": false,
       "locked": {
-        "lastModified": 1748408240,
-        "narHash": "sha256-9M2b1rMyMzJK0eusea0x3lyh3mu5nMeEDSc4RZkGm+g=",
+        "lastModified": 1752979451,
+        "narHash": "sha256-0CQM+FkYy0fOO/sMGhOoNL80ftsAzYCg9VhIrodqusM=",
         "owner": "tinted-theming",
         "repo": "base16-helix",
-        "rev": "6c711ab1a9db6f51e2f6887cc3345530b33e152e",
+        "rev": "27cf1e66e50abc622fb76a3019012dc07c678fac",
         "type": "github"
       },
       "original": {
@@ -168,11 +168,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -218,11 +218,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
         "type": "github"
       },
       "original": {
@@ -373,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750779888,
-        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
+        "lastModified": 1755960406,
+        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
         "type": "github"
       },
       "original": {
@@ -453,11 +453,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752814804,
-        "narHash": "sha256-irfg7lnfEpJY+3Cffkluzp2MTVw1Uq9QGxFp6qadcXI=",
+        "lastModified": 1756903364,
+        "narHash": "sha256-vZh/YH2D7oDFek10r0TbGn3qJrqGv69sSP+oF8PFDqQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d0300c8808e41da81d6edfc202f3d3833c157daf",
+        "rev": "6159629d05a0e92bb7fb7211e74106ae1d552401",
         "type": "github"
       },
       "original": {
@@ -494,11 +494,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1752292276,
-        "narHash": "sha256-cl1NEWTUsNxBmLjyvz+GDP4Hy7riaOszSGpfplHA7Y4=",
+        "lastModified": 1755569534,
+        "narHash": "sha256-ukXfV1cAsxoar0IVEO2/s3qnVEZpZf0wvqE3PIESobw=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "59b57fca0634c98f23227ea948f87df7814e72f6",
+        "rev": "6385f2e15df908e0c13bed800f4b091300e5b981",
         "type": "github"
       },
       "original": {
@@ -575,11 +575,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1752441837,
-        "narHash": "sha256-FMH1OSSJp8Cx8MZHXz6KckxJGbCnVMotZNAH3v2WneU=",
+        "lastModified": 1756612744,
+        "narHash": "sha256-/glV6VAq8Va3ghIbmhET3S1dzkbZqicsk5h+FtvwiPE=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "839e02dece5845be3a322e507a79712b73a96ba2",
+        "rev": "3fe768e1f058961095b4a0d7a2ba15dc9736bdc6",
         "type": "github"
       },
       "original": {
@@ -594,11 +594,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1752890945,
-        "narHash": "sha256-gl+t06pZuUqg7Z9YUP1FeGSkJOZ39+ZZUhNvk+GeSG4=",
+        "lastModified": 1756864266,
+        "narHash": "sha256-2X1atbNXhevmp7+RZ9AC6Uafh8dXdMl88ao41OjXKg8=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "c3938b6402946ff1c4837db266448cf158f41a66",
+        "rev": "0fa39712a6079f2b5ad4beb36f388e875acc359f",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
         "type": "github"
       },
       "original": {
@@ -709,11 +709,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1751984180,
-        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
         "type": "github"
       },
       "original": {
@@ -757,11 +757,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1752687322,
-        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
+        "lastModified": 1756787288,
+        "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
+        "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1752687322,
-        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
+        "lastModified": 1756787288,
+        "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
+        "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
         "type": "github"
       },
       "original": {
@@ -809,11 +809,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1752936601,
-        "narHash": "sha256-if3M7x7MrlGvS+U5JKa62vG2rCqdAcUQYSd27VOYzjQ=",
+        "lastModified": 1756903679,
+        "narHash": "sha256-5LILWgddjmHxmZ+kXW+UQVHiPCCP0/VIg9X1Y4wGpKo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12143c8cd2d109a301e9c59b257148d8b9c75baf",
+        "rev": "d8cfb3ad481b6b86982c0fe6220eef68ea53695c",
         "type": "github"
       },
       "original": {
@@ -857,11 +857,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748196248,
-        "narHash": "sha256-1iHjsH6/5UOerJEoZKE+Gx1BgAoge/YcnUsOA4wQ/BU=",
+        "lastModified": 1756632588,
+        "narHash": "sha256-ydam6eggXf3ZwRutyCABwSbMAlX+5lW6w1SVZQ+kfSo=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "b7697abe89967839b273a863a3805345ea54ab56",
+        "rev": "d47428e5390d6a5a8f764808a4db15929347cd77",
         "type": "github"
       },
       "original": {
@@ -970,11 +970,11 @@
         "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1752381641,
-        "narHash": "sha256-R2iDZb94RosuCeuIukacZVVXxzWYr4jn/QI/ax15nW8=",
+        "lastModified": 1756614537,
+        "narHash": "sha256-qyszmZO9CEKAlj5NBQo1AIIADm5Fgqs5ZggW1sU1TVo=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "8f9fd947c52aa6adb6bafe72516eccf186708954",
+        "rev": "374eb5d97092b97f7aaafd58a2012943b388c0df",
         "type": "github"
       },
       "original": {
@@ -1002,11 +1002,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752750082,
-        "narHash": "sha256-NoVAqy+Wj4tgkvrYB8zWncl8Z6Hb80aX3t/TYGdsfaM=",
+        "lastModified": 1756811338,
+        "narHash": "sha256-fwgklhY9kJSTDMGuwHJUVBCuJDVvxxljjGOLhxC84ko=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "03699ed214f6e8195bc7199d6ae3aeccf9732b08",
+        "rev": "989312ab49e6eb1d076f9d194d43f9f9c513087e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 36

Flakes Changelog:
```
• Updated input 'agenix':
    'github:ryantm/agenix/531beac616433bac6f9e2a19feb8e99a22a66baf' (2025-06-17)
  → 'github:ryantm/agenix/9edb1787864c4f59ae5074ad498b6272b3ec308d' (2025-08-05)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/77826244401ea9de6e3bac47c2db46005e1f30b5' (2025-07-01)
  → 'github:hercules-ci/flake-parts/4524271976b625a4a605beefd893f270620fd751' (2025-09-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/14a40a1d7fb9afa4739275ac642ed7301a9ba1ab' (2025-06-29)
  → 'github:nix-community/nixpkgs.lib/a73b9c743612e4244d865a2fdee11865283c04e6' (2025-08-10)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/16ec914f6fb6f599ce988427d9d94efddf25fe6d' (2025-06-24)
  → 'github:cachix/git-hooks.nix/e891a93b193fcaf2fc8012d890dc7f0befe86ec2' (2025-08-23)
• Updated input 'git-hooks/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
  → 'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885' (2025-05-12)
• Updated input 'home-manager':
    'github:nix-community/home-manager/d0300c8808e41da81d6edfc202f3d3833c157daf' (2025-07-18)
  → 'github:nix-community/home-manager/6159629d05a0e92bb7fb7211e74106ae1d552401' (2025-09-03)
• Updated input 'hyprpanel':
    'github:Jas-SinghFSU/HyprPanel/59b57fca0634c98f23227ea948f87df7814e72f6' (2025-07-12)
  → 'github:Jas-SinghFSU/HyprPanel/6385f2e15df908e0c13bed800f4b091300e5b981' (2025-08-19)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/839e02dece5845be3a322e507a79712b73a96ba2' (2025-07-13)
  → 'github:nix-community/nix-index-database/3fe768e1f058961095b4a0d7a2ba15dc9736bdc6' (2025-08-31)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0' (2025-07-08)
  → 'github:NixOS/nixpkgs/d7600c775f877cd87b4f5a831c28aa94137377aa' (2025-08-30)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/c3938b6402946ff1c4837db266448cf158f41a66' (2025-07-19)
  → 'github:nix-community/nix-vscode-extensions/0fa39712a6079f2b5ad4beb36f388e875acc359f' (2025-09-03)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/6e987485eb2c77e5dcc5af4e3c70843711ef9251' (2025-07-16)
  → 'github:NixOS/nixpkgs/d0fc30899600b9b3466ddb260fd83deb486c32f1' (2025-09-02)
• Updated input 'nur':
    'github:nix-community/NUR/12143c8cd2d109a301e9c59b257148d8b9c75baf' (2025-07-19)
  → 'github:nix-community/NUR/d8cfb3ad481b6b86982c0fe6220eef68ea53695c' (2025-09-03)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/6e987485eb2c77e5dcc5af4e3c70843711ef9251' (2025-07-16)
  → 'github:nixos/nixpkgs/d0fc30899600b9b3466ddb260fd83deb486c32f1' (2025-09-02)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/b7697abe89967839b273a863a3805345ea54ab56' (2025-05-25)
  → 'github:nix-community/plasma-manager/d47428e5390d6a5a8f764808a4db15929347cd77' (2025-08-31)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/8f9fd947c52aa6adb6bafe72516eccf186708954' (2025-07-13)
  → 'github:Gerg-L/spicetify-nix/374eb5d97092b97f7aaafd58a2012943b388c0df' (2025-08-31)
• Updated input 'stylix':
    'github:danth/stylix/03699ed214f6e8195bc7199d6ae3aeccf9732b08' (2025-07-17)
  → 'github:danth/stylix/989312ab49e6eb1d076f9d194d43f9f9c513087e' (2025-09-02)
• Updated input 'stylix/base16-helix':
    'github:tinted-theming/base16-helix/6c711ab1a9db6f51e2f6887cc3345530b33e152e' (2025-05-28)
  → 'github:tinted-theming/base16-helix/27cf1e66e50abc622fb76a3019012dc07c678fac' (2025-07-20)
```

Sources Changelog:
```
firefox-gnome-theme: v140 → v142
obs_catppuccin: 58a80435caf1ff4f62b94592f508fba4c3776c97 → 05c55ffe499c183c98be469147f602c3f8e84b87
nix-fast-build: 663f68f1f5a283e8a6d5b929104f7b4b084c47bd → 135fd0edf1dff4128f6f38822dbb24f333b8073f
eza_themes: 57149851f07b3ee6ca94f5fe3d9d552f73f8b8b4 → 17095bff4792eecd7f4f1ed8301b15000331c906
```
