### PR TITLE
chore: update flake.lock & sources (2026-03-28)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-03-18",
+        "date": "2026-03-22",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "9c5bad875bba54351daa48a4119bfb9ba04e3e03",
-            "sha256": "sha256-sH/KWX8NO8iurnnkI7w8eWMkbnRBbvEIK9IW4LnR0qQ=",
+            "rev": "066bb98bf0b8f7e648a2c1dd5216d307d936e302",
+            "sha256": "sha256-7XLKuyLDsQAy5Ssf4r7EpPT7DHPwI3/TgYl7wfuNkAg=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "9c5bad875bba54351daa48a4119bfb9ba04e3e03"
+        "version": "066bb98bf0b8f7e648a2c1dd5216d307d936e302"
     },
     "obs_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "9c5bad875bba54351daa48a4119bfb9ba04e3e03";
+    version = "066bb98bf0b8f7e648a2c1dd5216d307d936e302";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "9c5bad875bba54351daa48a4119bfb9ba04e3e03";
+      rev = "066bb98bf0b8f7e648a2c1dd5216d307d936e302";
       fetchSubmodules = false;
-      sha256 = "sha256-sH/KWX8NO8iurnnkI7w8eWMkbnRBbvEIK9IW4LnR0qQ=";
+      sha256 = "sha256-7XLKuyLDsQAy5Ssf4r7EpPT7DHPwI3/TgYl7wfuNkAg=";
     };
-    date = "2026-03-18";
+    date = "2026-03-22";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -436,11 +436,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774007980,
-        "narHash": "sha256-FOnZjElEI8pqqCvB6K/1JRHTE8o4rer8driivTpq2uo=",
+        "lastModified": 1774715571,
+        "narHash": "sha256-MMjHif46sc/iLF9JqxBhFaueSPRcjPeP9AiujERH6N0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9670de2921812bc4e0452f6e3efd8c859696c183",
+        "rev": "557f5e38ce94ef0f02f05de7ae65057d4b2a89a6",
         "type": "github"
       },
       "original": {
@@ -477,11 +477,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1767767975,
-        "narHash": "sha256-yBejG3j6OLQYn87UozFAI3q9a1vH00u9xjIf2Q4V5j8=",
+        "lastModified": 1774257081,
+        "narHash": "sha256-92ZbaBfsEXEE7VaWJjv9aRSk3l9nyoYYyMe2AwTqSZI=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "0e73df1dfedf0f6fa21ed0ae5e031b0663c8f400",
+        "rev": "e919b4a8a8ab5f2a0752f68576ab3eed6993cefd",
         "type": "github"
       },
       "original": {
@@ -537,11 +537,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1773552174,
-        "narHash": "sha256-mHSRNrT1rjeYBgkAlj07dW3+1nFEgAd8Gu6lgyfT9DU=",
+        "lastModified": 1774156144,
+        "narHash": "sha256-gdYe9wTPl4ignDyXUl1LlICWj41+S0GB5lG1fKP17+A=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "8faeb68130df077450451b6734a221ba0d6cde42",
+        "rev": "55b588747fa3d7fc351a11831c4b874dab992862",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1774060814,
-        "narHash": "sha256-zOuRC3Nc9/hmvo/wvNA5ue4lAVYpinUst4/esF+DTKo=",
+        "lastModified": 1774666189,
+        "narHash": "sha256-cnPH7kFfC5Mw/av5bdpxTDpvFMyGbY6B5trC2oFXmyI=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "266f0a0d6946a117b10b3fff94032029a91e3ef7",
+        "rev": "a37604b5eff1581cc0046a58bebf352b296ff80c",
         "type": "github"
       },
       "original": {
@@ -657,11 +657,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1773389992,
-        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1773821835,
-        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
         "type": "github"
       },
       "original": {
@@ -705,11 +705,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1773821835,
-        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
         "type": "github"
       },
       "original": {
@@ -741,11 +741,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1774111616,
-        "narHash": "sha256-5+r1awY77X2eJxb73nPPeVi5iiJOHeO+eJGmc1Ed4a8=",
+        "lastModified": 1774716377,
+        "narHash": "sha256-XYPyIF1ioZJTkk71kQvpFByKVcrUgo+n7BAV5vZVItE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b4a27c396389e2ac02413b138ba12ea9d111cb93",
+        "rev": "448eec7575984998b104d4e4b77d14d7b00e785c",
         "type": "github"
       },
       "original": {
@@ -901,11 +901,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1773619901,
-        "narHash": "sha256-Br8CQy4ht+a2OxyzaRwuP5+oIFfoRvCxYgsmdrgid40=",
+        "lastModified": 1774157037,
+        "narHash": "sha256-kJpgEIF0sxMW0vx543m3AwyqptJOxPoOJY1DfJ4jQas=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "6f06ff05cd536b790b7662550a10b61a1ac4619e",
+        "rev": "2e2234c2932a3aff5f845cda33cb1972a9e889aa",
         "type": "github"
       },
       "original": {
@@ -933,11 +933,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1773792048,
-        "narHash": "sha256-Oy9PCLG3vtflFBWcJd8c/EB3h5RU7ABAIDWn6JrGf6o=",
+        "lastModified": 1774124764,
+        "narHash": "sha256-Poz9WTjiRlqZIf197CrMMJfTifZhrZpbHFv0eU1Nhtg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3f2f9d307fe58c6abe2a16eb9b62c42d53ef5ee1",
+        "rev": "e31c79f571c5595a155f84b9d77ce53a84745494",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 13

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/9670de2921812bc4e0452f6e3efd8c859696c183' (2026-03-20)
  → 'github:nix-community/home-manager/557f5e38ce94ef0f02f05de7ae65057d4b2a89a6' (2026-03-28)
• Updated input 'hyprpanel':
    'github:Jas-SinghFSU/HyprPanel/0e73df1dfedf0f6fa21ed0ae5e031b0663c8f400' (2026-01-07)
  → 'github:Jas-SinghFSU/HyprPanel/e919b4a8a8ab5f2a0752f68576ab3eed6993cefd' (2026-03-23)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/8faeb68130df077450451b6734a221ba0d6cde42' (2026-03-15)
  → 'github:nix-community/nix-index-database/55b588747fa3d7fc351a11831c4b874dab992862' (2026-03-22)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/c06b4ae3d6599a672a6210b7021d699c351eebda' (2026-03-13)
  → 'github:NixOS/nixpkgs/b40629efe5d6ec48dd1efba650c797ddbd39ace0' (2026-03-18)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/266f0a0d6946a117b10b3fff94032029a91e3ef7' (2026-03-21)
  → 'github:nix-community/nix4vscode/a37604b5eff1581cc0046a58bebf352b296ff80c' (2026-03-28)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/b40629efe5d6ec48dd1efba650c797ddbd39ace0' (2026-03-18)
  → 'github:NixOS/nixpkgs/46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9' (2026-03-24)
• Updated input 'nur':
    'github:nix-community/NUR/b4a27c396389e2ac02413b138ba12ea9d111cb93' (2026-03-21)
  → 'github:nix-community/NUR/448eec7575984998b104d4e4b77d14d7b00e785c' (2026-03-28)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/b40629efe5d6ec48dd1efba650c797ddbd39ace0' (2026-03-18)
  → 'github:nixos/nixpkgs/46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9' (2026-03-24)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/6f06ff05cd536b790b7662550a10b61a1ac4619e' (2026-03-16)
  → 'github:Gerg-L/spicetify-nix/2e2234c2932a3aff5f845cda33cb1972a9e889aa' (2026-03-22)
• Updated input 'stylix':
    'github:danth/stylix/3f2f9d307fe58c6abe2a16eb9b62c42d53ef5ee1' (2026-03-18)
  → 'github:danth/stylix/e31c79f571c5595a155f84b9d77ce53a84745494' (2026-03-21)
```

Sources Changelog:
```
nix-fast-build: 9c5bad875bba54351daa48a4119bfb9ba04e3e03 → 066bb98bf0b8f7e648a2c1dd5216d307d936e302
```
