### PR TITLE
chore: update flake.lock & sources (2026-04-11)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-03-29",
+        "date": "2026-04-09",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,16 +118,16 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "bfc06c68a9c7ac7a931487d21aa7cf0fb29a75ae",
-            "sha256": "sha256-xl/XzBrlbELlqvuWLDvjqHRc61WR5SeYBMVJInhDuSA=",
+            "rev": "1030b0cfaca52f95769d0998ea366946144cd47c",
+            "sha256": "sha256-IJSKVJ0+MXMMLiViVlfEDpfA339fNHYdMoLa69HhlXg=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "bfc06c68a9c7ac7a931487d21aa7cf0fb29a75ae"
+        "version": "1030b0cfaca52f95769d0998ea366946144cd47c"
     },
     "obs_catppuccin": {
         "cargoLock": null,
-        "date": "2026-03-01",
+        "date": "2026-04-05",
         "extract": null,
         "name": "obs_catppuccin",
         "passthru": null,
@@ -139,12 +139,12 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "obs",
-            "rev": "c5357ce7b0fb8c73aab0a80739832474087b1af6",
-            "sha256": "sha256-Uk4a0HKaeyQilgBiPsuAWQubk1yZdyirNcfhYJEL+lQ=",
+            "rev": "94d317949c0f4c3e55b8ccc7f16890ce7ba3fc37",
+            "sha256": "sha256-Eb9P4ZWRHy0KjysWgL4F6jOq21yCl8E/hT+eZhTO/pA=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "c5357ce7b0fb8c73aab0a80739832474087b1af6"
+        "version": "94d317949c0f4c3e55b8ccc7f16890ce7ba3fc37"
     },
     "prismlauncher_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,27 +67,27 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "bfc06c68a9c7ac7a931487d21aa7cf0fb29a75ae";
+    version = "1030b0cfaca52f95769d0998ea366946144cd47c";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "bfc06c68a9c7ac7a931487d21aa7cf0fb29a75ae";
+      rev = "1030b0cfaca52f95769d0998ea366946144cd47c";
       fetchSubmodules = false;
-      sha256 = "sha256-xl/XzBrlbELlqvuWLDvjqHRc61WR5SeYBMVJInhDuSA=";
+      sha256 = "sha256-IJSKVJ0+MXMMLiViVlfEDpfA339fNHYdMoLa69HhlXg=";
     };
-    date = "2026-03-29";
+    date = "2026-04-09";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";
-    version = "c5357ce7b0fb8c73aab0a80739832474087b1af6";
+    version = "94d317949c0f4c3e55b8ccc7f16890ce7ba3fc37";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "obs";
-      rev = "c5357ce7b0fb8c73aab0a80739832474087b1af6";
+      rev = "94d317949c0f4c3e55b8ccc7f16890ce7ba3fc37";
       fetchSubmodules = false;
-      sha256 = "sha256-Uk4a0HKaeyQilgBiPsuAWQubk1yZdyirNcfhYJEL+lQ=";
+      sha256 = "sha256-Eb9P4ZWRHy0KjysWgL4F6jOq21yCl8E/hT+eZhTO/pA=";
     };
-    date = "2026-03-01";
+    date = "2026-04-05";
   };
   prismlauncher_catppuccin = {
     pname = "prismlauncher_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -354,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775036584,
-        "narHash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU=",
+        "lastModified": 1775585728,
+        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4e0eb042b67d863b1b34b3f64d52ceb9cd926735",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
         "type": "github"
       },
       "original": {
@@ -434,11 +434,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775320414,
-        "narHash": "sha256-pIDPHus8udcxO4lT+zUULBfvue2D08E73abzVEJNE+8=",
+        "lastModified": 1775900011,
+        "narHash": "sha256-QUGu6CJYFQ5AWVV0n3/FsJyV+1/gj7HSDx68/SX9pwM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5ee3b3ef63e469c84639c2c9e282726352c86069",
+        "rev": "b0569dc6ec1e6e7fefd8f6897184e4c191cd768e",
         "type": "github"
       },
       "original": {
@@ -535,11 +535,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1774762074,
-        "narHash": "sha256-89Mh4Eb/5stVJX6kGagVMijcU2FmfeD8Qv7UXc5d92o=",
+        "lastModified": 1775365369,
+        "narHash": "sha256-DgH5mveLoau20CuTnaU5RXZWgFQWn56onQ4Du2CqYoI=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "bc13aeaed568be76eab84df88ff39261bb52ff70",
+        "rev": "cef5cf82671e749ac87d69aadecbb75967e6f6c3",
         "type": "github"
       },
       "original": {
@@ -556,11 +556,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1775270954,
-        "narHash": "sha256-Y/SdeQGRGW8kqVvllQ1axdMwjQ1cFPYsFRJqre2znew=",
+        "lastModified": 1775876161,
+        "narHash": "sha256-RiLmcXpK9ytPuWsozx2mox7ElEYsEpG3E62tCxMZVpQ=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "2ff6aa339cff736bbe9db5bf02d4625e6316a382",
+        "rev": "98c5bbb8b5cd5f3fe1ce1de3dabf744dfa100c49",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
         "type": "github"
       },
       "original": {
@@ -687,11 +687,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {
@@ -703,11 +703,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {
@@ -739,11 +739,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1775321535,
-        "narHash": "sha256-GC3gqbwvZSUuybzjsr+KrlmDgF0KPWvqG5pjV8UzjUE=",
+        "lastModified": 1775926478,
+        "narHash": "sha256-+X/8LTj68Q5mSeC1mMx0fffgFBtQdktMimQlFeUdsd8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77f938ed32135f6e833f9de7694dd758dd1a976f",
+        "rev": "6046e21406c4a6cac05b22c077e0f4ed5f2d7b8e",
         "type": "github"
       },
       "original": {
@@ -787,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774915545,
-        "narHash": "sha256-COT4l/+ZddGBvrDVfPf7MEOJxV8EDKame6/aRnNIKcY=",
+        "lastModified": 1775856943,
+        "narHash": "sha256-b7Mp7P+q2Md5AGt4rjHfMcBykzMumFTen10ST++AuTU=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "f3177b3c69fb3f03201098d7fe8ab6422cce7fc1",
+        "rev": "a524a6160e6df89f7673ba293cf7d78b559eb1a5",
         "type": "github"
       },
       "original": {
@@ -899,11 +899,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1774790928,
-        "narHash": "sha256-/JO77td8AOH45kg9IJl2DXDwbhn+cyQxYbCMu4Ae1CA=",
+        "lastModified": 1775421933,
+        "narHash": "sha256-JkEbzFDFTsUlVtHEzA8Y4r3O9LInhb96eOCbtGjGnbM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "2bfdf55faf76fed12950b17d4af501e5a463607f",
+        "rev": "ec8d73085fdf807d55765335dc8126e14e7b2096",
         "type": "github"
       },
       "original": {
@@ -930,11 +930,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1775247334,
-        "narHash": "sha256-eVKt8wpQqg6Hq/UdHQkV1izXGloGQxdlE4SSk9/X27s=",
+        "lastModified": 1775429060,
+        "narHash": "sha256-wbFF5cRxQOCzL/wHOKYm21t5AHPH2Lfp0mVPCOAvEoc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "6d0502ef7447090abf8b00362b5cda8ac64595b4",
+        "rev": "d27951a6539951d87f75cf0a7cda8a3a24016019",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 15

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/4e0eb042b67d863b1b34b3f64d52ceb9cd926735' (2026-04-01)
  → 'github:cachix/git-hooks.nix/580633fa3fe5fc0379905986543fd7495481913d' (2026-04-07)
• Updated input 'home-manager':
    'github:nix-community/home-manager/5ee3b3ef63e469c84639c2c9e282726352c86069' (2026-04-04)
  → 'github:nix-community/home-manager/b0569dc6ec1e6e7fefd8f6897184e4c191cd768e' (2026-04-11)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/bc13aeaed568be76eab84df88ff39261bb52ff70' (2026-03-29)
  → 'github:nix-community/nix-index-database/cef5cf82671e749ac87d69aadecbb75967e6f6c3' (2026-04-05)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9' (2026-03-24)
  → 'github:NixOS/nixpkgs/6201e203d09599479a3b3450ed24fa81537ebc4e' (2026-04-01)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/2ff6aa339cff736bbe9db5bf02d4625e6316a382' (2026-04-04)
  → 'github:nix-community/nix4vscode/98c5bbb8b5cd5f3fe1ce1de3dabf744dfa100c49' (2026-04-11)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/6201e203d09599479a3b3450ed24fa81537ebc4e' (2026-04-01)
  → 'github:NixOS/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa' (2026-04-09)
• Updated input 'nur':
    'github:nix-community/NUR/77f938ed32135f6e833f9de7694dd758dd1a976f' (2026-04-04)
  → 'github:nix-community/NUR/6046e21406c4a6cac05b22c077e0f4ed5f2d7b8e' (2026-04-11)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/6201e203d09599479a3b3450ed24fa81537ebc4e' (2026-04-01)
  → 'github:nixos/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa' (2026-04-09)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/f3177b3c69fb3f03201098d7fe8ab6422cce7fc1' (2026-03-31)
  → 'github:nix-community/plasma-manager/a524a6160e6df89f7673ba293cf7d78b559eb1a5' (2026-04-10)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/2bfdf55faf76fed12950b17d4af501e5a463607f' (2026-03-29)
  → 'github:Gerg-L/spicetify-nix/ec8d73085fdf807d55765335dc8126e14e7b2096' (2026-04-05)
• Updated input 'stylix':
    'github:danth/stylix/6d0502ef7447090abf8b00362b5cda8ac64595b4' (2026-04-03)
  → 'github:danth/stylix/d27951a6539951d87f75cf0a7cda8a3a24016019' (2026-04-05)
```

Sources Changelog:
```
obs_catppuccin: c5357ce7b0fb8c73aab0a80739832474087b1af6 → 94d317949c0f4c3e55b8ccc7f16890ce7ba3fc37
nix-fast-build: bfc06c68a9c7ac7a931487d21aa7cf0fb29a75ae → 1030b0cfaca52f95769d0998ea366946144cd47c
```
