### PR TITLE
chore: update flake.lock & sources (2026-01-24)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLocks": null,
-        "date": "2026-01-04",
+        "date": "2026-01-18",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "8bdcf0842574b902143871a27064131d9e526b94",
-            "sha256": "sha256-+sU5tsQqo5//LqE18IOX7YC/kD0eNZo3LHD/+mx4pXs=",
+            "rev": "87930e949d526b5ebdea7109275b3d35b124386a",
+            "sha256": "sha256-U7wjqn3tNt+okbxPNOFy7Rr9NUvWYL7SXBhr1oaRI60=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "8bdcf0842574b902143871a27064131d9e526b94"
+        "version": "87930e949d526b5ebdea7109275b3d35b124386a"
     },
     "obs_catppuccin": {
         "cargoLocks": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "8bdcf0842574b902143871a27064131d9e526b94";
+    version = "87930e949d526b5ebdea7109275b3d35b124386a";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "8bdcf0842574b902143871a27064131d9e526b94";
+      rev = "87930e949d526b5ebdea7109275b3d35b124386a";
       fetchSubmodules = false;
-      sha256 = "sha256-+sU5tsQqo5//LqE18IOX7YC/kD0eNZo3LHD/+mx4pXs=";
+      sha256 = "sha256-U7wjqn3tNt+okbxPNOFy7Rr9NUvWYL7SXBhr1oaRI60=";
     };
-    date = "2026-01-04";
+    date = "2026-01-18";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764011051,
-        "narHash": "sha256-M7SZyPZiqZUR/EiiBJnmyUbOi5oE/03tCeFrTiUZchI=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "17ed8d9744ebe70424659b0ef74ad6d41fc87071",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -219,11 +219,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1767609335,
-        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767281941,
-        "narHash": "sha256-6MkqajPICgugsuZ92OMoQcgSHnD6sJHwk8AxvMcIgTE=",
+        "lastModified": 1769069492,
+        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f0927703b7b1c8d97511c4116eb9b4ec6645a0fa",
+        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768062556,
-        "narHash": "sha256-jgC3INik4sJCx31bR+DJMNCoRtSf/9rKL1ZSBVRL0AU=",
+        "lastModified": 1769187349,
+        "narHash": "sha256-clG+nT6I2qxjIgk5WoSDKJyNhzKJs9jzbCujPF2S/yg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "312c4fe0bbf054e3c87ebad51792f2e6d2ce4f01",
+        "rev": "082a4cd87c6089d1d9c58ebe52655f9e07245fcb",
         "type": "github"
       },
       "original": {
@@ -542,11 +542,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1768011069,
-        "narHash": "sha256-n2mL0Mzc7cc4CBpAZNLoEpi0O7xzv9bFFAF31YtW7XA=",
+        "lastModified": 1769220699,
+        "narHash": "sha256-V+72j5o7sO3YW1w3TcK0NEkRMaXGR54Qx0sVXeroHWo=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "6c8e10292b702380b55fb0f83e10d7360dae5680",
+        "rev": "e1f0e44e632057292875651482fe5d2d70175477",
         "type": "github"
       },
       "original": {
@@ -673,11 +673,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1767892417,
-        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
+        "lastModified": 1769018530,
+        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1767892417,
-        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
+        "lastModified": 1769018530,
+        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1768059548,
-        "narHash": "sha256-NSMGzFQtoZxdxrQiShWjfJ5k2gzW+atxcr8MiywI1eI=",
+        "lastModified": 1769270997,
+        "narHash": "sha256-ujqHCg2GFohnyMeiI4sqhJtDa39HthluhG5+mtPJPqY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4f7c05a5f80044f9dcf3dfeb55a16b5a2713caf",
+        "rev": "dd3026c2388891f206e995d104b9120fd2c774ce",
         "type": "github"
       },
       "original": {
@@ -884,11 +884,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1767502559,
-        "narHash": "sha256-om0IPjW850vhhIrNZ5tiXjsYuqyoI44IdE+I9AwZ96I=",
+        "lastModified": 1769272603,
+        "narHash": "sha256-4GPBYEycM3f0DlCWehekAWaW8gLe9KpVI3BMJ8/xoTU=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "806c1fdeb7af3e013215d14f5d9f06685fa6650f",
+        "rev": "58706a685864a03e5ade6b436b1b3310b44f1a22",
         "type": "github"
       },
       "original": {
@@ -916,11 +916,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1767903301,
-        "narHash": "sha256-h7HUP2xjbwjXb+DvAxIH6R9G1RdGCAQao8zCw3jj+yY=",
+        "lastModified": 1769202931,
+        "narHash": "sha256-4IZuCMjlWEtS6rVXozVXaJG6QADHVncXC29PLZr6ZB4=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "2b727da436910c4a59b5fd2401609bd5cb7ec64a",
+        "rev": "749285c90e3e35ebe0952c86838f3089abbc7939",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 04

Flakes Changelog:
```
• Updated input 'devshell':
    'github:numtide/devshell/17ed8d9744ebe70424659b0ef74ad6d41fc87071' (2025-11-24)
  → 'github:numtide/devshell/255a2b1725a20d060f566e4755dbf571bbbb5f76' (2026-01-19)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/250481aafeb741edfe23d29195671c19b36b6dca' (2026-01-05)
  → 'github:hercules-ci/flake-parts/80daad04eddbbf5a4d883996a73f3f542fa437ac' (2026-01-11)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/f0927703b7b1c8d97511c4116eb9b4ec6645a0fa' (2026-01-01)
  → 'github:cachix/git-hooks.nix/a1ef738813b15cf8ec759bdff5761b027e3e1d23' (2026-01-22)
• Updated input 'home-manager':
    'github:nix-community/home-manager/312c4fe0bbf054e3c87ebad51792f2e6d2ce4f01' (2026-01-10)
  → 'github:nix-community/home-manager/082a4cd87c6089d1d9c58ebe52655f9e07245fcb' (2026-01-23)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/6c8e10292b702380b55fb0f83e10d7360dae5680' (2026-01-10)
  → 'github:nix-community/nix4vscode/e1f0e44e632057292875651482fe5d2d70175477' (2026-01-24)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/3497aa5c9457a9d88d71fa93a4a8368816fbeeba' (2026-01-08)
  → 'github:NixOS/nixpkgs/88d3861acdd3d2f0e361767018218e51810df8a1' (2026-01-21)
• Updated input 'nur':
    'github:nix-community/NUR/a4f7c05a5f80044f9dcf3dfeb55a16b5a2713caf' (2026-01-10)
  → 'github:nix-community/NUR/dd3026c2388891f206e995d104b9120fd2c774ce' (2026-01-24)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/3497aa5c9457a9d88d71fa93a4a8368816fbeeba' (2026-01-08)
  → 'github:nixos/nixpkgs/88d3861acdd3d2f0e361767018218e51810df8a1' (2026-01-21)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/806c1fdeb7af3e013215d14f5d9f06685fa6650f' (2026-01-04)
  → 'github:Gerg-L/spicetify-nix/58706a685864a03e5ade6b436b1b3310b44f1a22' (2026-01-24)
• Updated input 'stylix':
    'github:danth/stylix/2b727da436910c4a59b5fd2401609bd5cb7ec64a' (2026-01-08)
  → 'github:danth/stylix/749285c90e3e35ebe0952c86838f3089abbc7939' (2026-01-23)
```

Sources Changelog:
```
nix-fast-build: 8bdcf0842574b902143871a27064131d9e526b94 → 87930e949d526b5ebdea7109275b3d35b124386a
```
