### PR TITLE
chore: update flake.lock & sources (2025-10-25)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -43,7 +43,7 @@
     },
     "eza_themes": {
         "cargoLocks": null,
-        "date": "2025-08-03",
+        "date": "2025-10-12",
         "extract": null,
         "name": "eza_themes",
         "passthru": null,
@@ -55,12 +55,12 @@
             "name": null,
             "owner": "eza-community",
             "repo": "eza-themes",
-            "rev": "17095bff4792eecd7f4f1ed8301b15000331c906",
-            "sha256": "sha256-2WTbCQlhwMo5cOn3KwtNiIst0tNfASfZnPNsNBs+gcU=",
+            "rev": "c03051f67e84110fbae91ab7cbc377b3460f035c",
+            "sha256": "sha256-qEC7H9/ghnjkwmMZ788TSgS9ysyIfD+3NHCjxq0Dps0=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "17095bff4792eecd7f4f1ed8301b15000331c906"
+        "version": "c03051f67e84110fbae91ab7cbc377b3460f035c"
     },
     "filen": {
         "cargoLocks": null,
@@ -91,16 +91,16 @@
             "name": null,
             "owner": "rafaelmardojai",
             "repo": "firefox-gnome-theme",
-            "rev": "v142",
-            "sha256": "sha256-kyxuK5Fras7QYiJmUomqdq8NlgWV66hmNvxcJnGCpUE=",
+            "rev": "v143",
+            "sha256": "sha256-0E3TqvXAy81qeM/jZXWWOTZ14Hs1RT7o78UyZM+Jbr4=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "v142"
+        "version": "v143"
     },
     "joplin_catppuccin": {
         "cargoLocks": null,
-        "date": "2025-05-11",
+        "date": "2025-09-16",
         "extract": null,
         "name": "joplin_catppuccin",
         "passthru": null,
@@ -112,16 +112,16 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "joplin",
-            "rev": "96d4311a079a5cd1c990d654853a63df0d962027",
-            "sha256": "sha256-XJOCk6Gts7n3sqWM2kTJ1X5T/QoKMBLCEmR+dhJ6+IM=",
+            "rev": "780ff535705411a92cb8d939b51a0e9abf5b8688",
+            "sha256": "sha256-xl9zjVQUHCT3yo5GAsjcfBh1yVM4ryYj/u1v0ws4Ik8=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "96d4311a079a5cd1c990d654853a63df0d962027"
+        "version": "780ff535705411a92cb8d939b51a0e9abf5b8688"
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2025-08-31",
+        "date": "2025-10-22",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -133,12 +133,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "135fd0edf1dff4128f6f38822dbb24f333b8073f",
-            "sha256": "sha256-ai5enFBtuTqdAnJs2fG4TatnvmJtAPEgMf3oA726FBc=",
+            "rev": "f50063e40cc6ac9f46d8dcd515ca5b025ce95b1a",
+            "sha256": "sha256-x0te9hJrB+GO0Y6d0jSEK0XQNt7xuEO7vdeYPIdHaeQ=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "135fd0edf1dff4128f6f38822dbb24f333b8073f"
+        "version": "f50063e40cc6ac9f46d8dcd515ca5b025ce95b1a"
     },
     "obs_catppuccin": {
         "cargoLocks": null,
@@ -163,7 +163,7 @@
     },
     "prismlauncher_catppuccin": {
         "cargoLocks": null,
-        "date": "2024-06-11",
+        "date": "2025-09-08",
         "extract": null,
         "name": "prismlauncher_catppuccin",
         "passthru": null,
@@ -175,12 +175,12 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "prismlauncher",
-            "rev": "2edbdf5295bc3c12c3dd53b203ab91028fce2c54",
-            "sha256": "sha256-+yGrSZztf2sZ9frPT3ydIJDavo4eXs03cQWfdTAmn3w=",
+            "rev": "1ef0e745286ce32750abc3bc5d3ca8073a623b60",
+            "sha256": "sha256-RN1VM29OH75GHSHgpu3HW8YSonIEnX7MZzCObJ6BwtQ=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "2edbdf5295bc3c12c3dd53b203ab91028fce2c54"
+        "version": "1ef0e745286ce32750abc3bc5d3ca8073a623b60"
     },
     "rofi-bluetooth": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -32,15 +32,15 @@
   };
   eza_themes = {
     pname = "eza_themes";
-    version = "17095bff4792eecd7f4f1ed8301b15000331c906";
+    version = "c03051f67e84110fbae91ab7cbc377b3460f035c";
     src = fetchFromGitHub {
       owner = "eza-community";
       repo = "eza-themes";
-      rev = "17095bff4792eecd7f4f1ed8301b15000331c906";
+      rev = "c03051f67e84110fbae91ab7cbc377b3460f035c";
       fetchSubmodules = false;
-      sha256 = "sha256-2WTbCQlhwMo5cOn3KwtNiIst0tNfASfZnPNsNBs+gcU=";
+      sha256 = "sha256-qEC7H9/ghnjkwmMZ788TSgS9ysyIfD+3NHCjxq0Dps0=";
     };
-    date = "2025-08-03";
+    date = "2025-10-12";
   };
   filen = {
     pname = "filen";
@@ -52,38 +52,38 @@
   };
   firefox-gnome-theme = {
     pname = "firefox-gnome-theme";
-    version = "v142";
+    version = "v143";
     src = fetchFromGitHub {
       owner = "rafaelmardojai";
       repo = "firefox-gnome-theme";
-      rev = "v142";
+      rev = "v143";
       fetchSubmodules = false;
-      sha256 = "sha256-kyxuK5Fras7QYiJmUomqdq8NlgWV66hmNvxcJnGCpUE=";
+      sha256 = "sha256-0E3TqvXAy81qeM/jZXWWOTZ14Hs1RT7o78UyZM+Jbr4=";
     };
   };
   joplin_catppuccin = {
     pname = "joplin_catppuccin";
-    version = "96d4311a079a5cd1c990d654853a63df0d962027";
+    version = "780ff535705411a92cb8d939b51a0e9abf5b8688";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "joplin";
-      rev = "96d4311a079a5cd1c990d654853a63df0d962027";
+      rev = "780ff535705411a92cb8d939b51a0e9abf5b8688";
       fetchSubmodules = false;
-      sha256 = "sha256-XJOCk6Gts7n3sqWM2kTJ1X5T/QoKMBLCEmR+dhJ6+IM=";
+      sha256 = "sha256-xl9zjVQUHCT3yo5GAsjcfBh1yVM4ryYj/u1v0ws4Ik8=";
     };
-    date = "2025-05-11";
+    date = "2025-09-16";
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "135fd0edf1dff4128f6f38822dbb24f333b8073f";
+    version = "f50063e40cc6ac9f46d8dcd515ca5b025ce95b1a";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "135fd0edf1dff4128f6f38822dbb24f333b8073f";
+      rev = "f50063e40cc6ac9f46d8dcd515ca5b025ce95b1a";
       fetchSubmodules = false;
-      sha256 = "sha256-ai5enFBtuTqdAnJs2fG4TatnvmJtAPEgMf3oA726FBc=";
+      sha256 = "sha256-x0te9hJrB+GO0Y6d0jSEK0XQNt7xuEO7vdeYPIdHaeQ=";
     };
-    date = "2025-08-31";
+    date = "2025-10-22";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";
@@ -99,15 +99,15 @@
   };
   prismlauncher_catppuccin = {
     pname = "prismlauncher_catppuccin";
-    version = "2edbdf5295bc3c12c3dd53b203ab91028fce2c54";
+    version = "1ef0e745286ce32750abc3bc5d3ca8073a623b60";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "prismlauncher";
-      rev = "2edbdf5295bc3c12c3dd53b203ab91028fce2c54";
+      rev = "1ef0e745286ce32750abc3bc5d3ca8073a623b60";
       fetchSubmodules = false;
-      sha256 = "sha256-+yGrSZztf2sZ9frPT3ydIJDavo4eXs03cQWfdTAmn3w=";
+      sha256 = "sha256-RN1VM29OH75GHSHgpu3HW8YSonIEnX7MZzCObJ6BwtQ=";
     };
-    date = "2024-06-11";
+    date = "2025-09-08";
   };
   rofi-bluetooth = {
     pname = "rofi-bluetooth";

--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1754433428,
-        "narHash": "sha256-NA/FT2hVhKDftbHSwVnoRTFhes62+7dxZbxj5Gxvghs=",
+        "lastModified": 1760836749,
+        "narHash": "sha256-wyT7Pl6tMFbFrs8Lk/TlEs81N6L+VSybPfiIgzU8lbQ=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "9edb1787864c4f59ae5074ad498b6272b3ec308d",
+        "rev": "2f0f812f69f3eb4140157fe15e12739adf82e32a",
         "type": "github"
       },
       "original": {
@@ -46,16 +46,17 @@
     "base16-fish": {
       "flake": false,
       "locked": {
-        "lastModified": 1622559957,
-        "narHash": "sha256-PebymhVYbL8trDVVXxCvZgc0S5VxI7I1Hv4RMSquTpA=",
+        "lastModified": 1754405784,
+        "narHash": "sha256-l9xHIy+85FN+bEo6yquq2IjD1rSg9fjfjpyGP1W8YXo=",
         "owner": "tomyun",
         "repo": "base16-fish",
-        "rev": "2f6dd973a9075dabccd26f1cded09508180bf5fe",
+        "rev": "23ae20a0093dca0d7b39d76ba2401af0ccf9c561",
         "type": "github"
       },
       "original": {
         "owner": "tomyun",
         "repo": "base16-fish",
+        "rev": "23ae20a0093dca0d7b39d76ba2401af0ccf9c561",
         "type": "github"
       }
     },
@@ -142,12 +143,12 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1757699119,
-        "narHash": "sha256-iOOoVdrkcyk95Xg68TuPeAwpz+v80mgZCqil0jpPZuY=",
-        "rev": "1e16c8f8a44573bb0648c76b6c98352436f5171e",
-        "revCount": 304,
+        "lastModified": 1761251546,
+        "narHash": "sha256-I/TDYHCKui0K62f2cEk2UJf6N9rO/hdsa65kpEJMhSo=",
+        "rev": "70beec406153496943274f59cb2ded76be49fcd7",
+        "revCount": 306,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/3.11.2/01993f0b-1215-7072-ac1a-f2b27b566115/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/3.12.0/019a12c8-c95c-7c68-8da4-d8cc92608fbf/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -157,37 +158,37 @@
     "determinate-nixd-aarch64-darwin": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-q1tqDvmfjDgLk/wbYf4pRhyHDS94iY85Q79FPBtcv7g=",
+        "narHash": "sha256-TORlljq+wwn8XWLoN0giLY15pNiIAXuU0igpIXjLhMY=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.11.2/macOS"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.12.0/macOS"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.11.2/macOS"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.12.0/macOS"
       }
     },
     "determinate-nixd-aarch64-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-E1vGfcQ5dqtRG9EDP6eOQWCnCIRB2XFkFBp2C4FgQ8c=",
+        "narHash": "sha256-1HEvUQcG0mVdEQrEqcLEdB9nHpMNbb39bdNxdvyizqk=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.11.2/aarch64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.12.0/aarch64-linux"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.11.2/aarch64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.12.0/aarch64-linux"
       }
     },
     "determinate-nixd-x86_64-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-GtxtkI0cOC2A30Xw6gCDTN7JxN1zJGh7/eIXr6AlTSA=",
+        "narHash": "sha256-WrXQbrXVisAdZl/hh49PsErSPHwzks1Vw+O3jarVjDo=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.11.2/x86_64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.12.0/x86_64-linux"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.11.2/x86_64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.12.0/x86_64-linux"
       }
     },
     "devshell": {
@@ -213,11 +214,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1756083905,
-        "narHash": "sha256-UqYGTBgI5ypGh0Kf6zZjom/vABg7HQocB4gmxzl12uo=",
+        "lastModified": 1758112371,
+        "narHash": "sha256-lizRM2pj6PHrR25yimjyFn04OS4wcdbc38DCdBVa2rk=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "b655eaf16d4cbec9c3472f62eee285d4b419a808",
+        "rev": "0909cfe4a2af8d358ad13b20246a350e14c2473d",
         "type": "github"
       },
       "original": {
@@ -316,11 +317,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1760948891,
+        "narHash": "sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "864599284fc7c0ba6357ed89ed5e2cd5040f0c04",
         "type": "github"
       },
       "original": {
@@ -428,24 +429,6 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_4"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "fromYaml": {
       "flake": false,
       "locked": {
@@ -471,11 +454,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757588530,
-        "narHash": "sha256-tJ7A8mID3ct69n9WCvZ3PzIIl3rXTdptn/lZmqSS95U=",
+        "lastModified": 1760663237,
+        "narHash": "sha256-BflA6U4AM1bzuRMR8QqzPXqh8sWVCNDzOdsxXEguJIc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "b084b2c2b6bc23e83bbfe583b03664eb0b18c411",
+        "rev": "ca5b894d3e3e151ffc1db040b6ce4dcc75d31c37",
         "type": "github"
       },
       "original": {
@@ -577,11 +560,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757920978,
-        "narHash": "sha256-Mv16aegXLulgyDunijP6SPFJNm8lSXb2w3Q0X+vZ9TY=",
+        "lastModified": 1761395627,
+        "narHash": "sha256-9wQpgBRW2PzYw1wx+MgCt1IbPAYz93csApLMgSZOJCk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "11cc5449c50e0e5b785be3dfcb88245232633eb8",
+        "rev": "7296022150cd775917e4c831c393026eae7c2427",
         "type": "github"
       },
       "original": {
@@ -687,12 +670,12 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1757694985,
-        "narHash": "sha256-3Ia+y7Hbwnzcuf1hyuVnFtbnSR6ErQeFjemHdVxjCNE=",
-        "rev": "766f43aa6acb1b3578db488c19fbbedf04ed9f24",
-        "revCount": 22340,
+        "lastModified": 1761238235,
+        "narHash": "sha256-BvEZ31+FQKJz2XH8PTXpJqGZ1eT9bhMQ2wBj2ehBYvM=",
+        "rev": "9512828397f684d0f732ea76b7631f69a0db34f7",
+        "revCount": 23138,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.11.2/01993ee9-f8e7-7b80-80df-ec0a20a32514/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.12.0/019a1277-d4c6-7dca-9d55-ee5165fd0bf6/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -720,11 +703,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757822619,
-        "narHash": "sha256-3HIpe3P2h1AUPYcAH9cjuX0tZOqJpX01c0iDwoUYNZ8=",
+        "lastModified": 1760846226,
+        "narHash": "sha256-xmU8kAsRprJiTGBTaGrwmjBP3AMA9ltlrxHKFuy5JWc=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "050a5feb5d1bb5b6e5fc04a7d3d816923a87c9ea",
+        "rev": "5024e1901239a76b7bf94a4cd27f3507e639d49e",
         "type": "github"
       },
       "original": {
@@ -735,15 +718,14 @@
     },
     "nix-vscode-extensions": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1757901553,
-        "narHash": "sha256-gW45THWkxnzWpPtjuaDeTnpKFB6i5cZmxk4WuGKhCNc=",
+        "lastModified": 1761356956,
+        "narHash": "sha256-qheNc4YWy/lzrY69NTFlE4uXsv+IijorjjIBszHUT2s=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "846f1334090a2c44d77850c00d0c17a27ad66618",
+        "rev": "cc2e15a69d4295493a68a9a2248adc68ed42f792",
         "type": "github"
       },
       "original": {
@@ -884,12 +866,12 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1757034884,
-        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
-        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
-        "revCount": 856744,
+        "lastModified": 1760965567,
+        "narHash": "sha256-0JDOal5P7xzzAibvD0yTE3ptyvoVOAL0rcELmDdtSKg=",
+        "rev": "cb82756ecc37fa623f8cf3e88854f9bf7f64af93",
+        "revCount": 880602,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.856744%2Brev-ca77296380960cd497a765102eeb1356eb80fed0/01992cf9-9347-761a-8963-9cbe43abe2fa/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.880602%2Brev-cb82756ecc37fa623f8cf3e88854f9bf7f64af93/019a0545-358b-78f4-97fe-88a7820eac2f/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -914,11 +896,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1760524057,
+        "narHash": "sha256-EVAqOteLBFmd7pKkb0+FIUyzTF61VKi7YmvP1tw4nEw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "544961dfcce86422ba200ed9a0b00dd4b1486ec5",
         "type": "github"
       },
       "original": {
@@ -930,17 +912,17 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1744868846,
-        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
-        "owner": "NixOS",
+        "lastModified": 1759770925,
+        "narHash": "sha256-CZwkCtzTNclqlhuwDsVtGoRumTpqCUK0xSnFIMgd8ls=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "674c2b09c59a220204350ced584cadaacee30038",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "674c2b09c59a220204350ced584cadaacee30038",
         "type": "github"
       }
     },
@@ -962,11 +944,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1761114652,
+        "narHash": "sha256-f/QCJM/YhrV/lavyCVz8iU3rlZun6d+dAiC3H+CDle4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "01f116e4df6a15f4ccdffb1bcd41096869fb385c",
         "type": "github"
       },
       "original": {
@@ -978,11 +960,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1761114652,
+        "narHash": "sha256-f/QCJM/YhrV/lavyCVz8iU3rlZun6d+dAiC3H+CDle4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "01f116e4df6a15f4ccdffb1bcd41096869fb385c",
         "type": "github"
       },
       "original": {
@@ -994,11 +976,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1756819007,
-        "narHash": "sha256-12V64nKG/O/guxSYnr5/nq1EfqwJCdD2+cIGmhz3nrE=",
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aaff8c16d7fc04991cac6245bee1baa31f72b1e1",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
         "type": "github"
       },
       "original": {
@@ -1014,11 +996,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757946652,
-        "narHash": "sha256-PpPoePu9UIJdjtuaQ1xLM8PVqekI2s9im7r3SWgpVtU=",
+        "lastModified": 1761407082,
+        "narHash": "sha256-Pm8NDHKn1sAlN0H367gc+a5+IGIVFb6JDi9p7t8+GvE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c4ccef96fa4d2411b89a3696d3e871047219b93",
+        "rev": "1a12617a8a5308fecc7a2142146841202ec2491a",
         "type": "github"
       },
       "original": {
@@ -1039,11 +1021,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756961635,
-        "narHash": "sha256-hETvQcILTg5kChjYNns1fD5ELdsYB/VVgVmBtqKQj9A=",
+        "lastModified": 1758998580,
+        "narHash": "sha256-VLx0z396gDCGSiowLMFz5XRO/XuNV+4EnDYjdJhHvUk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ca27b2654ac55e3f6e0ca434c1b4589ae22b370",
+        "rev": "ba8d9c98f5f4630bcb0e815ab456afd90c930728",
         "type": "github"
       },
       "original": {
@@ -1062,11 +1044,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756632588,
-        "narHash": "sha256-ydam6eggXf3ZwRutyCABwSbMAlX+5lW6w1SVZQ+kfSo=",
+        "lastModified": 1761078382,
+        "narHash": "sha256-JNJesbe9MMN1Brq41BHEpuH+Z+Zg74y/nI5AFZX84Vw=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "d47428e5390d6a5a8f764808a4db15929347cd77",
+        "rev": "27dfa61b64d0cdb8e4ba6f3aaa4d4e067d64cb5c",
         "type": "github"
       },
       "original": {
@@ -1123,7 +1105,7 @@
         "plasma-manager": "plasma-manager",
         "spicetify-nix": "spicetify-nix",
         "stylix": "stylix",
-        "systems": "systems_7"
+        "systems": "systems_6"
       }
     },
     "rust-overlay": {
@@ -1173,14 +1155,14 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_5"
+        "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1757824114,
-        "narHash": "sha256-cyVbc8UxyWKAuXOgqLggil2mXLZWY0wyfBWYqUwgYjM=",
+        "lastModified": 1760848035,
+        "narHash": "sha256-H3MFH8+i4wFagkebtHPcosQdkmxQ4a6fl1lMbLb+RkA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "d23584b2000b7f7a59a1764ff9ab93b89444bfd9",
+        "rev": "cde9f78ae705343a38f5d1d19ab34858b5e9caa9",
         "type": "github"
       },
       "original": {
@@ -1200,7 +1182,7 @@
         "gnome-shell": "gnome-shell",
         "nixpkgs": "nixpkgs_9",
         "nur": "nur_2",
-        "systems": "systems_6",
+        "systems": "systems_5",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
@@ -1208,11 +1190,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1757360005,
-        "narHash": "sha256-VwzdFEQCpYMU9mc7BSQGQe5wA1MuTYPJnRc9TQCTMcM=",
+        "lastModified": 1761028816,
+        "narHash": "sha256-s1XiIeJHpODVWfzsPaK9e21iz1dQSCU3H4/1OxOsyps=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "834a743c11d66ea18e8c54872fbcc72ce48bc57f",
+        "rev": "b81dc0a385443099e7d231fe6275189e32c3b760",
         "type": "github"
       },
       "original": {
@@ -1311,21 +1293,6 @@
         "type": "github"
       }
     },
-    "systems_7": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "tinted-foot": {
       "flake": false,
       "locked": {
@@ -1362,11 +1329,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1754779259,
-        "narHash": "sha256-8KG2lXGaXLUE0F/JVwLQe7kOVm21IDfNEo0gfga5P4M=",
+        "lastModified": 1757716333,
+        "narHash": "sha256-d4km8W7w2zCUEmPAPUoLk1NlYrGODuVa3P7St+UrqkM=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "097d751b9e3c8b97ce158e7d141e5a292545b502",
+        "rev": "317a5e10c35825a6c905d912e480dfe8e71c7559",
         "type": "github"
       },
       "original": {
@@ -1378,11 +1345,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1754788770,
-        "narHash": "sha256-LAu5nBr7pM/jD9jwFc6/kyFY4h7Us4bZz7dvVvehuwo=",
+        "lastModified": 1757811970,
+        "narHash": "sha256-n5ZJgmzGZXOD9pZdAl1OnBu3PIqD+X3vEBUGbTi4JiI=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "fb2175accef8935f6955503ec9dd3c973eec385c",
+        "rev": "d217ba31c846006e9e0ae70775b0ee0f00aa6b1e",
         "type": "github"
       },
       "original": {
@@ -1394,11 +1361,11 @@
     "tinted-zed": {
       "flake": false,
       "locked": {
-        "lastModified": 1755613540,
-        "narHash": "sha256-zBFrrTxHLDMDX/OYxkCwGGbAhPXLi8FrnLhYLsSOKeY=",
+        "lastModified": 1757811247,
+        "narHash": "sha256-4EFOUyLj85NRL3OacHoLGEo0wjiRJzfsXtR4CZWAn6w=",
         "owner": "tinted-theming",
         "repo": "base16-zed",
-        "rev": "937bada16cd3200bdbd3a2f5776fc3b686d5cba0",
+        "rev": "824fe0aacf82b3c26690d14e8d2cedd56e18404e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 43

Flakes Changelog:
```
• Updated input 'agenix':
    'github:ryantm/agenix/9edb1787864c4f59ae5074ad498b6272b3ec308d' (2025-08-05)
  → 'github:ryantm/agenix/2f0f812f69f3eb4140157fe15e12739adf82e32a' (2025-10-19)
• Updated input 'determinate':
    'https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/3.11.2/01993f0b-1215-7072-ac1a-f2b27b566115/source.tar.gz?narHash=sha256-iOOoVdrkcyk95Xg68TuPeAwpz%2Bv80mgZCqil0jpPZuY%3D' (2025-09-12)
  → 'https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/3.12.0/019a12c8-c95c-7c68-8da4-d8cc92608fbf/source.tar.gz?narHash=sha256-I/TDYHCKui0K62f2cEk2UJf6N9rO/hdsa65kpEJMhSo%3D' (2025-10-23)
• Updated input 'determinate/determinate-nixd-aarch64-darwin':
• Updated input 'determinate/determinate-nixd-aarch64-linux':
• Updated input 'determinate/determinate-nixd-x86_64-linux':
• Updated input 'determinate/nix':
    'https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.11.2/01993ee9-f8e7-7b80-80df-ec0a20a32514/source.tar.gz?narHash=sha256-3Ia%2By7Hbwnzcuf1hyuVnFtbnSR6ErQeFjemHdVxjCNE%3D' (2025-09-12)
  → 'https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.12.0/019a1277-d4c6-7dca-9d55-ee5165fd0bf6/source.tar.gz?narHash=sha256-BvEZ31%2BFQKJz2XH8PTXpJqGZ1eT9bhMQ2wBj2ehBYvM%3D' (2025-10-23)
• Updated input 'determinate/nixpkgs':
    'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.856744%2Brev-ca77296380960cd497a765102eeb1356eb80fed0/01992cf9-9347-761a-8963-9cbe43abe2fa/source.tar.gz?narHash=sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao%3D' (2025-09-05)
  → 'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.880602%2Brev-cb82756ecc37fa623f8cf3e88854f9bf7f64af93/019a0545-358b-78f4-97fe-88a7820eac2f/source.tar.gz?narHash=sha256-0JDOal5P7xzzAibvD0yTE3ptyvoVOAL0rcELmDdtSKg%3D' (2025-10-20)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/4524271976b625a4a605beefd893f270620fd751' (2025-09-01)
  → 'github:hercules-ci/flake-parts/864599284fc7c0ba6357ed89ed5e2cd5040f0c04' (2025-10-20)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/b084b2c2b6bc23e83bbfe583b03664eb0b18c411' (2025-09-11)
  → 'github:cachix/git-hooks.nix/ca5b894d3e3e151ffc1db040b6ce4dcc75d31c37' (2025-10-17)
• Updated input 'home-manager':
    'github:nix-community/home-manager/11cc5449c50e0e5b785be3dfcb88245232633eb8' (2025-09-15)
  → 'github:nix-community/home-manager/7296022150cd775917e4c831c393026eae7c2427' (2025-10-25)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/050a5feb5d1bb5b6e5fc04a7d3d816923a87c9ea' (2025-09-14)
  → 'github:nix-community/nix-index-database/5024e1901239a76b7bf94a4cd27f3507e639d49e' (2025-10-19)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/c23193b943c6c689d70ee98ce3128239ed9e32d1' (2025-09-13)
  → 'github:NixOS/nixpkgs/544961dfcce86422ba200ed9a0b00dd4b1486ec5' (2025-10-15)
• Updated input 'nix-vscode-extensions':
    'github:nix-community/nix-vscode-extensions/846f1334090a2c44d77850c00d0c17a27ad66618' (2025-09-15)
  → 'github:nix-community/nix-vscode-extensions/cc2e15a69d4295493a68a9a2248adc68ed42f792' (2025-10-25)
• Updated input 'nix-vscode-extensions/nixpkgs':
    'github:NixOS/nixpkgs/ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c' (2025-04-17)
  → 'github:nixos/nixpkgs/674c2b09c59a220204350ced584cadaacee30038' (2025-10-06)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c23193b943c6c689d70ee98ce3128239ed9e32d1' (2025-09-13)
  → 'github:NixOS/nixpkgs/01f116e4df6a15f4ccdffb1bcd41096869fb385c' (2025-10-22)
• Updated input 'nur':
    'github:nix-community/NUR/9c4ccef96fa4d2411b89a3696d3e871047219b93' (2025-09-15)
  → 'github:nix-community/NUR/1a12617a8a5308fecc7a2142146841202ec2491a' (2025-10-25)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/c23193b943c6c689d70ee98ce3128239ed9e32d1' (2025-09-13)
  → 'github:nixos/nixpkgs/01f116e4df6a15f4ccdffb1bcd41096869fb385c' (2025-10-22)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/d47428e5390d6a5a8f764808a4db15929347cd77' (2025-08-31)
  → 'github:nix-community/plasma-manager/27dfa61b64d0cdb8e4ba6f3aaa4d4e067d64cb5c' (2025-10-21)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/d23584b2000b7f7a59a1764ff9ab93b89444bfd9' (2025-09-14)
  → 'github:Gerg-L/spicetify-nix/cde9f78ae705343a38f5d1d19ab34858b5e9caa9' (2025-10-19)
• Updated input 'stylix':
    'github:danth/stylix/834a743c11d66ea18e8c54872fbcc72ce48bc57f' (2025-09-08)
  → 'github:danth/stylix/b81dc0a385443099e7d231fe6275189e32c3b760' (2025-10-21)
• Updated input 'stylix/base16-fish':
    'github:tomyun/base16-fish/2f6dd973a9075dabccd26f1cded09508180bf5fe' (2021-06-01)
  → 'github:tomyun/base16-fish/23ae20a0093dca0d7b39d76ba2401af0ccf9c561' (2025-08-05)
• Updated input 'stylix/firefox-gnome-theme':
    'github:rafaelmardojai/firefox-gnome-theme/b655eaf16d4cbec9c3472f62eee285d4b419a808' (2025-08-25)
  → 'github:rafaelmardojai/firefox-gnome-theme/0909cfe4a2af8d358ad13b20246a350e14c2473d' (2025-09-17)
• Updated input 'stylix/nixpkgs':
    'github:NixOS/nixpkgs/aaff8c16d7fc04991cac6245bee1baa31f72b1e1' (2025-09-02)
  → 'github:NixOS/nixpkgs/e643668fd71b949c53f8626614b21ff71a07379d' (2025-09-24)
• Updated input 'stylix/nur':
    'github:nix-community/NUR/6ca27b2654ac55e3f6e0ca434c1b4589ae22b370' (2025-09-04)
  → 'github:nix-community/NUR/ba8d9c98f5f4630bcb0e815ab456afd90c930728' (2025-09-27)
• Updated input 'stylix/tinted-schemes':
    'github:tinted-theming/schemes/097d751b9e3c8b97ce158e7d141e5a292545b502' (2025-08-09)
  → 'github:tinted-theming/schemes/317a5e10c35825a6c905d912e480dfe8e71c7559' (2025-09-12)
• Updated input 'stylix/tinted-tmux':
    'github:tinted-theming/tinted-tmux/fb2175accef8935f6955503ec9dd3c973eec385c' (2025-08-10)
  → 'github:tinted-theming/tinted-tmux/d217ba31c846006e9e0ae70775b0ee0f00aa6b1e' (2025-09-14)
• Updated input 'stylix/tinted-zed':
    'github:tinted-theming/base16-zed/937bada16cd3200bdbd3a2f5776fc3b686d5cba0' (2025-08-19)
  → 'github:tinted-theming/base16-zed/824fe0aacf82b3c26690d14e8d2cedd56e18404e' (2025-09-14)
```

Sources Changelog:
```
nix-fast-build: 135fd0edf1dff4128f6f38822dbb24f333b8073f → f50063e40cc6ac9f46d8dcd515ca5b025ce95b1a
joplin_catppuccin: 96d4311a079a5cd1c990d654853a63df0d962027 → 780ff535705411a92cb8d939b51a0e9abf5b8688
eza_themes: 17095bff4792eecd7f4f1ed8301b15000331c906 → c03051f67e84110fbae91ab7cbc377b3460f035c
firefox-gnome-theme: v142 → v143
prismlauncher_catppuccin: 2edbdf5295bc3c12c3dd53b203ab91028fce2c54 → 1ef0e745286ce32750abc3bc5d3ca8073a623b60
```
