### PR TITLE
chore: update flake.lock & sources (2025-09-27)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -100,7 +100,7 @@
     },
     "joplin_catppuccin": {
         "cargoLocks": null,
-        "date": "2025-05-11",
+        "date": "2025-09-16",
         "extract": null,
         "name": "joplin_catppuccin",
         "passthru": null,
@@ -112,16 +112,16 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "joplin",
-            "rev": "96d4311a079a5cd1c990d654853a63df0d962027",
-            "sha256": "sha256-XJOCk6Gts7n3sqWM2kTJ1X5T/QoKMBLCEmR+dhJ6+IM=",
+            "rev": "780ff535705411a92cb8d939b51a0e9abf5b8688",
+            "sha256": "sha256-xl9zjVQUHCT3yo5GAsjcfBh1yVM4ryYj/u1v0ws4Ik8=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "96d4311a079a5cd1c990d654853a63df0d962027"
+        "version": "780ff535705411a92cb8d939b51a0e9abf5b8688"
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2025-08-31",
+        "date": "2025-09-21",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -133,12 +133,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "135fd0edf1dff4128f6f38822dbb24f333b8073f",
-            "sha256": "sha256-ai5enFBtuTqdAnJs2fG4TatnvmJtAPEgMf3oA726FBc=",
+            "rev": "862aa595b7e2494eb7df611a016ef910cf3e9fd3",
+            "sha256": "sha256-1v3j1CBBgr5kaw366GVlslz4xOJsI1hkX1/IgMe2v8M=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "135fd0edf1dff4128f6f38822dbb24f333b8073f"
+        "version": "862aa595b7e2494eb7df611a016ef910cf3e9fd3"
     },
     "obs_catppuccin": {
         "cargoLocks": null,
@@ -163,7 +163,7 @@
     },
     "prismlauncher_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-06-11",
+        "date": "2025-09-08",
         "extract": null,
         "name": "prismlauncher_catppuccin",
         "passthru": null,
@@ -175,12 +175,12 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "prismlauncher",
-            "rev": "2edbdf5295bc3c12c3dd53b203ab91028fce2c54",
-            "sha256": "sha256-+yGrSZztf2sZ9frPT3ydIJDavo4eXs03cQWfdTAmn3w=",
+            "rev": "1ef0e745286ce32750abc3bc5d3ca8073a623b60",
+            "sha256": "sha256-RN1VM29OH75GHSHgpu3HW8YSonIEnX7MZzCObJ6BwtQ=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "2edbdf5295bc3c12c3dd53b203ab91028fce2c54"
+        "version": "1ef0e745286ce32750abc3bc5d3ca8073a623b60"
     },
     "rofi-bluetooth": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -63,27 +63,27 @@
   };
   joplin_catppuccin = {
     pname = "joplin_catppuccin";
-    version = "96d4311a079a5cd1c990d654853a63df0d962027";
+    version = "780ff535705411a92cb8d939b51a0e9abf5b8688";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "joplin";
-      rev = "96d4311a079a5cd1c990d654853a63df0d962027";
+      rev = "780ff535705411a92cb8d939b51a0e9abf5b8688";
       fetchSubmodules = false;
-      sha256 = "sha256-XJOCk6Gts7n3sqWM2kTJ1X5T/QoKMBLCEmR+dhJ6+IM=";
+      sha256 = "sha256-xl9zjVQUHCT3yo5GAsjcfBh1yVM4ryYj/u1v0ws4Ik8=";
     };
-    date = "2025-05-11";
+    date = "2025-09-16";
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "135fd0edf1dff4128f6f38822dbb24f333b8073f";
+    version = "862aa595b7e2494eb7df611a016ef910cf3e9fd3";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "135fd0edf1dff4128f6f38822dbb24f333b8073f";
+      rev = "862aa595b7e2494eb7df611a016ef910cf3e9fd3";
       fetchSubmodules = false;
-      sha256 = "sha256-ai5enFBtuTqdAnJs2fG4TatnvmJtAPEgMf3oA726FBc=";
+      sha256 = "sha256-1v3j1CBBgr5kaw366GVlslz4xOJsI1hkX1/IgMe2v8M=";
     };
-    date = "2025-08-31";
+    date = "2025-09-21";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";
@@ -99,15 +99,15 @@
   };
   prismlauncher_catppuccin = {
     pname = "prismlauncher_catppuccin";
-    version = "2edbdf5295bc3c12c3dd53b203ab91028fce2c54";
+    version = "1ef0e745286ce32750abc3bc5d3ca8073a623b60";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "prismlauncher";
-      rev = "2edbdf5295bc3c12c3dd53b203ab91028fce2c54";
+      rev = "1ef0e745286ce32750abc3bc5d3ca8073a623b60";
       fetchSubmodules = false;
-      sha256 = "sha256-+yGrSZztf2sZ9frPT3ydIJDavo4eXs03cQWfdTAmn3w=";
+      sha256 = "sha256-RN1VM29OH75GHSHgpu3HW8YSonIEnX7MZzCObJ6BwtQ=";
     };
-    date = "2024-06-11";
+    date = "2025-09-08";
   };
   rofi-bluetooth = {
     pname = "rofi-bluetooth";

--- a/flake.lock
+++ b/flake.lock
@@ -471,11 +471,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757588530,
-        "narHash": "sha256-tJ7A8mID3ct69n9WCvZ3PzIIl3rXTdptn/lZmqSS95U=",
+        "lastModified": 1758108966,
+        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "b084b2c2b6bc23e83bbfe583b03664eb0b18c411",
+        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
         "type": "github"
       },
       "original": {
@@ -577,11 +577,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757920978,
-        "narHash": "sha256-Mv16aegXLulgyDunijP6SPFJNm8lSXb2w3Q0X+vZ9TY=",
+        "lastModified": 1758985165,
+        "narHash": "sha256-bzthrGCHUDzUHH9F3eNl5LG5rfg4ig9x3TGjjUE23qA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "11cc5449c50e0e5b785be3dfcb88245232633eb8",
+        "rev": "11cc3d55ded3346a8195000ddeadde782a611e56",
         "type": "github"
       },
       "original": {
@@ -720,11 +720,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757822619,
-        "narHash": "sha256-3HIpe3P2h1AUPYcAH9cjuX0tZOqJpX01c0iDwoUYNZ8=",
+        "lastModified": 1758427679,
+        "narHash": "sha256-xwjWRJTKDCjQ0iwfh7WhDhgcS0Wt3d1Yscg83mKBCn4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "050a5feb5d1bb5b6e5fc04a7d3d816923a87c9ea",
+        "rev": "fd2569ca2ef7d69f244cd9ffcb66a0540772ff85",
         "type": "github"
       },
       "original": {
@@ -739,11 +739,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1757901553,
-        "narHash": "sha256-gW45THWkxnzWpPtjuaDeTnpKFB6i5cZmxk4WuGKhCNc=",
+        "lastModified": 1758937884,
+        "narHash": "sha256-vwLF3vCIJS0UU3/SKij7xvyaR/ZWr1ynmNWRZtk8dsY=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "846f1334090a2c44d77850c00d0c17a27ad66618",
+        "rev": "6117b8feb7acbe702a48e562940fd8ab208bf63e",
         "type": "github"
       },
       "original": {
@@ -914,11 +914,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1758277210,
+        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
         "type": "github"
       },
       "original": {
@@ -962,11 +962,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
         "type": "github"
       },
       "original": {
@@ -978,11 +978,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
         "type": "github"
       },
       "original": {
@@ -1014,11 +1014,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757946652,
-        "narHash": "sha256-PpPoePu9UIJdjtuaQ1xLM8PVqekI2s9im7r3SWgpVtU=",
+        "lastModified": 1758986280,
+        "narHash": "sha256-xuvw0q3JAcUZteJ5x46ukkArWInTvSroWb23Wsd+sHs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c4ccef96fa4d2411b89a3696d3e871047219b93",
+        "rev": "b12d9127abe1fde785f751ddcf046b6707f53990",
         "type": "github"
       },
       "original": {
@@ -1062,11 +1062,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756632588,
-        "narHash": "sha256-ydam6eggXf3ZwRutyCABwSbMAlX+5lW6w1SVZQ+kfSo=",
+        "lastModified": 1758185783,
+        "narHash": "sha256-6fX2CG8PzdBNwJGBISnf/nVHUVMZdCsekT1mP672Uh8=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "d47428e5390d6a5a8f764808a4db15929347cd77",
+        "rev": "6a7d78cebd9a0f84a508bec9bc47ac504c5f51f4",
         "type": "github"
       },
       "original": {
@@ -1176,11 +1176,11 @@
         "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1757824114,
-        "narHash": "sha256-cyVbc8UxyWKAuXOgqLggil2mXLZWY0wyfBWYqUwgYjM=",
+        "lastModified": 1758584568,
+        "narHash": "sha256-FDxTheW6ynpbro/8eTZHhAY7J+HOf0jXeXq3jrJDcS8=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "d23584b2000b7f7a59a1764ff9ab93b89444bfd9",
+        "rev": "9e9e48ca16628bf09a02bc5449d4b0761e15eebd",
         "type": "github"
       },
       "original": {
@@ -1208,11 +1208,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1757360005,
-        "narHash": "sha256-VwzdFEQCpYMU9mc7BSQGQe5wA1MuTYPJnRc9TQCTMcM=",
+        "lastModified": 1758905463,
+        "narHash": "sha256-8ANQ3MxULwolfkJEdUYlL5usISAxtysWctqqeSiJ/OE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "834a743c11d66ea18e8c54872fbcc72ce48bc57f",
+        "rev": "4aae0ebc2b0d37d4f90ace2c8bbadffadb2e2a97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 39

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/b084b2c2b6bc23e83bbfe583b03664eb0b18c411' (2025-09-11)
  → 'github:cachix/git-hooks.nix/54df955a695a84cd47d4a43e08e1feaf90b1fd9b' (2025-09-17)
• Updated input 'home-manager':
    'github:nix-community/home-manager/11cc5449c50e0e5b785be3dfcb88245232633eb8' (2025-09-15)
  → 'github:nix-community/home-manager/11cc3d55ded3346a8195000ddeadde782a611e56' (2025-09-27)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/050a5feb5d1bb5b6e5fc04a7d3d816923a87c9ea' (2025-09-14)
  → 'github:nix-community/nix-index-database/fd2569ca2ef7d69f244cd9ffcb66a0540772ff85' (2025-09-21)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/c23193b943c6c689d70ee98ce3128239ed9e32d1' (2025-09-13)
  → 'github:NixOS/nixpkgs/8eaee110344796db060382e15d3af0a9fc396e0e' (2025-09-19)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/846f1334090a2c44d77850c00d0c17a27ad66618' (2025-09-15)
  → 'github:nix-community/nix-vscode-extensions/6117b8feb7acbe702a48e562940fd8ab208bf63e' (2025-09-27)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c23193b943c6c689d70ee98ce3128239ed9e32d1' (2025-09-13)
  → 'github:NixOS/nixpkgs/e643668fd71b949c53f8626614b21ff71a07379d' (2025-09-24)
• Updated input 'nur':
    'github:nix-community/NUR/9c4ccef96fa4d2411b89a3696d3e871047219b93' (2025-09-15)
  → 'github:nix-community/NUR/b12d9127abe1fde785f751ddcf046b6707f53990' (2025-09-27)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/c23193b943c6c689d70ee98ce3128239ed9e32d1' (2025-09-13)
  → 'github:nixos/nixpkgs/e643668fd71b949c53f8626614b21ff71a07379d' (2025-09-24)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/d47428e5390d6a5a8f764808a4db15929347cd77' (2025-08-31)
  → 'github:nix-community/plasma-manager/6a7d78cebd9a0f84a508bec9bc47ac504c5f51f4' (2025-09-18)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/d23584b2000b7f7a59a1764ff9ab93b89444bfd9' (2025-09-14)
  → 'github:Gerg-L/spicetify-nix/9e9e48ca16628bf09a02bc5449d4b0761e15eebd' (2025-09-22)
• Updated input 'stylix':
    'github:danth/stylix/834a743c11d66ea18e8c54872fbcc72ce48bc57f' (2025-09-08)
  → 'github:danth/stylix/4aae0ebc2b0d37d4f90ace2c8bbadffadb2e2a97' (2025-09-26)
```

Sources Changelog:
```
nix-fast-build: 135fd0edf1dff4128f6f38822dbb24f333b8073f → 862aa595b7e2494eb7df611a016ef910cf3e9fd3
prismlauncher_catppuccin: 2edbdf5295bc3c12c3dd53b203ab91028fce2c54 → 1ef0e745286ce32750abc3bc5d3ca8073a623b60
joplin_catppuccin: 96d4311a079a5cd1c990d654853a63df0d962027 → 780ff535705411a92cb8d939b51a0e9abf5b8688
```
