### PR TITLE
chore: update flake.lock & sources (2026-03-14)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-02-08",
+        "date": "2026-03-11",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "8ac62f38ac3b21eec112b4e6d8bd98fa84b465e0",
-            "sha256": "sha256-T7LydwjxHx4CzF2mgVyIhFVUjTYGWVafdhEaYRuGtv4=",
+            "rev": "f5ca03a4387aecd739d60c77ae26e567481c3013",
+            "sha256": "sha256-mInYAyDT49w0ux7Jgg4Ny3igyEKlRvqzG2KAG9YVmsg=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "8ac62f38ac3b21eec112b4e6d8bd98fa84b465e0"
+        "version": "f5ca03a4387aecd739d60c77ae26e567481c3013"
     },
     "obs_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "8ac62f38ac3b21eec112b4e6d8bd98fa84b465e0";
+    version = "f5ca03a4387aecd739d60c77ae26e567481c3013";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "8ac62f38ac3b21eec112b4e6d8bd98fa84b465e0";
+      rev = "f5ca03a4387aecd739d60c77ae26e567481c3013";
       fetchSubmodules = false;
-      sha256 = "sha256-T7LydwjxHx4CzF2mgVyIhFVUjTYGWVafdhEaYRuGtv4=";
+      sha256 = "sha256-mInYAyDT49w0ux7Jgg4Ny3igyEKlRvqzG2KAG9YVmsg=";
     };
-    date = "2026-02-08";
+    date = "2026-03-11";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -436,11 +436,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772845525,
-        "narHash": "sha256-Dp5Ir2u4jJDGCgeMRviHvEQDe+U37hMxp6RSNOoMMPc=",
+        "lastModified": 1773422513,
+        "narHash": "sha256-MPjR48roW7CUMU6lu0+qQGqj92Kuh3paIulMWFZy+NQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "27b93804fbef1544cb07718d3f0a451f4c4cd6c0",
+        "rev": "ef12a9a2b0f77c8fa3dda1e7e494fca668909056",
         "type": "github"
       },
       "original": {
@@ -537,11 +537,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1772341813,
-        "narHash": "sha256-/PQ0ubBCMj/MVCWEI/XMStn55a8dIKsvztj4ZVLvUrQ=",
+        "lastModified": 1772945408,
+        "narHash": "sha256-PMt48sEQ8cgCeljQ9I/32uoBq/8t8y+7W/nAZhf72TQ=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "a2051ff239ce2e8a0148fa7a152903d9a78e854f",
+        "rev": "1c1d8ea87b047788fd7567adf531418c5da321ec",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1772850987,
-        "narHash": "sha256-lx0Y2ZihQMNg5uRV2k3w6RGf3V/ldvvvFuPGzjxwMbM=",
+        "lastModified": 1773456229,
+        "narHash": "sha256-j4ekdDLttuC89x/w5+NmVQZcB7vpnTZvy/C7LImlLmo=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "e7869163915d6e9eae93640341178d55ea6b9cdb",
+        "rev": "8f236bbe6f32e9018f0b92fe99b9be404d8dd155",
         "type": "github"
       },
       "original": {
@@ -657,11 +657,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1772198003,
-        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
+        "lastModified": 1772773019,
+        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1772773019,
-        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "lastModified": 1773389992,
+        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
         "type": "github"
       },
       "original": {
@@ -705,11 +705,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1772773019,
-        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "lastModified": 1773389992,
+        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
         "type": "github"
       },
       "original": {
@@ -741,11 +741,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1772901786,
-        "narHash": "sha256-g72gv7PCDPS9/vwNmCISz7cSegsbrwcvG6CwpSLe/Dc=",
+        "lastModified": 1773506961,
+        "narHash": "sha256-Z2RKS0Wva27dPwm7LmexP8x9OPLjO2sZ0w3Fn+Csxd8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bb2075cf1ccdcd94f4027bac4040837af35bf7cb",
+        "rev": "aa4bf823a56df05ebaa670d7f559e03fe80abcd2",
         "type": "github"
       },
       "original": {
@@ -901,11 +901,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1772494187,
-        "narHash": "sha256-6ksgNAFXVK+Cg/6ww7bB2nJUPZlnS75UwZC7G+L03EE=",
+        "lastModified": 1773161309,
+        "narHash": "sha256-k2Un0blYBeoN8mB5HO4rqCKISb427IWy0fzCdCUIcio=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "915ab06b046d05613041780c575c62a32fe67cea",
+        "rev": "61df7293cf732c7b66cce7f8b46f7017e721a6cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 11

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/27b93804fbef1544cb07718d3f0a451f4c4cd6c0' (2026-03-07)
  → 'github:nix-community/home-manager/ef12a9a2b0f77c8fa3dda1e7e494fca668909056' (2026-03-13)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/a2051ff239ce2e8a0148fa7a152903d9a78e854f' (2026-03-01)
  → 'github:nix-community/nix-index-database/1c1d8ea87b047788fd7567adf531418c5da321ec' (2026-03-08)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/dd9b079222d43e1943b6ebd802f04fd959dc8e61' (2026-02-27)
  → 'github:NixOS/nixpkgs/aca4d95fce4914b3892661bcb80b8087293536c6' (2026-03-06)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/e7869163915d6e9eae93640341178d55ea6b9cdb' (2026-03-07)
  → 'github:nix-community/nix4vscode/8f236bbe6f32e9018f0b92fe99b9be404d8dd155' (2026-03-14)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/aca4d95fce4914b3892661bcb80b8087293536c6' (2026-03-06)
  → 'github:NixOS/nixpkgs/c06b4ae3d6599a672a6210b7021d699c351eebda' (2026-03-13)
• Updated input 'nur':
    'github:nix-community/NUR/bb2075cf1ccdcd94f4027bac4040837af35bf7cb' (2026-03-07)
  → 'github:nix-community/NUR/aa4bf823a56df05ebaa670d7f559e03fe80abcd2' (2026-03-14)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/aca4d95fce4914b3892661bcb80b8087293536c6' (2026-03-06)
  → 'github:nixos/nixpkgs/c06b4ae3d6599a672a6210b7021d699c351eebda' (2026-03-13)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/915ab06b046d05613041780c575c62a32fe67cea' (2026-03-02)
  → 'github:Gerg-L/spicetify-nix/61df7293cf732c7b66cce7f8b46f7017e721a6cd' (2026-03-10)
```

Sources Changelog:
```
nix-fast-build: 8ac62f38ac3b21eec112b4e6d8bd98fa84b465e0 → f5ca03a4387aecd739d60c77ae26e567481c3013
```
