### PR TITLE
chore: update flake.lock & sources (2026-02-28)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -354,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770726378,
-        "narHash": "sha256-kck+vIbGOaM/dHea7aTBxdFYpeUl/jHOy5W3eyRvVx8=",
+        "lastModified": 1772024342,
+        "narHash": "sha256-+eXlIc4/7dE6EcPs9a2DaSY3fTA9AE526hGqkNID3Wg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "5eaaedde414f6eb1aea8b8525c466dc37bba95ae",
+        "rev": "6e34e97ed9788b17796ee43ccdbaf871a5c2b476",
         "type": "github"
       },
       "original": {
@@ -436,11 +436,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771683283,
-        "narHash": "sha256-WxAEkAbo8dP7qiyPM6VN4ZGAxfuBVlNBNPkrqkrXVEc=",
+        "lastModified": 1772218752,
+        "narHash": "sha256-G8nArvOTZXU8DRvrzAdz3Elcj6kA/vMtvY9mrGLATtA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c6ed3eab64d23520bcbb858aa53fe2b533725d4a",
+        "rev": "f3a30376bb9eb2f6f61816be7d6ed954b6d2a3b9",
         "type": "github"
       },
       "original": {
@@ -537,11 +537,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1771130777,
-        "narHash": "sha256-UIKOwG0D9XVIJfNWg6+gENAvQP+7LO46eO0Jpe+ItJ0=",
+        "lastModified": 1771734689,
+        "narHash": "sha256-/phvMgr1yutyAMjKnZlxkVplzxHiz60i4rc+gKzpwhg=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "efec7aaad8d43f8e5194df46a007456093c40f88",
+        "rev": "8f590b832326ab9699444f3a48240595954a4b10",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1771641478,
-        "narHash": "sha256-iY4HhfBY2Jb0Q7PSaWmVNePeTloS7ZlIysCSFLr838A=",
+        "lastModified": 1772246016,
+        "narHash": "sha256-t597c98fklAy3a/VNrCo+X+GDe5plMjJilEQe3uIczM=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "4bec63f6f27a1d04cdde6e1ae40a79505d77f87e",
+        "rev": "5e82c8b3340893557d286a168624d24ec105f87b",
         "type": "github"
       },
       "original": {
@@ -657,11 +657,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1771008912,
-        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
         "type": "github"
       },
       "original": {
@@ -705,11 +705,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
         "type": "github"
       },
       "original": {
@@ -741,11 +741,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1771688364,
-        "narHash": "sha256-/0/vZBn5MJH16boxdSqvlDooxA+9jCj24uwsM5cZWFA=",
+        "lastModified": 1772296909,
+        "narHash": "sha256-rEDTiDd9jAdOMK37A00Lv8kE0ZVgB9qz/n2r9nODoRk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45d2966b546e0ce7ae48f2e100d71ce1299747bf",
+        "rev": "673b6008a62871ec3d1638b6fc999dbc4dfb5180",
         "type": "github"
       },
       "original": {
@@ -901,11 +901,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1771268051,
-        "narHash": "sha256-nGqPcngnezoT+/xAvw3UDjwdKP2MC4fO315A/Otb9eE=",
+        "lastModified": 1771737804,
+        "narHash": "sha256-7wn9qbzIQQgH8tnq4VwzuWEqEWpekuymlLyhY3vM/j8=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "b930de84c561f62a0c39a6a57c2ab553a97e8495",
+        "rev": "6dd43010ac2458cc56a6ac5250349b9217a7a2ae",
         "type": "github"
       },
       "original": {
@@ -933,11 +933,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1771626923,
-        "narHash": "sha256-Mn6oeKrY+Sw6kH0jK+hp5QQH4MTcqwBRQL/ScZDNcz8=",
+        "lastModified": 1772296853,
+        "narHash": "sha256-pAtzPsgHRKw/2Kv8HgAjSJg450FDldHPWsP3AKG/Xj0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b09847414b50c65788936199918272377f70fb91",
+        "rev": "c4b8e80a1020e09a1f081ad0f98ce804a6e85acf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 09

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/5eaaedde414f6eb1aea8b8525c466dc37bba95ae' (2026-02-10)
  → 'github:cachix/git-hooks.nix/6e34e97ed9788b17796ee43ccdbaf871a5c2b476' (2026-02-25)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c6ed3eab64d23520bcbb858aa53fe2b533725d4a' (2026-02-21)
  → 'github:nix-community/home-manager/f3a30376bb9eb2f6f61816be7d6ed954b6d2a3b9' (2026-02-27)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/efec7aaad8d43f8e5194df46a007456093c40f88' (2026-02-15)
  → 'github:nix-community/nix-index-database/8f590b832326ab9699444f3a48240595954a4b10' (2026-02-22)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/a82ccc39b39b621151d6732718e3e250109076fa' (2026-02-13)
  → 'github:NixOS/nixpkgs/0182a361324364ae3f436a63005877674cf45efb' (2026-02-17)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/4bec63f6f27a1d04cdde6e1ae40a79505d77f87e' (2026-02-21)
  → 'github:nix-community/nix4vscode/5e82c8b3340893557d286a168624d24ec105f87b' (2026-02-28)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/0182a361324364ae3f436a63005877674cf45efb' (2026-02-17)
  → 'github:NixOS/nixpkgs/2fc6539b481e1d2569f25f8799236694180c0993' (2026-02-23)
• Updated input 'nur':
    'github:nix-community/NUR/45d2966b546e0ce7ae48f2e100d71ce1299747bf' (2026-02-21)
  → 'github:nix-community/NUR/673b6008a62871ec3d1638b6fc999dbc4dfb5180' (2026-02-28)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/0182a361324364ae3f436a63005877674cf45efb' (2026-02-17)
  → 'github:nixos/nixpkgs/2fc6539b481e1d2569f25f8799236694180c0993' (2026-02-23)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/b930de84c561f62a0c39a6a57c2ab553a97e8495' (2026-02-16)
  → 'github:Gerg-L/spicetify-nix/6dd43010ac2458cc56a6ac5250349b9217a7a2ae' (2026-02-22)
• Updated input 'stylix':
    'github:danth/stylix/b09847414b50c65788936199918272377f70fb91' (2026-02-20)
  → 'github:danth/stylix/c4b8e80a1020e09a1f081ad0f98ce804a6e85acf' (2026-02-28)
```

Sources Changelog:
```
No changes!
```
