### PR TITLE
chore: update flake.lock & sources (2026-04-04)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -76,12 +76,12 @@
             "name": null,
             "owner": "rafaelmardojai",
             "repo": "firefox-gnome-theme",
-            "rev": "v143",
-            "sha256": "sha256-0E3TqvXAy81qeM/jZXWWOTZ14Hs1RT7o78UyZM+Jbr4=",
+            "rev": "v149.1",
+            "sha256": "sha256-QFY6Eu0kmaWl8W76bXs5K2BVtTh+Md+1rGba1WiTYxU=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "v143"
+        "version": "v149.1"
     },
     "joplin_catppuccin": {
         "cargoLock": null,
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-03-22",
+        "date": "2026-03-29",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "066bb98bf0b8f7e648a2c1dd5216d307d936e302",
-            "sha256": "sha256-7XLKuyLDsQAy5Ssf4r7EpPT7DHPwI3/TgYl7wfuNkAg=",
+            "rev": "bfc06c68a9c7ac7a931487d21aa7cf0fb29a75ae",
+            "sha256": "sha256-xl/XzBrlbELlqvuWLDvjqHRc61WR5SeYBMVJInhDuSA=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "066bb98bf0b8f7e648a2c1dd5216d307d936e302"
+        "version": "bfc06c68a9c7ac7a931487d21aa7cf0fb29a75ae"
     },
     "obs_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -44,13 +44,13 @@
   };
   firefox-gnome-theme = {
     pname = "firefox-gnome-theme";
-    version = "v143";
+    version = "v149.1";
     src = fetchFromGitHub {
       owner = "rafaelmardojai";
       repo = "firefox-gnome-theme";
-      rev = "v143";
+      rev = "v149.1";
       fetchSubmodules = false;
-      sha256 = "sha256-0E3TqvXAy81qeM/jZXWWOTZ14Hs1RT7o78UyZM+Jbr4=";
+      sha256 = "sha256-QFY6Eu0kmaWl8W76bXs5K2BVtTh+Md+1rGba1WiTYxU=";
     };
   };
   joplin_catppuccin = {
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "066bb98bf0b8f7e648a2c1dd5216d307d936e302";
+    version = "bfc06c68a9c7ac7a931487d21aa7cf0fb29a75ae";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "066bb98bf0b8f7e648a2c1dd5216d307d936e302";
+      rev = "bfc06c68a9c7ac7a931487d21aa7cf0fb29a75ae";
       fetchSubmodules = false;
-      sha256 = "sha256-7XLKuyLDsQAy5Ssf4r7EpPT7DHPwI3/TgYl7wfuNkAg=";
+      sha256 = "sha256-xl/XzBrlbELlqvuWLDvjqHRc61WR5SeYBMVJInhDuSA=";
     };
-    date = "2026-03-22";
+    date = "2026-03-29";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -169,11 +169,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1764873433,
-        "narHash": "sha256-1XPewtGMi+9wN9Ispoluxunw/RwozuTRVuuQOmxzt+A=",
+        "lastModified": 1775176642,
+        "narHash": "sha256-2veEED0Fg7Fsh81tvVDNYR6SzjqQxa7hbi18Jv4LWpM=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "f7ffd917ac0d253dbd6a3bf3da06888f57c69f92",
+        "rev": "179704030c5286c729b5b0522037d1d51341022c",
         "type": "github"
       },
       "original": {
@@ -235,11 +235,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -298,11 +298,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767609335,
-        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -354,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774104215,
-        "narHash": "sha256-EAtviqz0sEAxdHS4crqu7JGR5oI3BwaqG0mw7CmXkO8=",
+        "lastModified": 1775036584,
+        "narHash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
+        "rev": "4e0eb042b67d863b1b34b3f64d52ceb9cd926735",
         "type": "github"
       },
       "original": {
@@ -413,20 +413,18 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "host": "gitlab.gnome.org",
         "lastModified": 1767737596,
         "narHash": "sha256-eFujfIUQDgWnSJBablOuG+32hCai192yRdrNHTv0a+s=",
         "owner": "GNOME",
         "repo": "gnome-shell",
         "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
-        "type": "gitlab"
+        "type": "github"
       },
       "original": {
-        "host": "gitlab.gnome.org",
         "owner": "GNOME",
-        "ref": "gnome-49",
         "repo": "gnome-shell",
-        "type": "gitlab"
+        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
+        "type": "github"
       }
     },
     "home-manager": {
@@ -436,11 +434,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774715571,
-        "narHash": "sha256-MMjHif46sc/iLF9JqxBhFaueSPRcjPeP9AiujERH6N0=",
+        "lastModified": 1775320414,
+        "narHash": "sha256-pIDPHus8udcxO4lT+zUULBfvue2D08E73abzVEJNE+8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "557f5e38ce94ef0f02f05de7ae65057d4b2a89a6",
+        "rev": "5ee3b3ef63e469c84639c2c9e282726352c86069",
         "type": "github"
       },
       "original": {
@@ -537,11 +535,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1774156144,
-        "narHash": "sha256-gdYe9wTPl4ignDyXUl1LlICWj41+S0GB5lG1fKP17+A=",
+        "lastModified": 1774762074,
+        "narHash": "sha256-89Mh4Eb/5stVJX6kGagVMijcU2FmfeD8Qv7UXc5d92o=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "55b588747fa3d7fc351a11831c4b874dab992862",
+        "rev": "bc13aeaed568be76eab84df88ff39261bb52ff70",
         "type": "github"
       },
       "original": {
@@ -558,11 +556,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1774666189,
-        "narHash": "sha256-cnPH7kFfC5Mw/av5bdpxTDpvFMyGbY6B5trC2oFXmyI=",
+        "lastModified": 1775270954,
+        "narHash": "sha256-Y/SdeQGRGW8kqVvllQ1axdMwjQ1cFPYsFRJqre2znew=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "a37604b5eff1581cc0046a58bebf352b296ff80c",
+        "rev": "2ff6aa339cff736bbe9db5bf02d4625e6316a382",
         "type": "github"
       },
       "original": {
@@ -610,11 +608,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1772328832,
-        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {
@@ -657,11 +655,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1773821835,
-        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
         "type": "github"
       },
       "original": {
@@ -689,11 +687,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
         "type": "github"
       },
       "original": {
@@ -705,11 +703,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
         "type": "github"
       },
       "original": {
@@ -721,11 +719,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1767767207,
-        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
         "type": "github"
       },
       "original": {
@@ -741,11 +739,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1774716377,
-        "narHash": "sha256-XYPyIF1ioZJTkk71kQvpFByKVcrUgo+n7BAV5vZVItE=",
+        "lastModified": 1775321535,
+        "narHash": "sha256-GC3gqbwvZSUuybzjsr+KrlmDgF0KPWvqG5pjV8UzjUE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "448eec7575984998b104d4e4b77d14d7b00e785c",
+        "rev": "77f938ed32135f6e833f9de7694dd758dd1a976f",
         "type": "github"
       },
       "original": {
@@ -766,11 +764,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767810917,
-        "narHash": "sha256-ZKqhk772+v/bujjhla9VABwcvz+hB2IaRyeLT6CFnT0=",
+        "lastModified": 1775228139,
+        "narHash": "sha256-ebbeHmg+V7w8050bwQOuhmQHoLOEOfqKzM1KgCTexK4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dead29c804adc928d3a69dfe7f9f12d0eec1f1a4",
+        "rev": "601971b9c89e0304561977f2c28fa25e73aa7132",
         "type": "github"
       },
       "original": {
@@ -789,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772361940,
-        "narHash": "sha256-B1Cz+ydL1iaOnGlwOFld/C8lBECPtzhiy/pP93/CuyY=",
+        "lastModified": 1774915545,
+        "narHash": "sha256-COT4l/+ZddGBvrDVfPf7MEOJxV8EDKame6/aRnNIKcY=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "a4b33606111c9c5dcd10009042bb710307174f51",
+        "rev": "f3177b3c69fb3f03201098d7fe8ab6422cce7fc1",
         "type": "github"
       },
       "original": {
@@ -901,11 +899,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1774157037,
-        "narHash": "sha256-kJpgEIF0sxMW0vx543m3AwyqptJOxPoOJY1DfJ4jQas=",
+        "lastModified": 1774790928,
+        "narHash": "sha256-/JO77td8AOH45kg9IJl2DXDwbhn+cyQxYbCMu4Ae1CA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "2e2234c2932a3aff5f845cda33cb1972a9e889aa",
+        "rev": "2bfdf55faf76fed12950b17d4af501e5a463607f",
         "type": "github"
       },
       "original": {
@@ -926,18 +924,17 @@
         "nixpkgs": "nixpkgs_6",
         "nur": "nur_2",
         "systems": "systems_5",
-        "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1774124764,
-        "narHash": "sha256-Poz9WTjiRlqZIf197CrMMJfTifZhrZpbHFv0eU1Nhtg=",
+        "lastModified": 1775247334,
+        "narHash": "sha256-eVKt8wpQqg6Hq/UdHQkV1izXGloGQxdlE4SSk9/X27s=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e31c79f571c5595a155f84b9d77ce53a84745494",
+        "rev": "6d0502ef7447090abf8b00362b5cda8ac64595b4",
         "type": "github"
       },
       "original": {
@@ -1037,23 +1034,6 @@
         "type": "github"
       }
     },
-    "tinted-foot": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1726913040,
-        "narHash": "sha256-+eDZPkw7efMNUf3/Pv0EmsidqdwNJ1TaOum6k7lngDQ=",
-        "owner": "tinted-theming",
-        "repo": "tinted-foot",
-        "rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "tinted-foot",
-        "rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
-        "type": "github"
-      }
-    },
     "tinted-kitty": {
       "flake": false,
       "locked": {
@@ -1073,11 +1053,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1767710407,
-        "narHash": "sha256-+W1EB79Jl0/gm4JqmO0Nuc5C7hRdp4vfsV/VdzI+des=",
+        "lastModified": 1772661346,
+        "narHash": "sha256-4eu3LqB9tPqe0Vaqxd4wkZiBbthLbpb7llcoE/p5HT0=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "2800e2b8ac90f678d7e4acebe4fa253f602e05b2",
+        "rev": "13b5b0c299982bb361039601e2d72587d6846294",
         "type": "github"
       },
       "original": {
@@ -1089,11 +1069,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1767489635,
-        "narHash": "sha256-e6nnFnWXKBCJjCv4QG4bbcouJ6y3yeT70V9MofL32lU=",
+        "lastModified": 1772934010,
+        "narHash": "sha256-x+6+4UvaG+RBRQ6UaX+o6DjEg28u4eqhVRM9kpgJGjQ=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "3c32729ccae99be44fe8a125d20be06f8d7d8184",
+        "rev": "c3529673a5ab6e1b6830f618c45d9ce1bcdd829d",
         "type": "github"
       },
       "original": {
@@ -1105,11 +1085,11 @@
     "tinted-zed": {
       "flake": false,
       "locked": {
-        "lastModified": 1767488740,
-        "narHash": "sha256-wVOj0qyil8m+ouSsVZcNjl5ZR+1GdOOAooAatQXHbuU=",
+        "lastModified": 1772909925,
+        "narHash": "sha256-jx/5+pgYR0noHa3hk2esin18VMbnPSvWPL5bBjfTIAU=",
         "owner": "tinted-theming",
         "repo": "base16-zed",
-        "rev": "11abb0b282ad3786a2aae088d3a01c60916f2e40",
+        "rev": "b4d3a1b3bcbd090937ef609a0a3b37237af974df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 14

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/f20dc5d9b8027381c474144ecabc9034d6a839a3' (2026-03-01)
  → 'github:hercules-ci/flake-parts/3107b77cd68437b9a76194f0f7f9c55f2329ca5b' (2026-04-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/c185c7a5e5dd8f9add5b2f8ebeff00888b070742' (2026-03-01)
  → 'github:nix-community/nixpkgs.lib/333c4e0545a6da976206c74db8773a1645b5870a' (2026-03-29)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/f799ae951fde0627157f40aec28dec27b22076d0' (2026-03-21)
  → 'github:cachix/git-hooks.nix/4e0eb042b67d863b1b34b3f64d52ceb9cd926735' (2026-04-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/557f5e38ce94ef0f02f05de7ae65057d4b2a89a6' (2026-03-28)
  → 'github:nix-community/home-manager/5ee3b3ef63e469c84639c2c9e282726352c86069' (2026-04-04)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/55b588747fa3d7fc351a11831c4b874dab992862' (2026-03-22)
  → 'github:nix-community/nix-index-database/bc13aeaed568be76eab84df88ff39261bb52ff70' (2026-03-29)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/b40629efe5d6ec48dd1efba650c797ddbd39ace0' (2026-03-18)
  → 'github:NixOS/nixpkgs/46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9' (2026-03-24)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/a37604b5eff1581cc0046a58bebf352b296ff80c' (2026-03-28)
  → 'github:nix-community/nix4vscode/2ff6aa339cff736bbe9db5bf02d4625e6316a382' (2026-04-04)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9' (2026-03-24)
  → 'github:NixOS/nixpkgs/6201e203d09599479a3b3450ed24fa81537ebc4e' (2026-04-01)
• Updated input 'nur':
    'github:nix-community/NUR/448eec7575984998b104d4e4b77d14d7b00e785c' (2026-03-28)
  → 'github:nix-community/NUR/77f938ed32135f6e833f9de7694dd758dd1a976f' (2026-04-04)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9' (2026-03-24)
  → 'github:nixos/nixpkgs/6201e203d09599479a3b3450ed24fa81537ebc4e' (2026-04-01)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/a4b33606111c9c5dcd10009042bb710307174f51' (2026-03-01)
  → 'github:nix-community/plasma-manager/f3177b3c69fb3f03201098d7fe8ab6422cce7fc1' (2026-03-31)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/2e2234c2932a3aff5f845cda33cb1972a9e889aa' (2026-03-22)
  → 'github:Gerg-L/spicetify-nix/2bfdf55faf76fed12950b17d4af501e5a463607f' (2026-03-29)
• Updated input 'stylix':
    'github:danth/stylix/e31c79f571c5595a155f84b9d77ce53a84745494' (2026-03-21)
  → 'github:danth/stylix/6d0502ef7447090abf8b00362b5cda8ac64595b4' (2026-04-03)
• Updated input 'stylix/firefox-gnome-theme':
    'github:rafaelmardojai/firefox-gnome-theme/f7ffd917ac0d253dbd6a3bf3da06888f57c69f92' (2025-12-04)
  → 'github:rafaelmardojai/firefox-gnome-theme/179704030c5286c729b5b0522037d1d51341022c' (2026-04-03)
• Updated input 'stylix/flake-parts':
    'github:hercules-ci/flake-parts/250481aafeb741edfe23d29195671c19b36b6dca' (2026-01-05)
  → 'github:hercules-ci/flake-parts/3107b77cd68437b9a76194f0f7f9c55f2329ca5b' (2026-04-01)
• Updated input 'stylix/gnome-shell':
    'gitlab:GNOME/gnome-shell/ef02db02bf0ff342734d525b5767814770d85b49' (2026-01-06)
  → 'github:GNOME/gnome-shell/ef02db02bf0ff342734d525b5767814770d85b49' (2026-01-06)
• Updated input 'stylix/nixpkgs':
    'github:NixOS/nixpkgs/5912c1772a44e31bf1c63c0390b90501e5026886' (2026-01-07)
  → 'github:NixOS/nixpkgs/6201e203d09599479a3b3450ed24fa81537ebc4e' (2026-04-01)
• Updated input 'stylix/nur':
    'github:nix-community/NUR/dead29c804adc928d3a69dfe7f9f12d0eec1f1a4' (2026-01-07)
  → 'github:nix-community/NUR/601971b9c89e0304561977f2c28fa25e73aa7132' (2026-04-03)
• Updated input 'stylix/tinted-schemes':
    'github:tinted-theming/schemes/2800e2b8ac90f678d7e4acebe4fa253f602e05b2' (2026-01-06)
  → 'github:tinted-theming/schemes/13b5b0c299982bb361039601e2d72587d6846294' (2026-03-04)
• Updated input 'stylix/tinted-tmux':
    'github:tinted-theming/tinted-tmux/3c32729ccae99be44fe8a125d20be06f8d7d8184' (2026-01-04)
  → 'github:tinted-theming/tinted-tmux/c3529673a5ab6e1b6830f618c45d9ce1bcdd829d' (2026-03-08)
• Updated input 'stylix/tinted-zed':
    'github:tinted-theming/base16-zed/11abb0b282ad3786a2aae088d3a01c60916f2e40' (2026-01-04)
  → 'github:tinted-theming/base16-zed/b4d3a1b3bcbd090937ef609a0a3b37237af974df' (2026-03-07)
```

Sources Changelog:
```
nix-fast-build: 066bb98bf0b8f7e648a2c1dd5216d307d936e302 → bfc06c68a9c7ac7a931487d21aa7cf0fb29a75ae
firefox-gnome-theme: v143 → v149.1
```
