### PR TITLE
chore: update flake.lock & sources (2026-03-07)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -43,7 +43,7 @@
     },
     "eza_themes": {
         "cargoLock": null,
-        "date": "2025-12-15",
+        "date": "2026-03-04",
         "extract": null,
         "name": "eza_themes",
         "passthru": null,
@@ -55,12 +55,12 @@
             "name": null,
             "owner": "eza-community",
             "repo": "eza-themes",
-            "rev": "1239cb1dd23fa8b70865550db77701b164a53cde",
-            "sha256": "sha256-WcwzKm2mi/tyA+zZCpyvTdrOrZ1R1ENA3t622SGzFas=",
+            "rev": "add4c72c546992b8db674d6d3eea315bf2111b9a",
+            "sha256": "sha256-toqj3bv2kCC2FHbGfeFpS3g9DoxQeZ7cwPYVpD8cfgg=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "1239cb1dd23fa8b70865550db77701b164a53cde"
+        "version": "add4c72c546992b8db674d6d3eea315bf2111b9a"
     },
     "firefox-gnome-theme": {
         "cargoLock": null,
@@ -127,7 +127,7 @@
     },
     "obs_catppuccin": {
         "cargoLock": null,
-        "date": "2025-07-29",
+        "date": "2026-03-01",
         "extract": null,
         "name": "obs_catppuccin",
         "passthru": null,
@@ -139,12 +139,12 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "obs",
-            "rev": "05c55ffe499c183c98be469147f602c3f8e84b87",
-            "sha256": "sha256-ezz3euxO5lxyVaVFDPjNowpivAm9tRGHt8SbflAdkA8=",
+            "rev": "c5357ce7b0fb8c73aab0a80739832474087b1af6",
+            "sha256": "sha256-Uk4a0HKaeyQilgBiPsuAWQubk1yZdyirNcfhYJEL+lQ=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "05c55ffe499c183c98be469147f602c3f8e84b87"
+        "version": "c5357ce7b0fb8c73aab0a80739832474087b1af6"
     },
     "prismlauncher_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -32,15 +32,15 @@
   };
   eza_themes = {
     pname = "eza_themes";
-    version = "1239cb1dd23fa8b70865550db77701b164a53cde";
+    version = "add4c72c546992b8db674d6d3eea315bf2111b9a";
     src = fetchFromGitHub {
       owner = "eza-community";
       repo = "eza-themes";
-      rev = "1239cb1dd23fa8b70865550db77701b164a53cde";
+      rev = "add4c72c546992b8db674d6d3eea315bf2111b9a";
       fetchSubmodules = false;
-      sha256 = "sha256-WcwzKm2mi/tyA+zZCpyvTdrOrZ1R1ENA3t622SGzFas=";
+      sha256 = "sha256-toqj3bv2kCC2FHbGfeFpS3g9DoxQeZ7cwPYVpD8cfgg=";
     };
-    date = "2025-12-15";
+    date = "2026-03-04";
   };
   firefox-gnome-theme = {
     pname = "firefox-gnome-theme";
@@ -79,15 +79,15 @@
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";
-    version = "05c55ffe499c183c98be469147f602c3f8e84b87";
+    version = "c5357ce7b0fb8c73aab0a80739832474087b1af6";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "obs";
-      rev = "05c55ffe499c183c98be469147f602c3f8e84b87";
+      rev = "c5357ce7b0fb8c73aab0a80739832474087b1af6";
       fetchSubmodules = false;
-      sha256 = "sha256-ezz3euxO5lxyVaVFDPjNowpivAm9tRGHt8SbflAdkA8=";
+      sha256 = "sha256-Uk4a0HKaeyQilgBiPsuAWQubk1yZdyirNcfhYJEL+lQ=";
     };
-    date = "2025-07-29";
+    date = "2026-03-01";
   };
   prismlauncher_catppuccin = {
     pname = "prismlauncher_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -235,11 +235,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
@@ -354,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772024342,
-        "narHash": "sha256-+eXlIc4/7dE6EcPs9a2DaSY3fTA9AE526hGqkNID3Wg=",
+        "lastModified": 1772893680,
+        "narHash": "sha256-JDqZMgxUTCq85ObSaFw0HhE+lvdOre1lx9iI6vYyOEs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "6e34e97ed9788b17796ee43ccdbaf871a5c2b476",
+        "rev": "8baab586afc9c9b57645a734c820e4ac0a604af9",
         "type": "github"
       },
       "original": {
@@ -436,11 +436,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772218752,
-        "narHash": "sha256-G8nArvOTZXU8DRvrzAdz3Elcj6kA/vMtvY9mrGLATtA=",
+        "lastModified": 1772845525,
+        "narHash": "sha256-Dp5Ir2u4jJDGCgeMRviHvEQDe+U37hMxp6RSNOoMMPc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f3a30376bb9eb2f6f61816be7d6ed954b6d2a3b9",
+        "rev": "27b93804fbef1544cb07718d3f0a451f4c4cd6c0",
         "type": "github"
       },
       "original": {
@@ -537,11 +537,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1771734689,
-        "narHash": "sha256-/phvMgr1yutyAMjKnZlxkVplzxHiz60i4rc+gKzpwhg=",
+        "lastModified": 1772341813,
+        "narHash": "sha256-/PQ0ubBCMj/MVCWEI/XMStn55a8dIKsvztj4ZVLvUrQ=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "8f590b832326ab9699444f3a48240595954a4b10",
+        "rev": "a2051ff239ce2e8a0148fa7a152903d9a78e854f",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1772246016,
-        "narHash": "sha256-t597c98fklAy3a/VNrCo+X+GDe5plMjJilEQe3uIczM=",
+        "lastModified": 1772850987,
+        "narHash": "sha256-lx0Y2ZihQMNg5uRV2k3w6RGf3V/ldvvvFuPGzjxwMbM=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "5e82c8b3340893557d286a168624d24ec105f87b",
+        "rev": "e7869163915d6e9eae93640341178d55ea6b9cdb",
         "type": "github"
       },
       "original": {
@@ -610,11 +610,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1769909678,
-        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
         "type": "github"
       },
       "original": {
@@ -657,11 +657,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "lastModified": 1772198003,
+        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1772773019,
+        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
         "type": "github"
       },
       "original": {
@@ -705,11 +705,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1772773019,
+        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
         "type": "github"
       },
       "original": {
@@ -741,11 +741,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1772296909,
-        "narHash": "sha256-rEDTiDd9jAdOMK37A00Lv8kE0ZVgB9qz/n2r9nODoRk=",
+        "lastModified": 1772901786,
+        "narHash": "sha256-g72gv7PCDPS9/vwNmCISz7cSegsbrwcvG6CwpSLe/Dc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "673b6008a62871ec3d1638b6fc999dbc4dfb5180",
+        "rev": "bb2075cf1ccdcd94f4027bac4040837af35bf7cb",
         "type": "github"
       },
       "original": {
@@ -789,11 +789,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770766818,
-        "narHash": "sha256-12RCFLyAedyMOdenUi7cN3ioJPEGjA/ZG1BLjugfUVs=",
+        "lastModified": 1772361940,
+        "narHash": "sha256-B1Cz+ydL1iaOnGlwOFld/C8lBECPtzhiy/pP93/CuyY=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "44b928068359b7d2310a34de39555c63c93a2c90",
+        "rev": "a4b33606111c9c5dcd10009042bb710307174f51",
         "type": "github"
       },
       "original": {
@@ -901,11 +901,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1771737804,
-        "narHash": "sha256-7wn9qbzIQQgH8tnq4VwzuWEqEWpekuymlLyhY3vM/j8=",
+        "lastModified": 1772494187,
+        "narHash": "sha256-6ksgNAFXVK+Cg/6ww7bB2nJUPZlnS75UwZC7G+L03EE=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "6dd43010ac2458cc56a6ac5250349b9217a7a2ae",
+        "rev": "915ab06b046d05613041780c575c62a32fe67cea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 10

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/57928607ea566b5db3ad13af0e57e921e6b12381' (2026-02-02)
  → 'github:hercules-ci/flake-parts/f20dc5d9b8027381c474144ecabc9034d6a839a3' (2026-03-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/72716169fe93074c333e8d0173151350670b824c' (2026-02-01)
  → 'github:nix-community/nixpkgs.lib/c185c7a5e5dd8f9add5b2f8ebeff00888b070742' (2026-03-01)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/6e34e97ed9788b17796ee43ccdbaf871a5c2b476' (2026-02-25)
  → 'github:cachix/git-hooks.nix/8baab586afc9c9b57645a734c820e4ac0a604af9' (2026-03-07)
• Updated input 'home-manager':
    'github:nix-community/home-manager/f3a30376bb9eb2f6f61816be7d6ed954b6d2a3b9' (2026-02-27)
  → 'github:nix-community/home-manager/27b93804fbef1544cb07718d3f0a451f4c4cd6c0' (2026-03-07)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/8f590b832326ab9699444f3a48240595954a4b10' (2026-02-22)
  → 'github:nix-community/nix-index-database/a2051ff239ce2e8a0148fa7a152903d9a78e854f' (2026-03-01)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/0182a361324364ae3f436a63005877674cf45efb' (2026-02-17)
  → 'github:NixOS/nixpkgs/dd9b079222d43e1943b6ebd802f04fd959dc8e61' (2026-02-27)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/5e82c8b3340893557d286a168624d24ec105f87b' (2026-02-28)
  → 'github:nix-community/nix4vscode/e7869163915d6e9eae93640341178d55ea6b9cdb' (2026-03-07)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/2fc6539b481e1d2569f25f8799236694180c0993' (2026-02-23)
  → 'github:NixOS/nixpkgs/aca4d95fce4914b3892661bcb80b8087293536c6' (2026-03-06)
• Updated input 'nur':
    'github:nix-community/NUR/673b6008a62871ec3d1638b6fc999dbc4dfb5180' (2026-02-28)
  → 'github:nix-community/NUR/bb2075cf1ccdcd94f4027bac4040837af35bf7cb' (2026-03-07)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/2fc6539b481e1d2569f25f8799236694180c0993' (2026-02-23)
  → 'github:nixos/nixpkgs/aca4d95fce4914b3892661bcb80b8087293536c6' (2026-03-06)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/44b928068359b7d2310a34de39555c63c93a2c90' (2026-02-10)
  → 'github:nix-community/plasma-manager/a4b33606111c9c5dcd10009042bb710307174f51' (2026-03-01)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/6dd43010ac2458cc56a6ac5250349b9217a7a2ae' (2026-02-22)
  → 'github:Gerg-L/spicetify-nix/915ab06b046d05613041780c575c62a32fe67cea' (2026-03-02)
```

Sources Changelog:
```
obs_catppuccin: 05c55ffe499c183c98be469147f602c3f8e84b87 → c5357ce7b0fb8c73aab0a80739832474087b1af6
eza_themes: 1239cb1dd23fa8b70865550db77701b164a53cde → add4c72c546992b8db674d6d3eea315bf2111b9a
```
