### PR TITLE
chore: update flake.lock & sources (2026-01-31)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,6 +1,6 @@
 {
     "calibre_catppuccin": {
-        "cargoLocks": null,
+        "cargoLock": null,
         "date": "2024-09-14",
         "extract": null,
         "name": "calibre_catppuccin",
@@ -21,7 +21,7 @@
         "version": "27bd12d2d8dcd24b9ce7cae32135fbd41b896921"
     },
     "catppuccin_zsh_syntax_highlighting": {
-        "cargoLocks": null,
+        "cargoLock": null,
         "date": "2024-07-20",
         "extract": null,
         "name": "catppuccin_zsh_syntax_highlighting",
@@ -42,7 +42,7 @@
         "version": "7926c3d3e17d26b3779851a2255b95ee650bd928"
     },
     "eza_themes": {
-        "cargoLocks": null,
+        "cargoLock": null,
         "date": "2025-12-15",
         "extract": null,
         "name": "eza_themes",
@@ -63,7 +63,7 @@
         "version": "1239cb1dd23fa8b70865550db77701b164a53cde"
     },
     "firefox-gnome-theme": {
-        "cargoLocks": null,
+        "cargoLock": null,
         "date": null,
         "extract": null,
         "name": "firefox-gnome-theme",
@@ -84,7 +84,7 @@
         "version": "v143"
     },
     "joplin_catppuccin": {
-        "cargoLocks": null,
+        "cargoLock": null,
         "date": "2025-09-16",
         "extract": null,
         "name": "joplin_catppuccin",
@@ -105,8 +105,8 @@
         "version": "780ff535705411a92cb8d939b51a0e9abf5b8688"
     },
     "nix-fast-build": {
-        "cargoLocks": null,
-        "date": "2026-01-04",
+        "cargoLock": null,
+        "date": "2026-01-18",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,15 +118,15 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "8bdcf0842574b902143871a27064131d9e526b94",
-            "sha256": "sha256-+sU5tsQqo5//LqE18IOX7YC/kD0eNZo3LHD/+mx4pXs=",
+            "rev": "87930e949d526b5ebdea7109275b3d35b124386a",
+            "sha256": "sha256-U7wjqn3tNt+okbxPNOFy7Rr9NUvWYL7SXBhr1oaRI60=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "8bdcf0842574b902143871a27064131d9e526b94"
+        "version": "87930e949d526b5ebdea7109275b3d35b124386a"
     },
     "obs_catppuccin": {
-        "cargoLocks": null,
+        "cargoLock": null,
         "date": "2025-07-29",
         "extract": null,
         "name": "obs_catppuccin",
@@ -147,7 +147,7 @@
         "version": "05c55ffe499c183c98be469147f602c3f8e84b87"
     },
     "prismlauncher_catppuccin": {
-        "cargoLocks": null,
+        "cargoLock": null,
         "date": "2025-09-08",
         "extract": null,
         "name": "prismlauncher_catppuccin",
@@ -168,7 +168,7 @@
         "version": "1ef0e745286ce32750abc3bc5d3ca8073a623b60"
     },
     "rofi-bluetooth": {
-        "cargoLocks": null,
+        "cargoLock": null,
         "date": "2025-04-14",
         "extract": null,
         "name": "rofi-bluetooth",
@@ -189,7 +189,7 @@
         "version": "0cca4d4aa1c82c9373ce5da781d73683a29484c6"
     },
     "rofi_catppuccin": {
-        "cargoLocks": null,
+        "cargoLock": null,
         "date": "2025-07-19",
         "extract": null,
         "name": "rofi_catppuccin",
@@ -210,7 +210,7 @@
         "version": "71fb15577ccb091df2f4fc1f65710edbc61b5a53"
     },
     "wickedwizard_picture": {
-        "cargoLocks": null,
+        "cargoLock": null,
         "date": null,
         "extract": null,
         "name": "wickedwizard_picture",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "8bdcf0842574b902143871a27064131d9e526b94";
+    version = "87930e949d526b5ebdea7109275b3d35b124386a";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "8bdcf0842574b902143871a27064131d9e526b94";
+      rev = "87930e949d526b5ebdea7109275b3d35b124386a";
       fetchSubmodules = false;
-      sha256 = "sha256-+sU5tsQqo5//LqE18IOX7YC/kD0eNZo3LHD/+mx4pXs=";
+      sha256 = "sha256-U7wjqn3tNt+okbxPNOFy7Rr9NUvWYL7SXBhr1oaRI60=";
     };
-    date = "2026-01-04";
+    date = "2026-01-18";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764011051,
-        "narHash": "sha256-M7SZyPZiqZUR/EiiBJnmyUbOi5oE/03tCeFrTiUZchI=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "17ed8d9744ebe70424659b0ef74ad6d41fc87071",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -219,11 +219,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1767609335,
-        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767281941,
-        "narHash": "sha256-6MkqajPICgugsuZ92OMoQcgSHnD6sJHwk8AxvMcIgTE=",
+        "lastModified": 1769069492,
+        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f0927703b7b1c8d97511c4116eb9b4ec6645a0fa",
+        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768062556,
-        "narHash": "sha256-jgC3INik4sJCx31bR+DJMNCoRtSf/9rKL1ZSBVRL0AU=",
+        "lastModified": 1769872935,
+        "narHash": "sha256-07HMIGQ/WJeAQJooA7Kkg1SDKxhAiV6eodvOwTX6WKI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "312c4fe0bbf054e3c87ebad51792f2e6d2ce4f01",
+        "rev": "f4ad5068ee8e89e4a7c2e963e10dd35cd77b37b7",
         "type": "github"
       },
       "original": {
@@ -542,11 +542,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1768011069,
-        "narHash": "sha256-n2mL0Mzc7cc4CBpAZNLoEpi0O7xzv9bFFAF31YtW7XA=",
+        "lastModified": 1769827010,
+        "narHash": "sha256-a9TNgDs+FfD8yyc/SDRoiRkm4VTDN4rcGXCIKN4mvL4=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "6c8e10292b702380b55fb0f83e10d7360dae5680",
+        "rev": "c0d7d5949be1edc4d31af9c0173b85b74a4e23c8",
         "type": "github"
       },
       "original": {
@@ -673,11 +673,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1767892417,
-        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1767892417,
-        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1768059548,
-        "narHash": "sha256-NSMGzFQtoZxdxrQiShWjfJ5k2gzW+atxcr8MiywI1eI=",
+        "lastModified": 1769876589,
+        "narHash": "sha256-/r1fEFKQqMNtv6c4JUXjy1Au06PrQp8K8AP2rWEM/hI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4f7c05a5f80044f9dcf3dfeb55a16b5a2713caf",
+        "rev": "f792ac11fc18ef015d41102bf86d992fa39cb1d0",
         "type": "github"
       },
       "original": {
@@ -884,11 +884,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1767502559,
-        "narHash": "sha256-om0IPjW850vhhIrNZ5tiXjsYuqyoI44IdE+I9AwZ96I=",
+        "lastModified": 1769316930,
+        "narHash": "sha256-4EOGHYLpIscwr+6drHE28Qj7NDjjowp2Vd8QkXjdBBE=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "806c1fdeb7af3e013215d14f5d9f06685fa6650f",
+        "rev": "b2ce438f386943ef611e196a178af2d79042903b",
         "type": "github"
       },
       "original": {
@@ -916,11 +916,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1767903301,
-        "narHash": "sha256-h7HUP2xjbwjXb+DvAxIH6R9G1RdGCAQao8zCw3jj+yY=",
+        "lastModified": 1769819994,
+        "narHash": "sha256-AJB2hcg1OgocLGuVdot9HyCD+Kv+a6znhY2i3XqcZYU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "2b727da436910c4a59b5fd2401609bd5cb7ec64a",
+        "rev": "8b14679c0e1570b0e137f0f7997717be0fdf2cf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 05

Flakes Changelog:
```
• Updated input 'devshell':
    'github:numtide/devshell/17ed8d9744ebe70424659b0ef74ad6d41fc87071' (2025-11-24)
  → 'github:numtide/devshell/255a2b1725a20d060f566e4755dbf571bbbb5f76' (2026-01-19)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/250481aafeb741edfe23d29195671c19b36b6dca' (2026-01-05)
  → 'github:hercules-ci/flake-parts/80daad04eddbbf5a4d883996a73f3f542fa437ac' (2026-01-11)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/f0927703b7b1c8d97511c4116eb9b4ec6645a0fa' (2026-01-01)
  → 'github:cachix/git-hooks.nix/a1ef738813b15cf8ec759bdff5761b027e3e1d23' (2026-01-22)
• Updated input 'home-manager':
    'github:nix-community/home-manager/312c4fe0bbf054e3c87ebad51792f2e6d2ce4f01' (2026-01-10)
  → 'github:nix-community/home-manager/f4ad5068ee8e89e4a7c2e963e10dd35cd77b37b7' (2026-01-31)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/6c8e10292b702380b55fb0f83e10d7360dae5680' (2026-01-10)
  → 'github:nix-community/nix4vscode/c0d7d5949be1edc4d31af9c0173b85b74a4e23c8' (2026-01-31)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/3497aa5c9457a9d88d71fa93a4a8368816fbeeba' (2026-01-08)
  → 'github:NixOS/nixpkgs/bfc1b8a4574108ceef22f02bafcf6611380c100d' (2026-01-26)
• Updated input 'nur':
    'github:nix-community/NUR/a4f7c05a5f80044f9dcf3dfeb55a16b5a2713caf' (2026-01-10)
  → 'github:nix-community/NUR/f792ac11fc18ef015d41102bf86d992fa39cb1d0' (2026-01-31)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/3497aa5c9457a9d88d71fa93a4a8368816fbeeba' (2026-01-08)
  → 'github:nixos/nixpkgs/bfc1b8a4574108ceef22f02bafcf6611380c100d' (2026-01-26)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/806c1fdeb7af3e013215d14f5d9f06685fa6650f' (2026-01-04)
  → 'github:Gerg-L/spicetify-nix/b2ce438f386943ef611e196a178af2d79042903b' (2026-01-25)
• Updated input 'stylix':
    'github:danth/stylix/2b727da436910c4a59b5fd2401609bd5cb7ec64a' (2026-01-08)
  → 'github:danth/stylix/8b14679c0e1570b0e137f0f7997717be0fdf2cf2' (2026-01-31)
```

Sources Changelog:
```
nix-fast-build: 8bdcf0842574b902143871a27064131d9e526b94 → 87930e949d526b5ebdea7109275b3d35b124386a
```
