### PR TITLE
chore: update flake.lock & sources (2026-03-21)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-03-11",
+        "date": "2026-03-18",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "f5ca03a4387aecd739d60c77ae26e567481c3013",
-            "sha256": "sha256-mInYAyDT49w0ux7Jgg4Ny3igyEKlRvqzG2KAG9YVmsg=",
+            "rev": "9c5bad875bba54351daa48a4119bfb9ba04e3e03",
+            "sha256": "sha256-sH/KWX8NO8iurnnkI7w8eWMkbnRBbvEIK9IW4LnR0qQ=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "f5ca03a4387aecd739d60c77ae26e567481c3013"
+        "version": "9c5bad875bba54351daa48a4119bfb9ba04e3e03"
     },
     "obs_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "f5ca03a4387aecd739d60c77ae26e567481c3013";
+    version = "9c5bad875bba54351daa48a4119bfb9ba04e3e03";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "f5ca03a4387aecd739d60c77ae26e567481c3013";
+      rev = "9c5bad875bba54351daa48a4119bfb9ba04e3e03";
       fetchSubmodules = false;
-      sha256 = "sha256-mInYAyDT49w0ux7Jgg4Ny3igyEKlRvqzG2KAG9YVmsg=";
+      sha256 = "sha256-sH/KWX8NO8iurnnkI7w8eWMkbnRBbvEIK9IW4LnR0qQ=";
     };
-    date = "2026-03-11";
+    date = "2026-03-18";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -354,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772893680,
-        "narHash": "sha256-JDqZMgxUTCq85ObSaFw0HhE+lvdOre1lx9iI6vYyOEs=",
+        "lastModified": 1774104215,
+        "narHash": "sha256-EAtviqz0sEAxdHS4crqu7JGR5oI3BwaqG0mw7CmXkO8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "8baab586afc9c9b57645a734c820e4ac0a604af9",
+        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
         "type": "github"
       },
       "original": {
@@ -436,11 +436,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773422513,
-        "narHash": "sha256-MPjR48roW7CUMU6lu0+qQGqj92Kuh3paIulMWFZy+NQ=",
+        "lastModified": 1774007980,
+        "narHash": "sha256-FOnZjElEI8pqqCvB6K/1JRHTE8o4rer8driivTpq2uo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ef12a9a2b0f77c8fa3dda1e7e494fca668909056",
+        "rev": "9670de2921812bc4e0452f6e3efd8c859696c183",
         "type": "github"
       },
       "original": {
@@ -537,11 +537,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1772945408,
-        "narHash": "sha256-PMt48sEQ8cgCeljQ9I/32uoBq/8t8y+7W/nAZhf72TQ=",
+        "lastModified": 1773552174,
+        "narHash": "sha256-mHSRNrT1rjeYBgkAlj07dW3+1nFEgAd8Gu6lgyfT9DU=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "1c1d8ea87b047788fd7567adf531418c5da321ec",
+        "rev": "8faeb68130df077450451b6734a221ba0d6cde42",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1773456229,
-        "narHash": "sha256-j4ekdDLttuC89x/w5+NmVQZcB7vpnTZvy/C7LImlLmo=",
+        "lastModified": 1774060814,
+        "narHash": "sha256-zOuRC3Nc9/hmvo/wvNA5ue4lAVYpinUst4/esF+DTKo=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "8f236bbe6f32e9018f0b92fe99b9be404d8dd155",
+        "rev": "266f0a0d6946a117b10b3fff94032029a91e3ef7",
         "type": "github"
       },
       "original": {
@@ -657,11 +657,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1772773019,
-        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "lastModified": 1773389992,
+        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1773389992,
-        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
         "type": "github"
       },
       "original": {
@@ -705,11 +705,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1773389992,
-        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
         "type": "github"
       },
       "original": {
@@ -741,11 +741,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1773506961,
-        "narHash": "sha256-Z2RKS0Wva27dPwm7LmexP8x9OPLjO2sZ0w3Fn+Csxd8=",
+        "lastModified": 1774111616,
+        "narHash": "sha256-5+r1awY77X2eJxb73nPPeVi5iiJOHeO+eJGmc1Ed4a8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa4bf823a56df05ebaa670d7f559e03fe80abcd2",
+        "rev": "b4a27c396389e2ac02413b138ba12ea9d111cb93",
         "type": "github"
       },
       "original": {
@@ -901,11 +901,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1773161309,
-        "narHash": "sha256-k2Un0blYBeoN8mB5HO4rqCKISb427IWy0fzCdCUIcio=",
+        "lastModified": 1773619901,
+        "narHash": "sha256-Br8CQy4ht+a2OxyzaRwuP5+oIFfoRvCxYgsmdrgid40=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "61df7293cf732c7b66cce7f8b46f7017e721a6cd",
+        "rev": "6f06ff05cd536b790b7662550a10b61a1ac4619e",
         "type": "github"
       },
       "original": {
@@ -933,11 +933,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1772296853,
-        "narHash": "sha256-pAtzPsgHRKw/2Kv8HgAjSJg450FDldHPWsP3AKG/Xj0=",
+        "lastModified": 1773792048,
+        "narHash": "sha256-Oy9PCLG3vtflFBWcJd8c/EB3h5RU7ABAIDWn6JrGf6o=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "c4b8e80a1020e09a1f081ad0f98ce804a6e85acf",
+        "rev": "3f2f9d307fe58c6abe2a16eb9b62c42d53ef5ee1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 12

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/8baab586afc9c9b57645a734c820e4ac0a604af9' (2026-03-07)
  → 'github:cachix/git-hooks.nix/f799ae951fde0627157f40aec28dec27b22076d0' (2026-03-21)
• Updated input 'home-manager':
    'github:nix-community/home-manager/ef12a9a2b0f77c8fa3dda1e7e494fca668909056' (2026-03-13)
  → 'github:nix-community/home-manager/9670de2921812bc4e0452f6e3efd8c859696c183' (2026-03-20)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/1c1d8ea87b047788fd7567adf531418c5da321ec' (2026-03-08)
  → 'github:nix-community/nix-index-database/8faeb68130df077450451b6734a221ba0d6cde42' (2026-03-15)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/aca4d95fce4914b3892661bcb80b8087293536c6' (2026-03-06)
  → 'github:NixOS/nixpkgs/c06b4ae3d6599a672a6210b7021d699c351eebda' (2026-03-13)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/8f236bbe6f32e9018f0b92fe99b9be404d8dd155' (2026-03-14)
  → 'github:nix-community/nix4vscode/266f0a0d6946a117b10b3fff94032029a91e3ef7' (2026-03-21)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c06b4ae3d6599a672a6210b7021d699c351eebda' (2026-03-13)
  → 'github:NixOS/nixpkgs/b40629efe5d6ec48dd1efba650c797ddbd39ace0' (2026-03-18)
• Updated input 'nur':
    'github:nix-community/NUR/aa4bf823a56df05ebaa670d7f559e03fe80abcd2' (2026-03-14)
  → 'github:nix-community/NUR/b4a27c396389e2ac02413b138ba12ea9d111cb93' (2026-03-21)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/c06b4ae3d6599a672a6210b7021d699c351eebda' (2026-03-13)
  → 'github:nixos/nixpkgs/b40629efe5d6ec48dd1efba650c797ddbd39ace0' (2026-03-18)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/61df7293cf732c7b66cce7f8b46f7017e721a6cd' (2026-03-10)
  → 'github:Gerg-L/spicetify-nix/6f06ff05cd536b790b7662550a10b61a1ac4619e' (2026-03-16)
• Updated input 'stylix':
    'github:danth/stylix/c4b8e80a1020e09a1f081ad0f98ce804a6e85acf' (2026-02-28)
  → 'github:danth/stylix/3f2f9d307fe58c6abe2a16eb9b62c42d53ef5ee1' (2026-03-18)
```

Sources Changelog:
```
nix-fast-build: f5ca03a4387aecd739d60c77ae26e567481c3013 → 9c5bad875bba54351daa48a4119bfb9ba04e3e03
```
