### PR TITLE
chore: update flake.lock & sources (2026-01-17)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2026-01-04",
+        "date": "2026-01-13",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "8bdcf0842574b902143871a27064131d9e526b94",
-            "sha256": "sha256-+sU5tsQqo5//LqE18IOX7YC/kD0eNZo3LHD/+mx4pXs=",
+            "rev": "79bef618aabb974f05a732349055854e215954cb",
+            "sha256": "sha256-IXPTmHVMJ+w2Kyjk5bH7Ut0iE+pwQ3Yqaltapqvac2U=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "8bdcf0842574b902143871a27064131d9e526b94"
+        "version": "79bef618aabb974f05a732349055854e215954cb"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "8bdcf0842574b902143871a27064131d9e526b94";
+    version = "79bef618aabb974f05a732349055854e215954cb";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "8bdcf0842574b902143871a27064131d9e526b94";
+      rev = "79bef618aabb974f05a732349055854e215954cb";
       fetchSubmodules = false;
-      sha256 = "sha256-+sU5tsQqo5//LqE18IOX7YC/kD0eNZo3LHD/+mx4pXs=";
+      sha256 = "sha256-IXPTmHVMJ+w2Kyjk5bH7Ut0iE+pwQ3Yqaltapqvac2U=";
     };
-    date = "2026-01-04";
+    date = "2026-01-13";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -219,11 +219,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1767609335,
-        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768062556,
-        "narHash": "sha256-jgC3INik4sJCx31bR+DJMNCoRtSf/9rKL1ZSBVRL0AU=",
+        "lastModified": 1768598210,
+        "narHash": "sha256-kkgA32s/f4jaa4UG+2f8C225Qvclxnqs76mf8zvTVPg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "312c4fe0bbf054e3c87ebad51792f2e6d2ce4f01",
+        "rev": "c47b2cc64a629f8e075de52e4742de688f930dc6",
         "type": "github"
       },
       "original": {
@@ -542,11 +542,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1768011069,
-        "narHash": "sha256-n2mL0Mzc7cc4CBpAZNLoEpi0O7xzv9bFFAF31YtW7XA=",
+        "lastModified": 1768615763,
+        "narHash": "sha256-FWg+qrog3FW6aYtt98J69jzXgZ/6aOZ7h/0SDZcwE/M=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "6c8e10292b702380b55fb0f83e10d7360dae5680",
+        "rev": "f1cbb1f3f12fe0d705a8be4dde2ddb49c0eab742",
         "type": "github"
       },
       "original": {
@@ -673,11 +673,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1767892417,
-        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
+        "lastModified": 1768564909,
+        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1767892417,
-        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
+        "lastModified": 1768564909,
+        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1768059548,
-        "narHash": "sha256-NSMGzFQtoZxdxrQiShWjfJ5k2gzW+atxcr8MiywI1eI=",
+        "lastModified": 1768667624,
+        "narHash": "sha256-NYlnLG5Xpg4GalcXi+hQo+S63r3sx5VonUOg2an+upw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4f7c05a5f80044f9dcf3dfeb55a16b5a2713caf",
+        "rev": "6bd1d0cc5ee055470e8351d58d87bd89033b1b08",
         "type": "github"
       },
       "original": {
@@ -884,11 +884,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1767502559,
-        "narHash": "sha256-om0IPjW850vhhIrNZ5tiXjsYuqyoI44IdE+I9AwZ96I=",
+        "lastModified": 1768656845,
+        "narHash": "sha256-xNlXMyn7yc3Z/NOsz4NchO7gWFwsoCvtJ26pys4s2/M=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "806c1fdeb7af3e013215d14f5d9f06685fa6650f",
+        "rev": "8bd7e49d5ac62756bee6e4b02221fb96bfc3c99a",
         "type": "github"
       },
       "original": {
@@ -916,11 +916,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1767903301,
-        "narHash": "sha256-h7HUP2xjbwjXb+DvAxIH6R9G1RdGCAQao8zCw3jj+yY=",
+        "lastModified": 1768603455,
+        "narHash": "sha256-ih6dYNhX1oSg0emfSAvf3iRcgsJtMmS6RUaoCX8kNoU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "2b727da436910c4a59b5fd2401609bd5cb7ec64a",
+        "rev": "590e5c68c4d5e8c766420473c0185d75113f653b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 03

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/250481aafeb741edfe23d29195671c19b36b6dca' (2026-01-05)
  → 'github:hercules-ci/flake-parts/80daad04eddbbf5a4d883996a73f3f542fa437ac' (2026-01-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/312c4fe0bbf054e3c87ebad51792f2e6d2ce4f01' (2026-01-10)
  → 'github:nix-community/home-manager/c47b2cc64a629f8e075de52e4742de688f930dc6' (2026-01-16)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/6c8e10292b702380b55fb0f83e10d7360dae5680' (2026-01-10)
  → 'github:nix-community/nix4vscode/f1cbb1f3f12fe0d705a8be4dde2ddb49c0eab742' (2026-01-17)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/3497aa5c9457a9d88d71fa93a4a8368816fbeeba' (2026-01-08)
  → 'github:NixOS/nixpkgs/e4bae1bd10c9c57b2cf517953ab70060a828ee6f' (2026-01-16)
• Updated input 'nur':
    'github:nix-community/NUR/a4f7c05a5f80044f9dcf3dfeb55a16b5a2713caf' (2026-01-10)
  → 'github:nix-community/NUR/6bd1d0cc5ee055470e8351d58d87bd89033b1b08' (2026-01-17)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/3497aa5c9457a9d88d71fa93a4a8368816fbeeba' (2026-01-08)
  → 'github:nixos/nixpkgs/e4bae1bd10c9c57b2cf517953ab70060a828ee6f' (2026-01-16)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/806c1fdeb7af3e013215d14f5d9f06685fa6650f' (2026-01-04)
  → 'github:Gerg-L/spicetify-nix/8bd7e49d5ac62756bee6e4b02221fb96bfc3c99a' (2026-01-17)
• Updated input 'stylix':
    'github:danth/stylix/2b727da436910c4a59b5fd2401609bd5cb7ec64a' (2026-01-08)
  → 'github:danth/stylix/590e5c68c4d5e8c766420473c0185d75113f653b' (2026-01-16)
```

Sources Changelog:
```
nix-fast-build: 8bdcf0842574b902143871a27064131d9e526b94 → 79bef618aabb974f05a732349055854e215954cb
```
