### PR TITLE
chore: update flake.lock & sources (2026-02-07)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-01-18",
+        "date": "2026-02-01",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "87930e949d526b5ebdea7109275b3d35b124386a",
-            "sha256": "sha256-U7wjqn3tNt+okbxPNOFy7Rr9NUvWYL7SXBhr1oaRI60=",
+            "rev": "abc09eff2c2c0c0c41a9a2b3955925eecbd7e520",
+            "sha256": "sha256-4ovZVXVBLTdKOiyCMLTgLt5bdwbbNalsjdLVrEKBkjw=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "87930e949d526b5ebdea7109275b3d35b124386a"
+        "version": "abc09eff2c2c0c0c41a9a2b3955925eecbd7e520"
     },
     "obs_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "87930e949d526b5ebdea7109275b3d35b124386a";
+    version = "abc09eff2c2c0c0c41a9a2b3955925eecbd7e520";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "87930e949d526b5ebdea7109275b3d35b124386a";
+      rev = "abc09eff2c2c0c0c41a9a2b3955925eecbd7e520";
       fetchSubmodules = false;
-      sha256 = "sha256-U7wjqn3tNt+okbxPNOFy7Rr9NUvWYL7SXBhr1oaRI60=";
+      sha256 = "sha256-4ovZVXVBLTdKOiyCMLTgLt5bdwbbNalsjdLVrEKBkjw=";
     };
-    date = "2026-01-18";
+    date = "2026-02-01";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -1,1107 +1,1107 @@
 {
-	"nodes": {
-		"agenix": {
-			"inputs": {
-				"darwin": "darwin",
-				"home-manager": [
-					"home-manager"
-				],
-				"nixpkgs": [
-					"nixpkgs"
-				],
-				"systems": "systems"
-			},
-			"locked": {
-				"lastModified": 1762618334,
-				"narHash": "sha256-wyT7Pl6tMFbFrs8Lk/TlEs81N6L+VSybPfiIgzU8lbQ=",
-				"owner": "ryantm",
-				"repo": "agenix",
-				"rev": "fcdea223397448d35d9b31f798479227e80183f6",
-				"type": "github"
-			},
-			"original": {
-				"owner": "ryantm",
-				"repo": "agenix",
-				"type": "github"
-			}
-		},
-		"base16": {
-			"inputs": {
-				"fromYaml": "fromYaml"
-			},
-			"locked": {
-				"lastModified": 1755819240,
-				"narHash": "sha256-qcMhnL7aGAuFuutH4rq9fvAhCpJWVHLcHVZLtPctPlo=",
-				"owner": "SenchoPens",
-				"repo": "base16.nix",
-				"rev": "75ed5e5e3fce37df22e49125181fa37899c3ccd6",
-				"type": "github"
-			},
-			"original": {
-				"owner": "SenchoPens",
-				"repo": "base16.nix",
-				"type": "github"
-			}
-		},
-		"base16-fish": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1765809053,
-				"narHash": "sha256-XCUQLoLfBJ8saWms2HCIj4NEN+xNsWBlU1NrEPcQG4s=",
-				"owner": "tomyun",
-				"repo": "base16-fish",
-				"rev": "86cbea4dca62e08fb7fd83a70e96472f92574782",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tomyun",
-				"repo": "base16-fish",
-				"rev": "86cbea4dca62e08fb7fd83a70e96472f92574782",
-				"type": "github"
-			}
-		},
-		"base16-helix": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1760703920,
-				"narHash": "sha256-m82fGUYns4uHd+ZTdoLX2vlHikzwzdu2s2rYM2bNwzw=",
-				"owner": "tinted-theming",
-				"repo": "base16-helix",
-				"rev": "d646af9b7d14bff08824538164af99d0c521b185",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tinted-theming",
-				"repo": "base16-helix",
-				"type": "github"
-			}
-		},
-		"base16-vim": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1732806396,
-				"narHash": "sha256-e0bpPySdJf0F68Ndanwm+KWHgQiZ0s7liLhvJSWDNsA=",
-				"owner": "tinted-theming",
-				"repo": "base16-vim",
-				"rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tinted-theming",
-				"repo": "base16-vim",
-				"rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
-				"type": "github"
-			}
-		},
-		"crane": {
-			"locked": {
-				"lastModified": 1754269165,
-				"narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
-				"owner": "ipetkov",
-				"repo": "crane",
-				"rev": "444e81206df3f7d92780680e45858e31d2f07a08",
-				"type": "github"
-			},
-			"original": {
-				"owner": "ipetkov",
-				"repo": "crane",
-				"type": "github"
-			}
-		},
-		"darwin": {
-			"inputs": {
-				"nixpkgs": [
-					"agenix",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1744478979,
-				"narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
-				"owner": "lnl7",
-				"repo": "nix-darwin",
-				"rev": "43975d782b418ebf4969e9ccba82466728c2851b",
-				"type": "github"
-			},
-			"original": {
-				"owner": "lnl7",
-				"ref": "master",
-				"repo": "nix-darwin",
-				"type": "github"
-			}
-		},
-		"devshell": {
-			"inputs": {
-				"nixpkgs": [
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1768818222,
-				"narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
-				"owner": "numtide",
-				"repo": "devshell",
-				"rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
-				"type": "github"
-			},
-			"original": {
-				"owner": "numtide",
-				"repo": "devshell",
-				"type": "github"
-			}
-		},
-		"firefox-gnome-theme": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1764873433,
-				"narHash": "sha256-1XPewtGMi+9wN9Ispoluxunw/RwozuTRVuuQOmxzt+A=",
-				"owner": "rafaelmardojai",
-				"repo": "firefox-gnome-theme",
-				"rev": "f7ffd917ac0d253dbd6a3bf3da06888f57c69f92",
-				"type": "github"
-			},
-			"original": {
-				"owner": "rafaelmardojai",
-				"repo": "firefox-gnome-theme",
-				"type": "github"
-			}
-		},
-		"flake-compat": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1767039857,
-				"narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-				"owner": "NixOS",
-				"repo": "flake-compat",
-				"rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"repo": "flake-compat",
-				"type": "github"
-			}
-		},
-		"flake-compat_2": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1747046372,
-				"narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
-				"owner": "edolstra",
-				"repo": "flake-compat",
-				"rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
-				"type": "github"
-			},
-			"original": {
-				"owner": "edolstra",
-				"repo": "flake-compat",
-				"type": "github"
-			}
-		},
-		"flake-compat_3": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1746162366,
-				"narHash": "sha256-5SSSZ/oQkwfcAz/o/6TlejlVGqeK08wyREBQ5qFFPhM=",
-				"owner": "nix-community",
-				"repo": "flake-compat",
-				"rev": "0f158086a2ecdbb138cd0429410e44994f1b7e4b",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "flake-compat",
-				"type": "github"
-			}
-		},
-		"flake-parts": {
-			"inputs": {
-				"nixpkgs-lib": "nixpkgs-lib"
-			},
-			"locked": {
-				"lastModified": 1768135262,
-				"narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
-				"type": "github"
-			},
-			"original": {
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"type": "github"
-			}
-		},
-		"flake-parts_2": {
-			"inputs": {
-				"nixpkgs-lib": [
-					"lanzaboote",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1754091436,
-				"narHash": "sha256-XKqDMN1/Qj1DKivQvscI4vmHfDfvYR2pfuFOJiCeewM=",
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"rev": "67df8c627c2c39c41dbec76a1f201929929ab0bd",
-				"type": "github"
-			},
-			"original": {
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"type": "github"
-			}
-		},
-		"flake-parts_3": {
-			"inputs": {
-				"nixpkgs-lib": [
-					"nur",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1733312601,
-				"narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
-				"type": "github"
-			},
-			"original": {
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"type": "github"
-			}
-		},
-		"flake-parts_4": {
-			"inputs": {
-				"nixpkgs-lib": [
-					"stylix",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1767609335,
-				"narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"rev": "250481aafeb741edfe23d29195671c19b36b6dca",
-				"type": "github"
-			},
-			"original": {
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"type": "github"
-			}
-		},
-		"flake-utils": {
-			"inputs": {
-				"systems": "systems_2"
-			},
-			"locked": {
-				"lastModified": 1731533236,
-				"narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-				"owner": "numtide",
-				"repo": "flake-utils",
-				"rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-				"type": "github"
-			},
-			"original": {
-				"owner": "numtide",
-				"repo": "flake-utils",
-				"type": "github"
-			}
-		},
-		"fromYaml": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1731966426,
-				"narHash": "sha256-lq95WydhbUTWig/JpqiB7oViTcHFP8Lv41IGtayokA8=",
-				"owner": "SenchoPens",
-				"repo": "fromYaml",
-				"rev": "106af9e2f715e2d828df706c386a685698f3223b",
-				"type": "github"
-			},
-			"original": {
-				"owner": "SenchoPens",
-				"repo": "fromYaml",
-				"type": "github"
-			}
-		},
-		"git-hooks": {
-			"inputs": {
-				"flake-compat": "flake-compat",
-				"gitignore": "gitignore",
-				"nixpkgs": [
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1769069492,
-				"narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
-				"owner": "cachix",
-				"repo": "git-hooks.nix",
-				"rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
-				"type": "github"
-			},
-			"original": {
-				"owner": "cachix",
-				"repo": "git-hooks.nix",
-				"type": "github"
-			}
-		},
-		"gitignore": {
-			"inputs": {
-				"nixpkgs": [
-					"git-hooks",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1709087332,
-				"narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-				"owner": "hercules-ci",
-				"repo": "gitignore.nix",
-				"rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-				"type": "github"
-			},
-			"original": {
-				"owner": "hercules-ci",
-				"repo": "gitignore.nix",
-				"type": "github"
-			}
-		},
-		"gitignore_2": {
-			"inputs": {
-				"nixpkgs": [
-					"lanzaboote",
-					"pre-commit-hooks-nix",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1709087332,
-				"narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-				"owner": "hercules-ci",
-				"repo": "gitignore.nix",
-				"rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-				"type": "github"
-			},
-			"original": {
-				"owner": "hercules-ci",
-				"repo": "gitignore.nix",
-				"type": "github"
-			}
-		},
-		"gnome-shell": {
-			"flake": false,
-			"locked": {
-				"host": "gitlab.gnome.org",
-				"lastModified": 1767737596,
-				"narHash": "sha256-eFujfIUQDgWnSJBablOuG+32hCai192yRdrNHTv0a+s=",
-				"owner": "GNOME",
-				"repo": "gnome-shell",
-				"rev": "ef02db02bf0ff342734d525b5767814770d85b49",
-				"type": "gitlab"
-			},
-			"original": {
-				"host": "gitlab.gnome.org",
-				"owner": "GNOME",
-				"ref": "gnome-49",
-				"repo": "gnome-shell",
-				"type": "gitlab"
-			}
-		},
-		"home-manager": {
-			"inputs": {
-				"nixpkgs": [
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1769872935,
-				"narHash": "sha256-07HMIGQ/WJeAQJooA7Kkg1SDKxhAiV6eodvOwTX6WKI=",
-				"owner": "nix-community",
-				"repo": "home-manager",
-				"rev": "f4ad5068ee8e89e4a7c2e963e10dd35cd77b37b7",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "home-manager",
-				"type": "github"
-			}
-		},
-		"home-manager_2": {
-			"inputs": {
-				"nixpkgs": [
-					"hyprpanel",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1750798083,
-				"narHash": "sha256-DTCCcp6WCFaYXWKFRA6fiI2zlvOLCf5Vwx8+/0R8Wc4=",
-				"owner": "nix-community",
-				"repo": "home-manager",
-				"rev": "ff31a4677c1a8ae506aa7e003a3dba08cb203f82",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "home-manager",
-				"type": "github"
-			}
-		},
-		"hyprpanel": {
-			"inputs": {
-				"flake-utils": "flake-utils",
-				"home-manager": "home-manager_2",
-				"nixpkgs": "nixpkgs"
-			},
-			"locked": {
-				"lastModified": 1767767975,
-				"narHash": "sha256-yBejG3j6OLQYn87UozFAI3q9a1vH00u9xjIf2Q4V5j8=",
-				"owner": "Jas-SinghFSU",
-				"repo": "HyprPanel",
-				"rev": "0e73df1dfedf0f6fa21ed0ae5e031b0663c8f400",
-				"type": "github"
-			},
-			"original": {
-				"owner": "Jas-SinghFSU",
-				"repo": "HyprPanel",
-				"type": "github"
-			}
-		},
-		"lanzaboote": {
-			"inputs": {
-				"crane": "crane",
-				"flake-compat": "flake-compat_2",
-				"flake-parts": "flake-parts_2",
-				"nixpkgs": [
-					"nixpkgs"
-				],
-				"pre-commit-hooks-nix": "pre-commit-hooks-nix",
-				"rust-overlay": "rust-overlay"
-			},
-			"locked": {
-				"lastModified": 1762205063,
-				"narHash": "sha256-If6vQ+KvtKs3ARBO9G3l+4wFSCYtRBrwX1z+I+B61wQ=",
-				"owner": "nix-community",
-				"repo": "lanzaboote",
-				"rev": "88b8a563ff5704f4e8d8e5118fb911fa2110ca05",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"ref": "v0.4.3",
-				"repo": "lanzaboote",
-				"type": "github"
-			}
-		},
-		"nix-flatpak": {
-			"locked": {
-				"lastModified": 1767983141,
-				"narHash": "sha256-7ZCulYUD9RmJIDULTRkGLSW1faMpDlPKcbWJLYHoXcs=",
-				"owner": "gmodena",
-				"repo": "nix-flatpak",
-				"rev": "440818969ac2cbd77bfe025e884d0aa528991374",
-				"type": "github"
-			},
-			"original": {
-				"owner": "gmodena",
-				"ref": "latest",
-				"repo": "nix-flatpak",
-				"type": "github"
-			}
-		},
-		"nix-index-database": {
-			"inputs": {
-				"nixpkgs": "nixpkgs_2"
-			},
-			"locked": {
-				"lastModified": 1765267181,
-				"narHash": "sha256-d3NBA9zEtBu2JFMnTBqWj7Tmi7R5OikoU2ycrdhQEws=",
-				"owner": "nix-community",
-				"repo": "nix-index-database",
-				"rev": "82befcf7dc77c909b0f2a09f5da910ec95c5b78f",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "nix-index-database",
-				"type": "github"
-			}
-		},
-		"nix4vscode": {
-			"inputs": {
-				"nixpkgs": [
-					"nixpkgs"
-				],
-				"systems": "systems_3"
-			},
-			"locked": {
-				"lastModified": 1769827010,
-				"narHash": "sha256-a9TNgDs+FfD8yyc/SDRoiRkm4VTDN4rcGXCIKN4mvL4=",
-				"owner": "nix-community",
-				"repo": "nix4vscode",
-				"rev": "c0d7d5949be1edc4d31af9c0173b85b74a4e23c8",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "nix4vscode",
-				"type": "github"
-			}
-		},
-		"nixos-cosmic": {
-			"inputs": {
-				"flake-compat": "flake-compat_3",
-				"nixpkgs": "nixpkgs_3",
-				"nixpkgs-stable": "nixpkgs-stable",
-				"rust-overlay": "rust-overlay_2"
-			},
-			"locked": {
-				"lastModified": 1751591814,
-				"narHash": "sha256-A4lgvuj4v+Pr8MniXz1FBG0DXOygi8tTECR+j53FMhM=",
-				"owner": "lilyinstarlight",
-				"repo": "nixos-cosmic",
-				"rev": "fef2d0c78c4e4d6c600a88795af193131ff51bdc",
-				"type": "github"
-			},
-			"original": {
-				"owner": "lilyinstarlight",
-				"repo": "nixos-cosmic",
-				"type": "github"
-			}
-		},
-		"nixpkgs": {
-			"locked": {
-				"lastModified": 1750776420,
-				"narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
-				"owner": "nixos",
-				"repo": "nixpkgs",
-				"rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nixos",
-				"ref": "nixos-unstable",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs-lib": {
-			"locked": {
-				"lastModified": 1765674936,
-				"narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
-				"owner": "nix-community",
-				"repo": "nixpkgs.lib",
-				"rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "nixpkgs.lib",
-				"type": "github"
-			}
-		},
-		"nixpkgs-stable": {
-			"locked": {
-				"lastModified": 1751048012,
-				"narHash": "sha256-MYbotu4UjWpTsq01wglhN5xDRfZYLFtNk7SBY0BcjkU=",
-				"owner": "NixOS",
-				"repo": "nixpkgs",
-				"rev": "a684c58d46ebbede49f280b653b9e56100aa3877",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"ref": "nixos-24.11",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs-stable_2": {
-			"locked": {
-				"lastModified": 1751274312,
-				"narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
-				"owner": "NixOS",
-				"repo": "nixpkgs",
-				"rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"ref": "nixos-24.11",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs_2": {
-			"locked": {
-				"lastModified": 1764950072,
-				"narHash": "sha256-BmPWzogsG2GsXZtlT+MTcAWeDK5hkbGRZTeZNW42fwA=",
-				"owner": "NixOS",
-				"repo": "nixpkgs",
-				"rev": "f61125a668a320878494449750330ca58b78c557",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"ref": "nixos-unstable",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs_3": {
-			"locked": {
-				"lastModified": 1751011381,
-				"narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
-				"owner": "NixOS",
-				"repo": "nixpkgs",
-				"rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"ref": "nixos-unstable",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs_4": {
-			"locked": {
-				"lastModified": 1769461804,
-				"narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
-				"owner": "NixOS",
-				"repo": "nixpkgs",
-				"rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"ref": "nixos-unstable",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs_5": {
-			"locked": {
-				"lastModified": 1769461804,
-				"narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
-				"owner": "nixos",
-				"repo": "nixpkgs",
-				"rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nixos",
-				"ref": "nixos-unstable",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs_6": {
-			"locked": {
-				"lastModified": 1767767207,
-				"narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
-				"owner": "NixOS",
-				"repo": "nixpkgs",
-				"rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"ref": "nixos-unstable",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nur": {
-			"inputs": {
-				"flake-parts": "flake-parts_3",
-				"nixpkgs": "nixpkgs_5"
-			},
-			"locked": {
-				"lastModified": 1769876589,
-				"narHash": "sha256-/r1fEFKQqMNtv6c4JUXjy1Au06PrQp8K8AP2rWEM/hI=",
-				"owner": "nix-community",
-				"repo": "NUR",
-				"rev": "f792ac11fc18ef015d41102bf86d992fa39cb1d0",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "NUR",
-				"type": "github"
-			}
-		},
-		"nur_2": {
-			"inputs": {
-				"flake-parts": [
-					"stylix",
-					"flake-parts"
-				],
-				"nixpkgs": [
-					"stylix",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1767810917,
-				"narHash": "sha256-ZKqhk772+v/bujjhla9VABwcvz+hB2IaRyeLT6CFnT0=",
-				"owner": "nix-community",
-				"repo": "NUR",
-				"rev": "dead29c804adc928d3a69dfe7f9f12d0eec1f1a4",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "NUR",
-				"type": "github"
-			}
-		},
-		"plasma-manager": {
-			"inputs": {
-				"home-manager": [
-					"home-manager"
-				],
-				"nixpkgs": [
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1767662275,
-				"narHash": "sha256-d5Q1GmQ+sW1Bt8cgDE0vOihzLaswsm8cSdg8124EqXE=",
-				"owner": "nix-community",
-				"repo": "plasma-manager",
-				"rev": "51816be33a1ff0d4b22427de83222d5bfa96d30e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "plasma-manager",
-				"type": "github"
-			}
-		},
-		"pre-commit-hooks-nix": {
-			"inputs": {
-				"flake-compat": [
-					"lanzaboote",
-					"flake-compat"
-				],
-				"gitignore": "gitignore_2",
-				"nixpkgs": [
-					"lanzaboote",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1750779888,
-				"narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
-				"owner": "cachix",
-				"repo": "pre-commit-hooks.nix",
-				"rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
-				"type": "github"
-			},
-			"original": {
-				"owner": "cachix",
-				"repo": "pre-commit-hooks.nix",
-				"type": "github"
-			}
-		},
-		"root": {
-			"inputs": {
-				"agenix": "agenix",
-				"devshell": "devshell",
-				"flake-parts": "flake-parts",
-				"git-hooks": "git-hooks",
-				"home-manager": "home-manager",
-				"hyprpanel": "hyprpanel",
-				"lanzaboote": "lanzaboote",
-				"nix-flatpak": "nix-flatpak",
-				"nix-index-database": "nix-index-database",
-				"nix4vscode": "nix4vscode",
-				"nixos-cosmic": "nixos-cosmic",
-				"nixpkgs": "nixpkgs_4",
-				"nixpkgs-stable": "nixpkgs-stable_2",
-				"nur": "nur",
-				"plasma-manager": "plasma-manager",
-				"spicetify-nix": "spicetify-nix",
-				"stylix": "stylix",
-				"systems": "systems_6"
-			}
-		},
-		"rust-overlay": {
-			"inputs": {
-				"nixpkgs": [
-					"lanzaboote",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1761791894,
-				"narHash": "sha256-myRIDh+PxaREz+z9LzbqBJF+SnTFJwkthKDX9zMyddY=",
-				"owner": "oxalica",
-				"repo": "rust-overlay",
-				"rev": "59c45eb69d9222a4362673141e00ff77842cd219",
-				"type": "github"
-			},
-			"original": {
-				"owner": "oxalica",
-				"repo": "rust-overlay",
-				"type": "github"
-			}
-		},
-		"rust-overlay_2": {
-			"inputs": {
-				"nixpkgs": [
-					"nixos-cosmic",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1751251399,
-				"narHash": "sha256-y+viCuy/eKKpkX1K2gDvXIJI/yzvy6zA3HObapz9XZ0=",
-				"owner": "oxalica",
-				"repo": "rust-overlay",
-				"rev": "b22d5ee8c60ed1291521f2dde48784edd6bf695b",
-				"type": "github"
-			},
-			"original": {
-				"owner": "oxalica",
-				"repo": "rust-overlay",
-				"type": "github"
-			}
-		},
-		"spicetify-nix": {
-			"inputs": {
-				"nixpkgs": [
-					"nixpkgs"
-				],
-				"systems": "systems_4"
-			},
-			"locked": {
-				"lastModified": 1769316930,
-				"narHash": "sha256-4EOGHYLpIscwr+6drHE28Qj7NDjjowp2Vd8QkXjdBBE=",
-				"owner": "Gerg-L",
-				"repo": "spicetify-nix",
-				"rev": "b2ce438f386943ef611e196a178af2d79042903b",
-				"type": "github"
-			},
-			"original": {
-				"owner": "Gerg-L",
-				"repo": "spicetify-nix",
-				"type": "github"
-			}
-		},
-		"stylix": {
-			"inputs": {
-				"base16": "base16",
-				"base16-fish": "base16-fish",
-				"base16-helix": "base16-helix",
-				"base16-vim": "base16-vim",
-				"firefox-gnome-theme": "firefox-gnome-theme",
-				"flake-parts": "flake-parts_4",
-				"gnome-shell": "gnome-shell",
-				"nixpkgs": "nixpkgs_6",
-				"nur": "nur_2",
-				"systems": "systems_5",
-				"tinted-foot": "tinted-foot",
-				"tinted-kitty": "tinted-kitty",
-				"tinted-schemes": "tinted-schemes",
-				"tinted-tmux": "tinted-tmux",
-				"tinted-zed": "tinted-zed"
-			},
-			"locked": {
-				"lastModified": 1769819994,
-				"narHash": "sha256-AJB2hcg1OgocLGuVdot9HyCD+Kv+a6znhY2i3XqcZYU=",
-				"owner": "danth",
-				"repo": "stylix",
-				"rev": "8b14679c0e1570b0e137f0f7997717be0fdf2cf2",
-				"type": "github"
-			},
-			"original": {
-				"owner": "danth",
-				"repo": "stylix",
-				"type": "github"
-			}
-		},
-		"systems": {
-			"locked": {
-				"lastModified": 1681028828,
-				"narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-				"owner": "nix-systems",
-				"repo": "default",
-				"rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-systems",
-				"repo": "default",
-				"type": "github"
-			}
-		},
-		"systems_2": {
-			"locked": {
-				"lastModified": 1681028828,
-				"narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-				"owner": "nix-systems",
-				"repo": "default",
-				"rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-systems",
-				"repo": "default",
-				"type": "github"
-			}
-		},
-		"systems_3": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1681028828,
-				"narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-				"owner": "nix-systems",
-				"repo": "default",
-				"rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-systems",
-				"repo": "default",
-				"type": "github"
-			}
-		},
-		"systems_4": {
-			"locked": {
-				"lastModified": 1681028828,
-				"narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-				"owner": "nix-systems",
-				"repo": "default",
-				"rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-systems",
-				"repo": "default",
-				"type": "github"
-			}
-		},
-		"systems_5": {
-			"locked": {
-				"lastModified": 1681028828,
-				"narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-				"owner": "nix-systems",
-				"repo": "default",
-				"rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-systems",
-				"repo": "default",
-				"type": "github"
-			}
-		},
-		"systems_6": {
-			"locked": {
-				"lastModified": 1681028828,
-				"narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-				"owner": "nix-systems",
-				"repo": "default",
-				"rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-systems",
-				"repo": "default",
-				"type": "github"
-			}
-		},
-		"tinted-foot": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1726913040,
-				"narHash": "sha256-+eDZPkw7efMNUf3/Pv0EmsidqdwNJ1TaOum6k7lngDQ=",
-				"owner": "tinted-theming",
-				"repo": "tinted-foot",
-				"rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tinted-theming",
-				"repo": "tinted-foot",
-				"rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
-				"type": "github"
-			}
-		},
-		"tinted-kitty": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1735730497,
-				"narHash": "sha256-4KtB+FiUzIeK/4aHCKce3V9HwRvYaxX+F1edUrfgzb8=",
-				"owner": "tinted-theming",
-				"repo": "tinted-kitty",
-				"rev": "de6f888497f2c6b2279361bfc790f164bfd0f3fa",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tinted-theming",
-				"repo": "tinted-kitty",
-				"type": "github"
-			}
-		},
-		"tinted-schemes": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1767710407,
-				"narHash": "sha256-+W1EB79Jl0/gm4JqmO0Nuc5C7hRdp4vfsV/VdzI+des=",
-				"owner": "tinted-theming",
-				"repo": "schemes",
-				"rev": "2800e2b8ac90f678d7e4acebe4fa253f602e05b2",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tinted-theming",
-				"repo": "schemes",
-				"type": "github"
-			}
-		},
-		"tinted-tmux": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1767489635,
-				"narHash": "sha256-e6nnFnWXKBCJjCv4QG4bbcouJ6y3yeT70V9MofL32lU=",
-				"owner": "tinted-theming",
-				"repo": "tinted-tmux",
-				"rev": "3c32729ccae99be44fe8a125d20be06f8d7d8184",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tinted-theming",
-				"repo": "tinted-tmux",
-				"type": "github"
-			}
-		},
-		"tinted-zed": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1767488740,
-				"narHash": "sha256-wVOj0qyil8m+ouSsVZcNjl5ZR+1GdOOAooAatQXHbuU=",
-				"owner": "tinted-theming",
-				"repo": "base16-zed",
-				"rev": "11abb0b282ad3786a2aae088d3a01c60916f2e40",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tinted-theming",
-				"repo": "base16-zed",
-				"type": "github"
-			}
-		}
-	},
-	"root": "root",
-	"version": 7
+  "nodes": {
+    "agenix": {
+      "inputs": {
+        "darwin": "darwin",
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1770165109,
+        "narHash": "sha256-9VnK6Oqai65puVJ4WYtCTvlJeXxMzAp/69HhQuTdl/I=",
+        "owner": "ryantm",
+        "repo": "agenix",
+        "rev": "b027ee29d959fda4b60b57566d64c98a202e0feb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ryantm",
+        "repo": "agenix",
+        "type": "github"
+      }
+    },
+    "base16": {
+      "inputs": {
+        "fromYaml": "fromYaml"
+      },
+      "locked": {
+        "lastModified": 1755819240,
+        "narHash": "sha256-qcMhnL7aGAuFuutH4rq9fvAhCpJWVHLcHVZLtPctPlo=",
+        "owner": "SenchoPens",
+        "repo": "base16.nix",
+        "rev": "75ed5e5e3fce37df22e49125181fa37899c3ccd6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SenchoPens",
+        "repo": "base16.nix",
+        "type": "github"
+      }
+    },
+    "base16-fish": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765809053,
+        "narHash": "sha256-XCUQLoLfBJ8saWms2HCIj4NEN+xNsWBlU1NrEPcQG4s=",
+        "owner": "tomyun",
+        "repo": "base16-fish",
+        "rev": "86cbea4dca62e08fb7fd83a70e96472f92574782",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tomyun",
+        "repo": "base16-fish",
+        "rev": "86cbea4dca62e08fb7fd83a70e96472f92574782",
+        "type": "github"
+      }
+    },
+    "base16-helix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1760703920,
+        "narHash": "sha256-m82fGUYns4uHd+ZTdoLX2vlHikzwzdu2s2rYM2bNwzw=",
+        "owner": "tinted-theming",
+        "repo": "base16-helix",
+        "rev": "d646af9b7d14bff08824538164af99d0c521b185",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-helix",
+        "type": "github"
+      }
+    },
+    "base16-vim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1732806396,
+        "narHash": "sha256-e0bpPySdJf0F68Ndanwm+KWHgQiZ0s7liLhvJSWDNsA=",
+        "owner": "tinted-theming",
+        "repo": "base16-vim",
+        "rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-vim",
+        "rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1754269165,
+        "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "444e81206df3f7d92780680e45858e31d2f07a08",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "agenix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744478979,
+        "narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
+        "owner": "lnl7",
+        "repo": "nix-darwin",
+        "rev": "43975d782b418ebf4969e9ccba82466728c2851b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lnl7",
+        "ref": "master",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "firefox-gnome-theme": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1764873433,
+        "narHash": "sha256-1XPewtGMi+9wN9Ispoluxunw/RwozuTRVuuQOmxzt+A=",
+        "owner": "rafaelmardojai",
+        "repo": "firefox-gnome-theme",
+        "rev": "f7ffd917ac0d253dbd6a3bf3da06888f57c69f92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rafaelmardojai",
+        "repo": "firefox-gnome-theme",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1746162366,
+        "narHash": "sha256-5SSSZ/oQkwfcAz/o/6TlejlVGqeK08wyREBQ5qFFPhM=",
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "rev": "0f158086a2ecdbb138cd0429410e44994f1b7e4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "lanzaboote",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754091436,
+        "narHash": "sha256-XKqDMN1/Qj1DKivQvscI4vmHfDfvYR2pfuFOJiCeewM=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "67df8c627c2c39c41dbec76a1f201929929ab0bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "stylix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767609335,
+        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "fromYaml": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1731966426,
+        "narHash": "sha256-lq95WydhbUTWig/JpqiB7oViTcHFP8Lv41IGtayokA8=",
+        "owner": "SenchoPens",
+        "repo": "fromYaml",
+        "rev": "106af9e2f715e2d828df706c386a685698f3223b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SenchoPens",
+        "repo": "fromYaml",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769939035,
+        "narHash": "sha256-Fok2AmefgVA0+eprw2NDwqKkPGEI5wvR+twiZagBvrg=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "a8ca480175326551d6c4121498316261cbb5b260",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "lanzaboote",
+          "pre-commit-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gnome-shell": {
+      "flake": false,
+      "locked": {
+        "host": "gitlab.gnome.org",
+        "lastModified": 1767737596,
+        "narHash": "sha256-eFujfIUQDgWnSJBablOuG+32hCai192yRdrNHTv0a+s=",
+        "owner": "GNOME",
+        "repo": "gnome-shell",
+        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
+        "type": "gitlab"
+      },
+      "original": {
+        "host": "gitlab.gnome.org",
+        "owner": "GNOME",
+        "ref": "gnome-49",
+        "repo": "gnome-shell",
+        "type": "gitlab"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770476834,
+        "narHash": "sha256-cyxgVsNfHnJ4Zn6G1EOzfTXbjTy7Ds9zMOsZaX7VZWs=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "6cee0821577643e0b34e2c5d9a90d0b1b5cdca70",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_2": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprpanel",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750798083,
+        "narHash": "sha256-DTCCcp6WCFaYXWKFRA6fiI2zlvOLCf5Vwx8+/0R8Wc4=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "ff31a4677c1a8ae506aa7e003a3dba08cb203f82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "hyprpanel": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "home-manager": "home-manager_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1767767975,
+        "narHash": "sha256-yBejG3j6OLQYn87UozFAI3q9a1vH00u9xjIf2Q4V5j8=",
+        "owner": "Jas-SinghFSU",
+        "repo": "HyprPanel",
+        "rev": "0e73df1dfedf0f6fa21ed0ae5e031b0663c8f400",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Jas-SinghFSU",
+        "repo": "HyprPanel",
+        "type": "github"
+      }
+    },
+    "lanzaboote": {
+      "inputs": {
+        "crane": "crane",
+        "flake-compat": "flake-compat_2",
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1762205063,
+        "narHash": "sha256-If6vQ+KvtKs3ARBO9G3l+4wFSCYtRBrwX1z+I+B61wQ=",
+        "owner": "nix-community",
+        "repo": "lanzaboote",
+        "rev": "88b8a563ff5704f4e8d8e5118fb911fa2110ca05",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v0.4.3",
+        "repo": "lanzaboote",
+        "type": "github"
+      }
+    },
+    "nix-flatpak": {
+      "locked": {
+        "lastModified": 1767983141,
+        "narHash": "sha256-7ZCulYUD9RmJIDULTRkGLSW1faMpDlPKcbWJLYHoXcs=",
+        "owner": "gmodena",
+        "repo": "nix-flatpak",
+        "rev": "440818969ac2cbd77bfe025e884d0aa528991374",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gmodena",
+        "ref": "latest",
+        "repo": "nix-flatpak",
+        "type": "github"
+      }
+    },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1770315571,
+        "narHash": "sha256-hy0gcAgAcxrnSWKGuNO+Ob0x6jQ2xkR6hoaR0qJBHYs=",
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "rev": "2684bb8080a6f2ca5f9d494de5ef875bc1c4ecdb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
+    "nix4vscode": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1770431980,
+        "narHash": "sha256-eEUlQvXjmAiGGZ335EzDXfu3UKvjBti4G6iTxSzeCDI=",
+        "owner": "nix-community",
+        "repo": "nix4vscode",
+        "rev": "a0c43a20777ba1deb286bd059fc4d4ad6ab587c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix4vscode",
+        "type": "github"
+      }
+    },
+    "nixos-cosmic": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-stable": "nixpkgs-stable",
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1751591814,
+        "narHash": "sha256-A4lgvuj4v+Pr8MniXz1FBG0DXOygi8tTECR+j53FMhM=",
+        "owner": "lilyinstarlight",
+        "repo": "nixos-cosmic",
+        "rev": "fef2d0c78c4e4d6c600a88795af193131ff51bdc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lilyinstarlight",
+        "repo": "nixos-cosmic",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750776420,
+        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1751048012,
+        "narHash": "sha256-MYbotu4UjWpTsq01wglhN5xDRfZYLFtNk7SBY0BcjkU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a684c58d46ebbede49f280b653b9e56100aa3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1770197578,
+        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1751011381,
+        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1770197578,
+        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1770197578,
+        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1767767207,
+        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nur": {
+      "inputs": {
+        "flake-parts": "flake-parts_3",
+        "nixpkgs": "nixpkgs_5"
+      },
+      "locked": {
+        "lastModified": 1770482948,
+        "narHash": "sha256-GgkGGYHo8YH1dMM9/6KrnRO4d1rVFmVrk9QLNu9ie6w=",
+        "owner": "nix-community",
+        "repo": "NUR",
+        "rev": "b01fc1da9173c447a1ab4db35c523951157b8e83",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NUR",
+        "type": "github"
+      }
+    },
+    "nur_2": {
+      "inputs": {
+        "flake-parts": [
+          "stylix",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "stylix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767810917,
+        "narHash": "sha256-ZKqhk772+v/bujjhla9VABwcvz+hB2IaRyeLT6CFnT0=",
+        "owner": "nix-community",
+        "repo": "NUR",
+        "rev": "dead29c804adc928d3a69dfe7f9f12d0eec1f1a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NUR",
+        "type": "github"
+      }
+    },
+    "plasma-manager": {
+      "inputs": {
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769956244,
+        "narHash": "sha256-12RCFLyAedyMOdenUi7cN3ioJPEGjA/ZG1BLjugfUVs=",
+        "owner": "nix-community",
+        "repo": "plasma-manager",
+        "rev": "fe54ea85c6e4413fba03b84d50f2b431d2f7c831",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "plasma-manager",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks-nix": {
+      "inputs": {
+        "flake-compat": [
+          "lanzaboote",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "lanzaboote",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "agenix": "agenix",
+        "devshell": "devshell",
+        "flake-parts": "flake-parts",
+        "git-hooks": "git-hooks",
+        "home-manager": "home-manager",
+        "hyprpanel": "hyprpanel",
+        "lanzaboote": "lanzaboote",
+        "nix-flatpak": "nix-flatpak",
+        "nix-index-database": "nix-index-database",
+        "nix4vscode": "nix4vscode",
+        "nixos-cosmic": "nixos-cosmic",
+        "nixpkgs": "nixpkgs_4",
+        "nixpkgs-stable": "nixpkgs-stable_2",
+        "nur": "nur",
+        "plasma-manager": "plasma-manager",
+        "spicetify-nix": "spicetify-nix",
+        "stylix": "stylix",
+        "systems": "systems_6"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "lanzaboote",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1761791894,
+        "narHash": "sha256-myRIDh+PxaREz+z9LzbqBJF+SnTFJwkthKDX9zMyddY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "59c45eb69d9222a4362673141e00ff77842cd219",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixos-cosmic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1751251399,
+        "narHash": "sha256-y+viCuy/eKKpkX1K2gDvXIJI/yzvy6zA3HObapz9XZ0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b22d5ee8c60ed1291521f2dde48784edd6bf695b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "spicetify-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1769986820,
+        "narHash": "sha256-O9OQ44dk9TJdtRIG828DUI54XdkfZET7AlN1RgTsPis=",
+        "owner": "Gerg-L",
+        "repo": "spicetify-nix",
+        "rev": "68de6434cfaa8983f3775b858b8b76e7c5dbd29c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Gerg-L",
+        "repo": "spicetify-nix",
+        "type": "github"
+      }
+    },
+    "stylix": {
+      "inputs": {
+        "base16": "base16",
+        "base16-fish": "base16-fish",
+        "base16-helix": "base16-helix",
+        "base16-vim": "base16-vim",
+        "firefox-gnome-theme": "firefox-gnome-theme",
+        "flake-parts": "flake-parts_4",
+        "gnome-shell": "gnome-shell",
+        "nixpkgs": "nixpkgs_6",
+        "nur": "nur_2",
+        "systems": "systems_5",
+        "tinted-foot": "tinted-foot",
+        "tinted-kitty": "tinted-kitty",
+        "tinted-schemes": "tinted-schemes",
+        "tinted-tmux": "tinted-tmux",
+        "tinted-zed": "tinted-zed"
+      },
+      "locked": {
+        "lastModified": 1770382623,
+        "narHash": "sha256-NB9j2JsIcSPcY7FzzoIqJA04p4xSdJpgyLAwzzzncpc=",
+        "owner": "danth",
+        "repo": "stylix",
+        "rev": "05c798e0074296df9bfc6ef3df0e936b878b835a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "danth",
+        "repo": "stylix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "tinted-foot": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1726913040,
+        "narHash": "sha256-+eDZPkw7efMNUf3/Pv0EmsidqdwNJ1TaOum6k7lngDQ=",
+        "owner": "tinted-theming",
+        "repo": "tinted-foot",
+        "rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-foot",
+        "rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
+        "type": "github"
+      }
+    },
+    "tinted-kitty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1735730497,
+        "narHash": "sha256-4KtB+FiUzIeK/4aHCKce3V9HwRvYaxX+F1edUrfgzb8=",
+        "owner": "tinted-theming",
+        "repo": "tinted-kitty",
+        "rev": "de6f888497f2c6b2279361bfc790f164bfd0f3fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-kitty",
+        "type": "github"
+      }
+    },
+    "tinted-schemes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767710407,
+        "narHash": "sha256-+W1EB79Jl0/gm4JqmO0Nuc5C7hRdp4vfsV/VdzI+des=",
+        "owner": "tinted-theming",
+        "repo": "schemes",
+        "rev": "2800e2b8ac90f678d7e4acebe4fa253f602e05b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "schemes",
+        "type": "github"
+      }
+    },
+    "tinted-tmux": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767489635,
+        "narHash": "sha256-e6nnFnWXKBCJjCv4QG4bbcouJ6y3yeT70V9MofL32lU=",
+        "owner": "tinted-theming",
+        "repo": "tinted-tmux",
+        "rev": "3c32729ccae99be44fe8a125d20be06f8d7d8184",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-tmux",
+        "type": "github"
+      }
+    },
+    "tinted-zed": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767488740,
+        "narHash": "sha256-wVOj0qyil8m+ouSsVZcNjl5ZR+1GdOOAooAatQXHbuU=",
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
+        "rev": "11abb0b282ad3786a2aae088d3a01c60916f2e40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
 }


### PR DESCRIPTION
Automated Pull Request for Week 06

Flakes Changelog:
```
• Updated input 'agenix':
    'github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6' (2025-11-08)
  → 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' (2026-02-04)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/80daad04eddbbf5a4d883996a73f3f542fa437ac' (2026-01-11)
  → 'github:hercules-ci/flake-parts/57928607ea566b5db3ad13af0e57e921e6b12381' (2026-02-02)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/2075416fcb47225d9b68ac469a5c4801a9c4dd85' (2025-12-14)
  → 'github:nix-community/nixpkgs.lib/72716169fe93074c333e8d0173151350670b824c' (2026-02-01)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/a1ef738813b15cf8ec759bdff5761b027e3e1d23' (2026-01-22)
  → 'github:cachix/git-hooks.nix/a8ca480175326551d6c4121498316261cbb5b260' (2026-02-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/f4ad5068ee8e89e4a7c2e963e10dd35cd77b37b7' (2026-01-31)
  → 'github:nix-community/home-manager/6cee0821577643e0b34e2c5d9a90d0b1b5cdca70' (2026-02-07)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/82befcf7dc77c909b0f2a09f5da910ec95c5b78f' (2025-12-09)
  → 'github:nix-community/nix-index-database/2684bb8080a6f2ca5f9d494de5ef875bc1c4ecdb' (2026-02-05)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/f61125a668a320878494449750330ca58b78c557' (2025-12-05)
  → 'github:NixOS/nixpkgs/00c21e4c93d963c50d4c0c89bfa84ed6e0694df2' (2026-02-04)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/c0d7d5949be1edc4d31af9c0173b85b74a4e23c8' (2026-01-31)
  → 'github:nix-community/nix4vscode/a0c43a20777ba1deb286bd059fc4d4ad6ab587c7' (2026-02-07)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/bfc1b8a4574108ceef22f02bafcf6611380c100d' (2026-01-26)
  → 'github:NixOS/nixpkgs/00c21e4c93d963c50d4c0c89bfa84ed6e0694df2' (2026-02-04)
• Updated input 'nur':
    'github:nix-community/NUR/f792ac11fc18ef015d41102bf86d992fa39cb1d0' (2026-01-31)
  → 'github:nix-community/NUR/b01fc1da9173c447a1ab4db35c523951157b8e83' (2026-02-07)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/bfc1b8a4574108ceef22f02bafcf6611380c100d' (2026-01-26)
  → 'github:nixos/nixpkgs/00c21e4c93d963c50d4c0c89bfa84ed6e0694df2' (2026-02-04)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/51816be33a1ff0d4b22427de83222d5bfa96d30e' (2026-01-06)
  → 'github:nix-community/plasma-manager/fe54ea85c6e4413fba03b84d50f2b431d2f7c831' (2026-02-01)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/b2ce438f386943ef611e196a178af2d79042903b' (2026-01-25)
  → 'github:Gerg-L/spicetify-nix/68de6434cfaa8983f3775b858b8b76e7c5dbd29c' (2026-02-01)
• Updated input 'stylix':
    'github:danth/stylix/8b14679c0e1570b0e137f0f7997717be0fdf2cf2' (2026-01-31)
  → 'github:danth/stylix/05c798e0074296df9bfc6ef3df0e936b878b835a' (2026-02-06)
```

Sources Changelog:
```
nix-fast-build: 87930e949d526b5ebdea7109275b3d35b124386a → abc09eff2c2c0c0c41a9a2b3955925eecbd7e520
```
