### PR TITLE
chore: update flake.lock & sources (2026-02-14)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-02-01",
+        "date": "2026-02-08",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "abc09eff2c2c0c0c41a9a2b3955925eecbd7e520",
-            "sha256": "sha256-4ovZVXVBLTdKOiyCMLTgLt5bdwbbNalsjdLVrEKBkjw=",
+            "rev": "8ac62f38ac3b21eec112b4e6d8bd98fa84b465e0",
+            "sha256": "sha256-T7LydwjxHx4CzF2mgVyIhFVUjTYGWVafdhEaYRuGtv4=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "abc09eff2c2c0c0c41a9a2b3955925eecbd7e520"
+        "version": "8ac62f38ac3b21eec112b4e6d8bd98fa84b465e0"
     },
     "obs_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "abc09eff2c2c0c0c41a9a2b3955925eecbd7e520";
+    version = "8ac62f38ac3b21eec112b4e6d8bd98fa84b465e0";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "abc09eff2c2c0c0c41a9a2b3955925eecbd7e520";
+      rev = "8ac62f38ac3b21eec112b4e6d8bd98fa84b465e0";
       fetchSubmodules = false;
-      sha256 = "sha256-4ovZVXVBLTdKOiyCMLTgLt5bdwbbNalsjdLVrEKBkjw=";
+      sha256 = "sha256-T7LydwjxHx4CzF2mgVyIhFVUjTYGWVafdhEaYRuGtv4=";
     };
-    date = "2026-02-01";
+    date = "2026-02-08";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -338,11 +338,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769939035,
-        "narHash": "sha256-Fok2AmefgVA0+eprw2NDwqKkPGEI5wvR+twiZagBvrg=",
+        "lastModified": 1770726378,
+        "narHash": "sha256-kck+vIbGOaM/dHea7aTBxdFYpeUl/jHOy5W3eyRvVx8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "a8ca480175326551d6c4121498316261cbb5b260",
+        "rev": "5eaaedde414f6eb1aea8b8525c466dc37bba95ae",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770476834,
-        "narHash": "sha256-cyxgVsNfHnJ4Zn6G1EOzfTXbjTy7Ds9zMOsZaX7VZWs=",
+        "lastModified": 1771037579,
+        "narHash": "sha256-NX5XuhGcsmk0oEII2PEtMRgvh2KaAv3/WWQsOpxAgR4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6cee0821577643e0b34e2c5d9a90d0b1b5cdca70",
+        "rev": "05e6dc0f6ed936f918cb6f0f21f1dad1e4c53150",
         "type": "github"
       },
       "original": {
@@ -542,11 +542,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1770431980,
-        "narHash": "sha256-eEUlQvXjmAiGGZ335EzDXfu3UKvjBti4G6iTxSzeCDI=",
+        "lastModified": 1771036853,
+        "narHash": "sha256-3bO2hG4sfHkXIdzYrC1NN3/7Tf/dLAp87k60+xq+1dY=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "a0c43a20777ba1deb286bd059fc4d4ad6ab587c7",
+        "rev": "83336aa085f4adfa4bc9289ad600dbc2f4f51088",
         "type": "github"
       },
       "original": {
@@ -673,11 +673,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1770197578,
-        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1770197578,
-        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1770482948,
-        "narHash": "sha256-GgkGGYHo8YH1dMM9/6KrnRO4d1rVFmVrk9QLNu9ie6w=",
+        "lastModified": 1771087708,
+        "narHash": "sha256-0e9rarmGTdl8P4OgBHotxfebcn3Cvw+U0w0saYAbOCk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b01fc1da9173c447a1ab4db35c523951157b8e83",
+        "rev": "b55ed52d18b2a2306454aa57554170f501bb06ed",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769956244,
+        "lastModified": 1770766818,
         "narHash": "sha256-12RCFLyAedyMOdenUi7cN3ioJPEGjA/ZG1BLjugfUVs=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "fe54ea85c6e4413fba03b84d50f2b431d2f7c831",
+        "rev": "44b928068359b7d2310a34de39555c63c93a2c90",
         "type": "github"
       },
       "original": {
@@ -884,11 +884,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1769986820,
-        "narHash": "sha256-O9OQ44dk9TJdtRIG828DUI54XdkfZET7AlN1RgTsPis=",
+        "lastModified": 1770846656,
+        "narHash": "sha256-wdYpo8++TqKp3GdRgLFykjuIVW1m9GlUnxID2FG74cE=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "68de6434cfaa8983f3775b858b8b76e7c5dbd29c",
+        "rev": "40e65cfc4608402674e1efaac3fccce20d2a72d3",
         "type": "github"
       },
       "original": {
@@ -916,11 +916,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1770382623,
-        "narHash": "sha256-NB9j2JsIcSPcY7FzzoIqJA04p4xSdJpgyLAwzzzncpc=",
+        "lastModified": 1770914701,
+        "narHash": "sha256-QHFYyngohNhih4w+3IqQty5DV+p1txsx1kkk6XJWar8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "05c798e0074296df9bfc6ef3df0e936b878b835a",
+        "rev": "db03fed72e5ca02be34e1d24789345a943329738",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 07

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/a8ca480175326551d6c4121498316261cbb5b260' (2026-02-01)
  → 'github:cachix/git-hooks.nix/5eaaedde414f6eb1aea8b8525c466dc37bba95ae' (2026-02-10)
• Updated input 'home-manager':
    'github:nix-community/home-manager/6cee0821577643e0b34e2c5d9a90d0b1b5cdca70' (2026-02-07)
  → 'github:nix-community/home-manager/05e6dc0f6ed936f918cb6f0f21f1dad1e4c53150' (2026-02-14)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/a0c43a20777ba1deb286bd059fc4d4ad6ab587c7' (2026-02-07)
  → 'github:nix-community/nix4vscode/83336aa085f4adfa4bc9289ad600dbc2f4f51088' (2026-02-14)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/00c21e4c93d963c50d4c0c89bfa84ed6e0694df2' (2026-02-04)
  → 'github:NixOS/nixpkgs/a82ccc39b39b621151d6732718e3e250109076fa' (2026-02-13)
• Updated input 'nur':
    'github:nix-community/NUR/b01fc1da9173c447a1ab4db35c523951157b8e83' (2026-02-07)
  → 'github:nix-community/NUR/b55ed52d18b2a2306454aa57554170f501bb06ed' (2026-02-14)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/00c21e4c93d963c50d4c0c89bfa84ed6e0694df2' (2026-02-04)
  → 'github:nixos/nixpkgs/a82ccc39b39b621151d6732718e3e250109076fa' (2026-02-13)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/fe54ea85c6e4413fba03b84d50f2b431d2f7c831' (2026-02-01)
  → 'github:nix-community/plasma-manager/44b928068359b7d2310a34de39555c63c93a2c90' (2026-02-10)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/68de6434cfaa8983f3775b858b8b76e7c5dbd29c' (2026-02-01)
  → 'github:Gerg-L/spicetify-nix/40e65cfc4608402674e1efaac3fccce20d2a72d3' (2026-02-11)
• Updated input 'stylix':
    'github:danth/stylix/05c798e0074296df9bfc6ef3df0e936b878b835a' (2026-02-06)
  → 'github:danth/stylix/db03fed72e5ca02be34e1d24789345a943329738' (2026-02-12)
```

Sources Changelog:
```
nix-fast-build: abc09eff2c2c0c0c41a9a2b3955925eecbd7e520 → 8ac62f38ac3b21eec112b4e6d8bd98fa84b465e0
```
