### PR TITLE
chore: update flake.lock & sources (2026-02-21)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -436,11 +436,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771037579,
-        "narHash": "sha256-NX5XuhGcsmk0oEII2PEtMRgvh2KaAv3/WWQsOpxAgR4=",
+        "lastModified": 1771683283,
+        "narHash": "sha256-WxAEkAbo8dP7qiyPM6VN4ZGAxfuBVlNBNPkrqkrXVEc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "05e6dc0f6ed936f918cb6f0f21f1dad1e4c53150",
+        "rev": "c6ed3eab64d23520bcbb858aa53fe2b533725d4a",
         "type": "github"
       },
       "original": {
@@ -537,11 +537,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1770315571,
-        "narHash": "sha256-hy0gcAgAcxrnSWKGuNO+Ob0x6jQ2xkR6hoaR0qJBHYs=",
+        "lastModified": 1771130777,
+        "narHash": "sha256-UIKOwG0D9XVIJfNWg6+gENAvQP+7LO46eO0Jpe+ItJ0=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "2684bb8080a6f2ca5f9d494de5ef875bc1c4ecdb",
+        "rev": "efec7aaad8d43f8e5194df46a007456093c40f88",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1771036853,
-        "narHash": "sha256-3bO2hG4sfHkXIdzYrC1NN3/7Tf/dLAp87k60+xq+1dY=",
+        "lastModified": 1771641478,
+        "narHash": "sha256-iY4HhfBY2Jb0Q7PSaWmVNePeTloS7ZlIysCSFLr838A=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "83336aa085f4adfa4bc9289ad600dbc2f4f51088",
+        "rev": "4bec63f6f27a1d04cdde6e1ae40a79505d77f87e",
         "type": "github"
       },
       "original": {
@@ -657,11 +657,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1770197578,
-        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1771008912,
-        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {
@@ -705,11 +705,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1771008912,
-        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {
@@ -741,11 +741,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1771087708,
-        "narHash": "sha256-0e9rarmGTdl8P4OgBHotxfebcn3Cvw+U0w0saYAbOCk=",
+        "lastModified": 1771688364,
+        "narHash": "sha256-/0/vZBn5MJH16boxdSqvlDooxA+9jCj24uwsM5cZWFA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b55ed52d18b2a2306454aa57554170f501bb06ed",
+        "rev": "45d2966b546e0ce7ae48f2e100d71ce1299747bf",
         "type": "github"
       },
       "original": {
@@ -901,11 +901,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1770846656,
-        "narHash": "sha256-wdYpo8++TqKp3GdRgLFykjuIVW1m9GlUnxID2FG74cE=",
+        "lastModified": 1771268051,
+        "narHash": "sha256-nGqPcngnezoT+/xAvw3UDjwdKP2MC4fO315A/Otb9eE=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "40e65cfc4608402674e1efaac3fccce20d2a72d3",
+        "rev": "b930de84c561f62a0c39a6a57c2ab553a97e8495",
         "type": "github"
       },
       "original": {
@@ -933,11 +933,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1770914701,
-        "narHash": "sha256-QHFYyngohNhih4w+3IqQty5DV+p1txsx1kkk6XJWar8=",
+        "lastModified": 1771626923,
+        "narHash": "sha256-Mn6oeKrY+Sw6kH0jK+hp5QQH4MTcqwBRQL/ScZDNcz8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "db03fed72e5ca02be34e1d24789345a943329738",
+        "rev": "b09847414b50c65788936199918272377f70fb91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 08

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/05e6dc0f6ed936f918cb6f0f21f1dad1e4c53150' (2026-02-14)
  → 'github:nix-community/home-manager/c6ed3eab64d23520bcbb858aa53fe2b533725d4a' (2026-02-21)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/2684bb8080a6f2ca5f9d494de5ef875bc1c4ecdb' (2026-02-05)
  → 'github:nix-community/nix-index-database/efec7aaad8d43f8e5194df46a007456093c40f88' (2026-02-15)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/00c21e4c93d963c50d4c0c89bfa84ed6e0694df2' (2026-02-04)
  → 'github:NixOS/nixpkgs/a82ccc39b39b621151d6732718e3e250109076fa' (2026-02-13)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/83336aa085f4adfa4bc9289ad600dbc2f4f51088' (2026-02-14)
  → 'github:nix-community/nix4vscode/4bec63f6f27a1d04cdde6e1ae40a79505d77f87e' (2026-02-21)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a82ccc39b39b621151d6732718e3e250109076fa' (2026-02-13)
  → 'github:NixOS/nixpkgs/0182a361324364ae3f436a63005877674cf45efb' (2026-02-17)
• Updated input 'nur':
    'github:nix-community/NUR/b55ed52d18b2a2306454aa57554170f501bb06ed' (2026-02-14)
  → 'github:nix-community/NUR/45d2966b546e0ce7ae48f2e100d71ce1299747bf' (2026-02-21)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/a82ccc39b39b621151d6732718e3e250109076fa' (2026-02-13)
  → 'github:nixos/nixpkgs/0182a361324364ae3f436a63005877674cf45efb' (2026-02-17)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/40e65cfc4608402674e1efaac3fccce20d2a72d3' (2026-02-11)
  → 'github:Gerg-L/spicetify-nix/b930de84c561f62a0c39a6a57c2ab553a97e8495' (2026-02-16)
• Updated input 'stylix':
    'github:danth/stylix/db03fed72e5ca02be34e1d24789345a943329738' (2026-02-12)
  → 'github:danth/stylix/b09847414b50c65788936199918272377f70fb91' (2026-02-20)
```

Sources Changelog:
```
No changes!
```
