### PR TITLE
chore: update flake.lock & sources (2026-01-10)

### DIFF
--- a/System/Lenovo-Laptop/Packages/adb.nix
+++ b/System/Lenovo-Laptop/Packages/adb.nix
@@ -1,3 +1,4 @@
+{ pkgs, ... }:
 {
-  programs.adb.enable = true;
+  environment.systemPackages = with pkgs; [ android-tools ];
 }

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2025-12-29",
+        "date": "2026-01-04",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "a3cbd5090711b9ca5811efdddef34b24d168100a",
-            "sha256": "sha256-vizR+bjRnVHlRhTuiQxB01eBzjMoOJcI16zMxKuHBQ4=",
+            "rev": "8bdcf0842574b902143871a27064131d9e526b94",
+            "sha256": "sha256-+sU5tsQqo5//LqE18IOX7YC/kD0eNZo3LHD/+mx4pXs=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "a3cbd5090711b9ca5811efdddef34b24d168100a"
+        "version": "8bdcf0842574b902143871a27064131d9e526b94"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "a3cbd5090711b9ca5811efdddef34b24d168100a";
+    version = "8bdcf0842574b902143871a27064131d9e526b94";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "a3cbd5090711b9ca5811efdddef34b24d168100a";
+      rev = "8bdcf0842574b902143871a27064131d9e526b94";
       fetchSubmodules = false;
-      sha256 = "sha256-vizR+bjRnVHlRhTuiQxB01eBzjMoOJcI16zMxKuHBQ4=";
+      sha256 = "sha256-+sU5tsQqo5//LqE18IOX7YC/kD0eNZo3LHD/+mx4pXs=";
     };
-    date = "2025-12-29";
+    date = "2026-01-04";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1764724327,
-        "narHash": "sha256-OkFLrD3pFR952TrjQi1+Vdj604KLcMnkpa7lkW7XskI=",
+        "lastModified": 1764873433,
+        "narHash": "sha256-1XPewtGMi+9wN9Ispoluxunw/RwozuTRVuuQOmxzt+A=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "66b7c635763d8e6eb86bd766de5a1e1fbfcc1047",
+        "rev": "f7ffd917ac0d253dbd6a3bf3da06888f57c69f92",
         "type": "github"
       },
       "original": {
@@ -219,11 +219,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1765835352,
-        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
+        "lastModified": 1767609335,
+        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
+        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
         "type": "github"
       },
       "original": {
@@ -282,11 +282,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763759067,
-        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
+        "lastModified": 1767609335,
+        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
+        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
         "type": "github"
       },
       "original": {
@@ -398,11 +398,11 @@
       "flake": false,
       "locked": {
         "host": "gitlab.gnome.org",
-        "lastModified": 1764524476,
-        "narHash": "sha256-bTmNn3Q4tMQ0J/P0O5BfTQwqEnCiQIzOGef9/aqAZvk=",
+        "lastModified": 1767737596,
+        "narHash": "sha256-eFujfIUQDgWnSJBablOuG+32hCai192yRdrNHTv0a+s=",
         "owner": "GNOME",
         "repo": "gnome-shell",
-        "rev": "c0e1ad9f0f703fd0519033b8f46c3267aab51a22",
+        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
         "type": "gitlab"
       },
       "original": {
@@ -420,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767437240,
-        "narHash": "sha256-OA0dBHhccdupFXp+/eaFfb8K1dQxk61in4aF5ITGVX8=",
+        "lastModified": 1768062556,
+        "narHash": "sha256-jgC3INik4sJCx31bR+DJMNCoRtSf/9rKL1ZSBVRL0AU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1cfa305fba94468f665de1bd1b62dddf2e0cb012",
+        "rev": "312c4fe0bbf054e3c87ebad51792f2e6d2ce4f01",
         "type": "github"
       },
       "original": {
@@ -461,11 +461,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1766564648,
-        "narHash": "sha256-xgMcrwKhFSQeSQN7ak0iUHNsnxaprEzuRYRo2ADeTtg=",
+        "lastModified": 1767767975,
+        "narHash": "sha256-yBejG3j6OLQYn87UozFAI3q9a1vH00u9xjIf2Q4V5j8=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "17ecff630bece1ac81569e427088ee8b11322f36",
+        "rev": "0e73df1dfedf0f6fa21ed0ae5e031b0663c8f400",
         "type": "github"
       },
       "original": {
@@ -502,11 +502,11 @@
     },
     "nix-flatpak": {
       "locked": {
-        "lastModified": 1739444422,
-        "narHash": "sha256-iAVVHi7X3kWORftY+LVbRiStRnQEob2TULWyjMS6dWg=",
+        "lastModified": 1767983141,
+        "narHash": "sha256-7ZCulYUD9RmJIDULTRkGLSW1faMpDlPKcbWJLYHoXcs=",
         "owner": "gmodena",
         "repo": "nix-flatpak",
-        "rev": "5e54c3ca05a7c7d968ae1ddeabe01d2a9bc1e177",
+        "rev": "440818969ac2cbd77bfe025e884d0aa528991374",
         "type": "github"
       },
       "original": {
@@ -542,11 +542,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1767405952,
-        "narHash": "sha256-l/ye/05HEGz3Wz2MIXuagsIEkoSb3JQbcijGqdtCEEY=",
+        "lastModified": 1768011069,
+        "narHash": "sha256-n2mL0Mzc7cc4CBpAZNLoEpi0O7xzv9bFFAF31YtW7XA=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "e5cd9785ba5205519b7e367693de37d457ce6d25",
+        "rev": "6c8e10292b702380b55fb0f83e10d7360dae5680",
         "type": "github"
       },
       "original": {
@@ -673,11 +673,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1767379071,
-        "narHash": "sha256-EgE0pxsrW9jp9YFMkHL9JMXxcqi/OoumPJYwf+Okucw=",
+        "lastModified": 1767892417,
+        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fb7944c166a3b630f177938e478f0378e64ce108",
+        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1767379071,
-        "narHash": "sha256-EgE0pxsrW9jp9YFMkHL9JMXxcqi/OoumPJYwf+Okucw=",
+        "lastModified": 1767892417,
+        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fb7944c166a3b630f177938e478f0378e64ce108",
+        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
         "type": "github"
       },
       "original": {
@@ -705,11 +705,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1766651565,
-        "narHash": "sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU=",
+        "lastModified": 1767767207,
+        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e2499d5539c16d0d173ba53552a4ff8547f4539",
+        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1767462501,
-        "narHash": "sha256-/xLq1QUbLA+QzsP7oI+pLT/S/yBCJYhQU9ILNTmLrsg=",
+        "lastModified": 1768059548,
+        "narHash": "sha256-NSMGzFQtoZxdxrQiShWjfJ5k2gzW+atxcr8MiywI1eI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9748a501c4d61db47d4ff9718d150ef83816ca9c",
+        "rev": "a4f7c05a5f80044f9dcf3dfeb55a16b5a2713caf",
         "type": "github"
       },
       "original": {
@@ -750,11 +750,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764773531,
-        "narHash": "sha256-mCBl7MD1WZ7yCG6bR9MmpPO2VydpNkWFgnslJRIT1YU=",
+        "lastModified": 1767810917,
+        "narHash": "sha256-ZKqhk772+v/bujjhla9VABwcvz+hB2IaRyeLT6CFnT0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1d9616689e98beded059ad0384b9951e967a17fa",
+        "rev": "dead29c804adc928d3a69dfe7f9f12d0eec1f1a4",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763909441,
-        "narHash": "sha256-56LwV51TX/FhgX+5LCG6akQ5KrOWuKgcJa+eUsRMxsc=",
+        "lastModified": 1767662275,
+        "narHash": "sha256-d5Q1GmQ+sW1Bt8cgDE0vOihzLaswsm8cSdg8124EqXE=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "b24ed4b272256dfc1cc2291f89a9821d5f9e14b4",
+        "rev": "51816be33a1ff0d4b22427de83222d5bfa96d30e",
         "type": "github"
       },
       "original": {
@@ -884,11 +884,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1767195736,
-        "narHash": "sha256-0xvPSbhIGeJzsJXNTkgJ3PjwdVItKm85wzYKA9NmSzI=",
+        "lastModified": 1767502559,
+        "narHash": "sha256-om0IPjW850vhhIrNZ5tiXjsYuqyoI44IdE+I9AwZ96I=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "465adc0ab6ff0c4b9b1db1c6e7fd7eeb553b3261",
+        "rev": "806c1fdeb7af3e013215d14f5d9f06685fa6650f",
         "type": "github"
       },
       "original": {
@@ -916,11 +916,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1767397606,
-        "narHash": "sha256-QA1d/6XzxK3lsMiJ+xiJf340cpNeJs/xIM6D0/yLqs4=",
+        "lastModified": 1767903301,
+        "narHash": "sha256-h7HUP2xjbwjXb+DvAxIH6R9G1RdGCAQao8zCw3jj+yY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "6850ad2e9f3f7ff6116e9e6fb73a9cca2d9b1a35",
+        "rev": "2b727da436910c4a59b5fd2401609bd5cb7ec64a",
         "type": "github"
       },
       "original": {
@@ -1056,11 +1056,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1763914658,
-        "narHash": "sha256-Hju0WtMf3iForxtOwXqGp3Ynipo0EYx1AqMKLPp9BJw=",
+        "lastModified": 1767710407,
+        "narHash": "sha256-+W1EB79Jl0/gm4JqmO0Nuc5C7hRdp4vfsV/VdzI+des=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "0f6be815d258e435c9b137befe5ef4ff24bea32c",
+        "rev": "2800e2b8ac90f678d7e4acebe4fa253f602e05b2",
         "type": "github"
       },
       "original": {
@@ -1072,11 +1072,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1764465359,
-        "narHash": "sha256-lbSVPqLEk2SqMrnpvWuKYGCaAlfWFMA6MVmcOFJjdjE=",
+        "lastModified": 1767489635,
+        "narHash": "sha256-e6nnFnWXKBCJjCv4QG4bbcouJ6y3yeT70V9MofL32lU=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "edf89a780e239263cc691a987721f786ddc4f6aa",
+        "rev": "3c32729ccae99be44fe8a125d20be06f8d7d8184",
         "type": "github"
       },
       "original": {
@@ -1088,11 +1088,11 @@
     "tinted-zed": {
       "flake": false,
       "locked": {
-        "lastModified": 1764464512,
-        "narHash": "sha256-rCD/pAhkMdCx6blsFwxIyvBJbPZZ1oL2sVFrH07lmqg=",
+        "lastModified": 1767488740,
+        "narHash": "sha256-wVOj0qyil8m+ouSsVZcNjl5ZR+1GdOOAooAatQXHbuU=",
         "owner": "tinted-theming",
         "repo": "base16-zed",
-        "rev": "907dbba5fb8cf69ebfd90b00813418a412d0a29a",
+        "rev": "11abb0b282ad3786a2aae088d3a01c60916f2e40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 02

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/a34fae9c08a15ad73f295041fec82323541400a9' (2025-12-15)
  → 'github:hercules-ci/flake-parts/250481aafeb741edfe23d29195671c19b36b6dca' (2026-01-05)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1cfa305fba94468f665de1bd1b62dddf2e0cb012' (2026-01-03)
  → 'github:nix-community/home-manager/312c4fe0bbf054e3c87ebad51792f2e6d2ce4f01' (2026-01-10)
• Updated input 'hyprpanel':
    'github:Jas-SinghFSU/HyprPanel/17ecff630bece1ac81569e427088ee8b11322f36' (2025-12-24)
  → 'github:Jas-SinghFSU/HyprPanel/0e73df1dfedf0f6fa21ed0ae5e031b0663c8f400' (2026-01-07)
• Updated input 'nix-flatpak':
    'github:gmodena/nix-flatpak/5e54c3ca05a7c7d968ae1ddeabe01d2a9bc1e177' (2025-02-13)
  → 'github:gmodena/nix-flatpak/440818969ac2cbd77bfe025e884d0aa528991374' (2026-01-09)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/e5cd9785ba5205519b7e367693de37d457ce6d25' (2026-01-03)
  → 'github:nix-community/nix4vscode/6c8e10292b702380b55fb0f83e10d7360dae5680' (2026-01-10)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/fb7944c166a3b630f177938e478f0378e64ce108' (2026-01-02)
  → 'github:NixOS/nixpkgs/3497aa5c9457a9d88d71fa93a4a8368816fbeeba' (2026-01-08)
• Updated input 'nur':
    'github:nix-community/NUR/9748a501c4d61db47d4ff9718d150ef83816ca9c' (2026-01-03)
  → 'github:nix-community/NUR/a4f7c05a5f80044f9dcf3dfeb55a16b5a2713caf' (2026-01-10)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/fb7944c166a3b630f177938e478f0378e64ce108' (2026-01-02)
  → 'github:nixos/nixpkgs/3497aa5c9457a9d88d71fa93a4a8368816fbeeba' (2026-01-08)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/b24ed4b272256dfc1cc2291f89a9821d5f9e14b4' (2025-11-23)
  → 'github:nix-community/plasma-manager/51816be33a1ff0d4b22427de83222d5bfa96d30e' (2026-01-06)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/465adc0ab6ff0c4b9b1db1c6e7fd7eeb553b3261' (2025-12-31)
  → 'github:Gerg-L/spicetify-nix/806c1fdeb7af3e013215d14f5d9f06685fa6650f' (2026-01-04)
• Updated input 'stylix':
    'github:danth/stylix/6850ad2e9f3f7ff6116e9e6fb73a9cca2d9b1a35' (2026-01-02)
  → 'github:danth/stylix/2b727da436910c4a59b5fd2401609bd5cb7ec64a' (2026-01-08)
• Updated input 'stylix/firefox-gnome-theme':
    'github:rafaelmardojai/firefox-gnome-theme/66b7c635763d8e6eb86bd766de5a1e1fbfcc1047' (2025-12-03)
  → 'github:rafaelmardojai/firefox-gnome-theme/f7ffd917ac0d253dbd6a3bf3da06888f57c69f92' (2025-12-04)
• Updated input 'stylix/flake-parts':
    'github:hercules-ci/flake-parts/2cccadc7357c0ba201788ae99c4dfa90728ef5e0' (2025-11-21)
  → 'github:hercules-ci/flake-parts/250481aafeb741edfe23d29195671c19b36b6dca' (2026-01-05)
• Updated input 'stylix/gnome-shell':
    'gitlab:GNOME/gnome-shell/c0e1ad9f0f703fd0519033b8f46c3267aab51a22' (2025-11-30)
  → 'gitlab:GNOME/gnome-shell/ef02db02bf0ff342734d525b5767814770d85b49' (2026-01-06)
• Updated input 'stylix/nixpkgs':
    'github:NixOS/nixpkgs/3e2499d5539c16d0d173ba53552a4ff8547f4539' (2025-12-25)
  → 'github:NixOS/nixpkgs/5912c1772a44e31bf1c63c0390b90501e5026886' (2026-01-07)
• Updated input 'stylix/nur':
    'github:nix-community/NUR/1d9616689e98beded059ad0384b9951e967a17fa' (2025-12-03)
  → 'github:nix-community/NUR/dead29c804adc928d3a69dfe7f9f12d0eec1f1a4' (2026-01-07)
• Updated input 'stylix/tinted-schemes':
    'github:tinted-theming/schemes/0f6be815d258e435c9b137befe5ef4ff24bea32c' (2025-11-23)
  → 'github:tinted-theming/schemes/2800e2b8ac90f678d7e4acebe4fa253f602e05b2' (2026-01-06)
• Updated input 'stylix/tinted-tmux':
    'github:tinted-theming/tinted-tmux/edf89a780e239263cc691a987721f786ddc4f6aa' (2025-11-30)
  → 'github:tinted-theming/tinted-tmux/3c32729ccae99be44fe8a125d20be06f8d7d8184' (2026-01-04)
• Updated input 'stylix/tinted-zed':
    'github:tinted-theming/base16-zed/907dbba5fb8cf69ebfd90b00813418a412d0a29a' (2025-11-30)
  → 'github:tinted-theming/base16-zed/11abb0b282ad3786a2aae088d3a01c60916f2e40' (2026-01-04)
```

Sources Changelog:
```
nix-fast-build: a3cbd5090711b9ca5811efdddef34b24d168100a → 8bdcf0842574b902143871a27064131d9e526b94
```
