### PR TITLE
chore: update flake.lock & sources (2026-04-18)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-04-09",
+        "date": "2026-04-12",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "1030b0cfaca52f95769d0998ea366946144cd47c",
-            "sha256": "sha256-IJSKVJ0+MXMMLiViVlfEDpfA339fNHYdMoLa69HhlXg=",
+            "rev": "67df5acda0e22b97e17d5eed579b969ddb9ea06c",
+            "sha256": "sha256-fVTG9Uw7wfKmjYSu0CuB+kdvs9p4MrPimjtUtgWOPJE=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "1030b0cfaca52f95769d0998ea366946144cd47c"
+        "version": "67df5acda0e22b97e17d5eed579b969ddb9ea06c"
     },
     "obs_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "1030b0cfaca52f95769d0998ea366946144cd47c";
+    version = "67df5acda0e22b97e17d5eed579b969ddb9ea06c";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "1030b0cfaca52f95769d0998ea366946144cd47c";
+      rev = "67df5acda0e22b97e17d5eed579b969ddb9ea06c";
       fetchSubmodules = false;
-      sha256 = "sha256-IJSKVJ0+MXMMLiViVlfEDpfA339fNHYdMoLa69HhlXg=";
+      sha256 = "sha256-fVTG9Uw7wfKmjYSu0CuB+kdvs9p4MrPimjtUtgWOPJE=";
     };
-    date = "2026-04-09";
+    date = "2026-04-12";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -1,1135 +1,1135 @@
 {
-	"nodes": {
-		"agenix": {
-			"inputs": {
-				"darwin": "darwin",
-				"home-manager": [
-					"home-manager"
-				],
-				"nixpkgs": [
-					"nixpkgs"
-				],
-				"systems": "systems"
-			},
-			"locked": {
-				"lastModified": 1770165109,
-				"narHash": "sha256-9VnK6Oqai65puVJ4WYtCTvlJeXxMzAp/69HhQuTdl/I=",
-				"owner": "ryantm",
-				"repo": "agenix",
-				"rev": "b027ee29d959fda4b60b57566d64c98a202e0feb",
-				"type": "github"
-			},
-			"original": {
-				"owner": "ryantm",
-				"repo": "agenix",
-				"type": "github"
-			}
-		},
-		"base16": {
-			"inputs": {
-				"fromYaml": "fromYaml"
-			},
-			"locked": {
-				"lastModified": 1755819240,
-				"narHash": "sha256-qcMhnL7aGAuFuutH4rq9fvAhCpJWVHLcHVZLtPctPlo=",
-				"owner": "SenchoPens",
-				"repo": "base16.nix",
-				"rev": "75ed5e5e3fce37df22e49125181fa37899c3ccd6",
-				"type": "github"
-			},
-			"original": {
-				"owner": "SenchoPens",
-				"repo": "base16.nix",
-				"type": "github"
-			}
-		},
-		"base16-fish": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1765809053,
-				"narHash": "sha256-XCUQLoLfBJ8saWms2HCIj4NEN+xNsWBlU1NrEPcQG4s=",
-				"owner": "tomyun",
-				"repo": "base16-fish",
-				"rev": "86cbea4dca62e08fb7fd83a70e96472f92574782",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tomyun",
-				"repo": "base16-fish",
-				"rev": "86cbea4dca62e08fb7fd83a70e96472f92574782",
-				"type": "github"
-			}
-		},
-		"base16-helix": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1760703920,
-				"narHash": "sha256-m82fGUYns4uHd+ZTdoLX2vlHikzwzdu2s2rYM2bNwzw=",
-				"owner": "tinted-theming",
-				"repo": "base16-helix",
-				"rev": "d646af9b7d14bff08824538164af99d0c521b185",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tinted-theming",
-				"repo": "base16-helix",
-				"type": "github"
-			}
-		},
-		"base16-vim": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1732806396,
-				"narHash": "sha256-e0bpPySdJf0F68Ndanwm+KWHgQiZ0s7liLhvJSWDNsA=",
-				"owner": "tinted-theming",
-				"repo": "base16-vim",
-				"rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tinted-theming",
-				"repo": "base16-vim",
-				"rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
-				"type": "github"
-			}
-		},
-		"crane": {
-			"locked": {
-				"lastModified": 1765145449,
-				"narHash": "sha256-aBVHGWWRzSpfL++LubA0CwOOQ64WNLegrYHwsVuVN7A=",
-				"owner": "ipetkov",
-				"repo": "crane",
-				"rev": "69f538cdce5955fcd47abfed4395dc6d5194c1c5",
-				"type": "github"
-			},
-			"original": {
-				"owner": "ipetkov",
-				"repo": "crane",
-				"type": "github"
-			}
-		},
-		"darwin": {
-			"inputs": {
-				"nixpkgs": [
-					"agenix",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1744478979,
-				"narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
-				"owner": "lnl7",
-				"repo": "nix-darwin",
-				"rev": "43975d782b418ebf4969e9ccba82466728c2851b",
-				"type": "github"
-			},
-			"original": {
-				"owner": "lnl7",
-				"ref": "master",
-				"repo": "nix-darwin",
-				"type": "github"
-			}
-		},
-		"devour-flake": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1770055559,
-				"narHash": "sha256-peb6VlxIDoqaHkGPanQ35p8SXy9t54NIJ8XJHgMSuFg=",
-				"owner": "srid",
-				"repo": "devour-flake",
-				"rev": "e65d15fd4ef46dbde90ac59be581b2a286c35d0f",
-				"type": "github"
-			},
-			"original": {
-				"owner": "srid",
-				"repo": "devour-flake",
-				"type": "github"
-			}
-		},
-		"devshell": {
-			"inputs": {
-				"nixpkgs": [
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1768818222,
-				"narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
-				"owner": "numtide",
-				"repo": "devshell",
-				"rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
-				"type": "github"
-			},
-			"original": {
-				"owner": "numtide",
-				"repo": "devshell",
-				"type": "github"
-			}
-		},
-		"firefox-gnome-theme": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1775176642,
-				"narHash": "sha256-2veEED0Fg7Fsh81tvVDNYR6SzjqQxa7hbi18Jv4LWpM=",
-				"owner": "rafaelmardojai",
-				"repo": "firefox-gnome-theme",
-				"rev": "179704030c5286c729b5b0522037d1d51341022c",
-				"type": "github"
-			},
-			"original": {
-				"owner": "rafaelmardojai",
-				"repo": "firefox-gnome-theme",
-				"type": "github"
-			}
-		},
-		"flake-compat": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1767039857,
-				"narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-				"owner": "NixOS",
-				"repo": "flake-compat",
-				"rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"repo": "flake-compat",
-				"type": "github"
-			}
-		},
-		"flake-compat_2": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1761588595,
-				"narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
-				"owner": "edolstra",
-				"repo": "flake-compat",
-				"rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
-				"type": "github"
-			},
-			"original": {
-				"owner": "edolstra",
-				"repo": "flake-compat",
-				"type": "github"
-			}
-		},
-		"flake-compat_3": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1746162366,
-				"narHash": "sha256-5SSSZ/oQkwfcAz/o/6TlejlVGqeK08wyREBQ5qFFPhM=",
-				"owner": "nix-community",
-				"repo": "flake-compat",
-				"rev": "0f158086a2ecdbb138cd0429410e44994f1b7e4b",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "flake-compat",
-				"type": "github"
-			}
-		},
-		"flake-parts": {
-			"inputs": {
-				"nixpkgs-lib": "nixpkgs-lib"
-			},
-			"locked": {
-				"lastModified": 1775087534,
-				"narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
-				"type": "github"
-			},
-			"original": {
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"type": "github"
-			}
-		},
-		"flake-parts_2": {
-			"inputs": {
-				"nixpkgs-lib": [
-					"nur",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1733312601,
-				"narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
-				"type": "github"
-			},
-			"original": {
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"type": "github"
-			}
-		},
-		"flake-parts_3": {
-			"inputs": {
-				"nixpkgs-lib": [
-					"stylix",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1775087534,
-				"narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
-				"type": "github"
-			},
-			"original": {
-				"owner": "hercules-ci",
-				"repo": "flake-parts",
-				"type": "github"
-			}
-		},
-		"flake-utils": {
-			"inputs": {
-				"systems": "systems_2"
-			},
-			"locked": {
-				"lastModified": 1731533236,
-				"narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-				"owner": "numtide",
-				"repo": "flake-utils",
-				"rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-				"type": "github"
-			},
-			"original": {
-				"owner": "numtide",
-				"repo": "flake-utils",
-				"type": "github"
-			}
-		},
-		"fromYaml": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1731966426,
-				"narHash": "sha256-lq95WydhbUTWig/JpqiB7oViTcHFP8Lv41IGtayokA8=",
-				"owner": "SenchoPens",
-				"repo": "fromYaml",
-				"rev": "106af9e2f715e2d828df706c386a685698f3223b",
-				"type": "github"
-			},
-			"original": {
-				"owner": "SenchoPens",
-				"repo": "fromYaml",
-				"type": "github"
-			}
-		},
-		"git-hooks": {
-			"inputs": {
-				"flake-compat": "flake-compat",
-				"gitignore": "gitignore",
-				"nixpkgs": [
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1775585728,
-				"narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
-				"owner": "cachix",
-				"repo": "git-hooks.nix",
-				"rev": "580633fa3fe5fc0379905986543fd7495481913d",
-				"type": "github"
-			},
-			"original": {
-				"owner": "cachix",
-				"repo": "git-hooks.nix",
-				"type": "github"
-			}
-		},
-		"gitignore": {
-			"inputs": {
-				"nixpkgs": [
-					"git-hooks",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1709087332,
-				"narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-				"owner": "hercules-ci",
-				"repo": "gitignore.nix",
-				"rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-				"type": "github"
-			},
-			"original": {
-				"owner": "hercules-ci",
-				"repo": "gitignore.nix",
-				"type": "github"
-			}
-		},
-		"gitignore_2": {
-			"inputs": {
-				"nixpkgs": [
-					"lanzaboote",
-					"pre-commit",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1709087332,
-				"narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-				"owner": "hercules-ci",
-				"repo": "gitignore.nix",
-				"rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-				"type": "github"
-			},
-			"original": {
-				"owner": "hercules-ci",
-				"repo": "gitignore.nix",
-				"type": "github"
-			}
-		},
-		"gnome-shell": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1767737596,
-				"narHash": "sha256-eFujfIUQDgWnSJBablOuG+32hCai192yRdrNHTv0a+s=",
-				"owner": "GNOME",
-				"repo": "gnome-shell",
-				"rev": "ef02db02bf0ff342734d525b5767814770d85b49",
-				"type": "github"
-			},
-			"original": {
-				"owner": "GNOME",
-				"repo": "gnome-shell",
-				"rev": "ef02db02bf0ff342734d525b5767814770d85b49",
-				"type": "github"
-			}
-		},
-		"home-manager": {
-			"inputs": {
-				"nixpkgs": [
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1775900011,
-				"narHash": "sha256-QUGu6CJYFQ5AWVV0n3/FsJyV+1/gj7HSDx68/SX9pwM=",
-				"owner": "nix-community",
-				"repo": "home-manager",
-				"rev": "b0569dc6ec1e6e7fefd8f6897184e4c191cd768e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "home-manager",
-				"type": "github"
-			}
-		},
-		"home-manager_2": {
-			"inputs": {
-				"nixpkgs": [
-					"hyprpanel",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1750798083,
-				"narHash": "sha256-DTCCcp6WCFaYXWKFRA6fiI2zlvOLCf5Vwx8+/0R8Wc4=",
-				"owner": "nix-community",
-				"repo": "home-manager",
-				"rev": "ff31a4677c1a8ae506aa7e003a3dba08cb203f82",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "home-manager",
-				"type": "github"
-			}
-		},
-		"home-manager_3": {
-			"inputs": {
-				"nixpkgs": [
-					"impermanence",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1768598210,
-				"narHash": "sha256-kkgA32s/f4jaa4UG+2f8C225Qvclxnqs76mf8zvTVPg=",
-				"owner": "nix-community",
-				"repo": "home-manager",
-				"rev": "c47b2cc64a629f8e075de52e4742de688f930dc6",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "home-manager",
-				"type": "github"
-			}
-		},
-		"hyprpanel": {
-			"inputs": {
-				"flake-utils": "flake-utils",
-				"home-manager": "home-manager_2",
-				"nixpkgs": "nixpkgs"
-			},
-			"locked": {
-				"lastModified": 1774257081,
-				"narHash": "sha256-92ZbaBfsEXEE7VaWJjv9aRSk3l9nyoYYyMe2AwTqSZI=",
-				"owner": "Jas-SinghFSU",
-				"repo": "HyprPanel",
-				"rev": "e919b4a8a8ab5f2a0752f68576ab3eed6993cefd",
-				"type": "github"
-			},
-			"original": {
-				"owner": "Jas-SinghFSU",
-				"repo": "HyprPanel",
-				"type": "github"
-			}
-		},
-		"impermanence": {
-			"inputs": {
-				"home-manager": "home-manager_3",
-				"nixpkgs": "nixpkgs_2"
-			},
-			"locked": {
-				"lastModified": 1769548169,
-				"narHash": "sha256-03+JxvzmfwRu+5JafM0DLbxgHttOQZkUtDWBmeUkN8Y=",
-				"owner": "nix-community",
-				"repo": "impermanence",
-				"rev": "7b1d382faf603b6d264f58627330f9faa5cba149",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "impermanence",
-				"type": "github"
-			}
-		},
-		"lanzaboote": {
-			"inputs": {
-				"crane": "crane",
-				"nixpkgs": [
-					"nixpkgs"
-				],
-				"pre-commit": "pre-commit",
-				"rust-overlay": "rust-overlay"
-			},
-			"locked": {
-				"lastModified": 1765382359,
-				"narHash": "sha256-RJmgVDzjRI18BWVogG6wpsl1UCuV6ui8qr4DJ1LfWZ8=",
-				"owner": "nix-community",
-				"repo": "lanzaboote",
-				"rev": "e8c096ade12ec9130ff931b0f0e25d2f1bc63607",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"ref": "v1.0.0",
-				"repo": "lanzaboote",
-				"type": "github"
-			}
-		},
-		"nix-flatpak": {
-			"locked": {
-				"lastModified": 1767983141,
-				"narHash": "sha256-7ZCulYUD9RmJIDULTRkGLSW1faMpDlPKcbWJLYHoXcs=",
-				"owner": "gmodena",
-				"repo": "nix-flatpak",
-				"rev": "440818969ac2cbd77bfe025e884d0aa528991374",
-				"type": "github"
-			},
-			"original": {
-				"owner": "gmodena",
-				"ref": "latest",
-				"repo": "nix-flatpak",
-				"type": "github"
-			}
-		},
-		"nix-index-database": {
-			"inputs": {
-				"nixpkgs": "nixpkgs_3"
-			},
-			"locked": {
-				"lastModified": 1775365369,
-				"narHash": "sha256-DgH5mveLoau20CuTnaU5RXZWgFQWn56onQ4Du2CqYoI=",
-				"owner": "nix-community",
-				"repo": "nix-index-database",
-				"rev": "cef5cf82671e749ac87d69aadecbb75967e6f6c3",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "nix-index-database",
-				"type": "github"
-			}
-		},
-		"nix4vscode": {
-			"inputs": {
-				"nixpkgs": [
-					"nixpkgs"
-				],
-				"systems": "systems_3"
-			},
-			"locked": {
-				"lastModified": 1775876161,
-				"narHash": "sha256-RiLmcXpK9ytPuWsozx2mox7ElEYsEpG3E62tCxMZVpQ=",
-				"owner": "nix-community",
-				"repo": "nix4vscode",
-				"rev": "98c5bbb8b5cd5f3fe1ce1de3dabf744dfa100c49",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "nix4vscode",
-				"type": "github"
-			}
-		},
-		"nixos-cosmic": {
-			"inputs": {
-				"flake-compat": "flake-compat_3",
-				"nixpkgs": "nixpkgs_4",
-				"nixpkgs-stable": "nixpkgs-stable",
-				"rust-overlay": "rust-overlay_2"
-			},
-			"locked": {
-				"lastModified": 1751591814,
-				"narHash": "sha256-A4lgvuj4v+Pr8MniXz1FBG0DXOygi8tTECR+j53FMhM=",
-				"owner": "lilyinstarlight",
-				"repo": "nixos-cosmic",
-				"rev": "fef2d0c78c4e4d6c600a88795af193131ff51bdc",
-				"type": "github"
-			},
-			"original": {
-				"owner": "lilyinstarlight",
-				"repo": "nixos-cosmic",
-				"type": "github"
-			}
-		},
-		"nixpkgs": {
-			"locked": {
-				"lastModified": 1750776420,
-				"narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
-				"owner": "nixos",
-				"repo": "nixpkgs",
-				"rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nixos",
-				"ref": "nixos-unstable",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs-lib": {
-			"locked": {
-				"lastModified": 1774748309,
-				"narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
-				"owner": "nix-community",
-				"repo": "nixpkgs.lib",
-				"rev": "333c4e0545a6da976206c74db8773a1645b5870a",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "nixpkgs.lib",
-				"type": "github"
-			}
-		},
-		"nixpkgs-stable": {
-			"locked": {
-				"lastModified": 1751048012,
-				"narHash": "sha256-MYbotu4UjWpTsq01wglhN5xDRfZYLFtNk7SBY0BcjkU=",
-				"owner": "NixOS",
-				"repo": "nixpkgs",
-				"rev": "a684c58d46ebbede49f280b653b9e56100aa3877",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"ref": "nixos-24.11",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs-stable_2": {
-			"locked": {
-				"lastModified": 1751274312,
-				"narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
-				"owner": "NixOS",
-				"repo": "nixpkgs",
-				"rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"ref": "nixos-24.11",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs_2": {
-			"locked": {
-				"lastModified": 1768564909,
-				"narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
-				"owner": "nixos",
-				"repo": "nixpkgs",
-				"rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nixos",
-				"ref": "nixos-unstable",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs_3": {
-			"locked": {
-				"lastModified": 1774386573,
-				"narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
-				"owner": "NixOS",
-				"repo": "nixpkgs",
-				"rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"ref": "nixos-unstable",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs_4": {
-			"locked": {
-				"lastModified": 1751011381,
-				"narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
-				"owner": "NixOS",
-				"repo": "nixpkgs",
-				"rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"ref": "nixos-unstable",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs_5": {
-			"locked": {
-				"lastModified": 1775710090,
-				"narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
-				"owner": "NixOS",
-				"repo": "nixpkgs",
-				"rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"ref": "nixos-unstable",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs_6": {
-			"locked": {
-				"lastModified": 1775710090,
-				"narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
-				"owner": "nixos",
-				"repo": "nixpkgs",
-				"rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nixos",
-				"ref": "nixos-unstable",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nixpkgs_7": {
-			"locked": {
-				"lastModified": 1775036866,
-				"narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
-				"owner": "NixOS",
-				"repo": "nixpkgs",
-				"rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "NixOS",
-				"ref": "nixos-unstable",
-				"repo": "nixpkgs",
-				"type": "github"
-			}
-		},
-		"nur": {
-			"inputs": {
-				"flake-parts": "flake-parts_2",
-				"nixpkgs": "nixpkgs_6"
-			},
-			"locked": {
-				"lastModified": 1775926478,
-				"narHash": "sha256-+X/8LTj68Q5mSeC1mMx0fffgFBtQdktMimQlFeUdsd8=",
-				"owner": "nix-community",
-				"repo": "NUR",
-				"rev": "6046e21406c4a6cac05b22c077e0f4ed5f2d7b8e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "NUR",
-				"type": "github"
-			}
-		},
-		"nur_2": {
-			"inputs": {
-				"flake-parts": [
-					"stylix",
-					"flake-parts"
-				],
-				"nixpkgs": [
-					"stylix",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1775228139,
-				"narHash": "sha256-ebbeHmg+V7w8050bwQOuhmQHoLOEOfqKzM1KgCTexK4=",
-				"owner": "nix-community",
-				"repo": "NUR",
-				"rev": "601971b9c89e0304561977f2c28fa25e73aa7132",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "NUR",
-				"type": "github"
-			}
-		},
-		"plasma-manager": {
-			"inputs": {
-				"home-manager": [
-					"home-manager"
-				],
-				"nixpkgs": [
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1775856943,
-				"narHash": "sha256-b7Mp7P+q2Md5AGt4rjHfMcBykzMumFTen10ST++AuTU=",
-				"owner": "nix-community",
-				"repo": "plasma-manager",
-				"rev": "a524a6160e6df89f7673ba293cf7d78b559eb1a5",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-community",
-				"repo": "plasma-manager",
-				"type": "github"
-			}
-		},
-		"pre-commit": {
-			"inputs": {
-				"flake-compat": "flake-compat_2",
-				"gitignore": "gitignore_2",
-				"nixpkgs": [
-					"lanzaboote",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1765016596,
-				"narHash": "sha256-rhSqPNxDVow7OQKi4qS5H8Au0P4S3AYbawBSmJNUtBQ=",
-				"owner": "cachix",
-				"repo": "pre-commit-hooks.nix",
-				"rev": "548fc44fca28a5e81c5d6b846e555e6b9c2a5a3c",
-				"type": "github"
-			},
-			"original": {
-				"owner": "cachix",
-				"repo": "pre-commit-hooks.nix",
-				"type": "github"
-			}
-		},
-		"root": {
-			"inputs": {
-				"agenix": "agenix",
-				"devour-flake": "devour-flake",
-				"devshell": "devshell",
-				"flake-parts": "flake-parts",
-				"git-hooks": "git-hooks",
-				"home-manager": "home-manager",
-				"hyprpanel": "hyprpanel",
-				"impermanence": "impermanence",
-				"lanzaboote": "lanzaboote",
-				"nix-flatpak": "nix-flatpak",
-				"nix-index-database": "nix-index-database",
-				"nix4vscode": "nix4vscode",
-				"nixos-cosmic": "nixos-cosmic",
-				"nixpkgs": "nixpkgs_5",
-				"nixpkgs-stable": "nixpkgs-stable_2",
-				"nur": "nur",
-				"plasma-manager": "plasma-manager",
-				"spicetify-nix": "spicetify-nix",
-				"stylix": "stylix",
-				"systems": "systems_6"
-			}
-		},
-		"rust-overlay": {
-			"inputs": {
-				"nixpkgs": [
-					"lanzaboote",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1765075567,
-				"narHash": "sha256-KFDCdQcHJ0hE3Nt5Gm5enRIhmtEifAjpxgUQ3mzSJpA=",
-				"owner": "oxalica",
-				"repo": "rust-overlay",
-				"rev": "769156779b41e8787a46ca3d7d76443aaf68be6f",
-				"type": "github"
-			},
-			"original": {
-				"owner": "oxalica",
-				"repo": "rust-overlay",
-				"type": "github"
-			}
-		},
-		"rust-overlay_2": {
-			"inputs": {
-				"nixpkgs": [
-					"nixos-cosmic",
-					"nixpkgs"
-				]
-			},
-			"locked": {
-				"lastModified": 1751251399,
-				"narHash": "sha256-y+viCuy/eKKpkX1K2gDvXIJI/yzvy6zA3HObapz9XZ0=",
-				"owner": "oxalica",
-				"repo": "rust-overlay",
-				"rev": "b22d5ee8c60ed1291521f2dde48784edd6bf695b",
-				"type": "github"
-			},
-			"original": {
-				"owner": "oxalica",
-				"repo": "rust-overlay",
-				"type": "github"
-			}
-		},
-		"spicetify-nix": {
-			"inputs": {
-				"nixpkgs": [
-					"nixpkgs"
-				],
-				"systems": "systems_4"
-			},
-			"locked": {
-				"lastModified": 1775421933,
-				"narHash": "sha256-JkEbzFDFTsUlVtHEzA8Y4r3O9LInhb96eOCbtGjGnbM=",
-				"owner": "Gerg-L",
-				"repo": "spicetify-nix",
-				"rev": "ec8d73085fdf807d55765335dc8126e14e7b2096",
-				"type": "github"
-			},
-			"original": {
-				"owner": "Gerg-L",
-				"repo": "spicetify-nix",
-				"type": "github"
-			}
-		},
-		"stylix": {
-			"inputs": {
-				"base16": "base16",
-				"base16-fish": "base16-fish",
-				"base16-helix": "base16-helix",
-				"base16-vim": "base16-vim",
-				"firefox-gnome-theme": "firefox-gnome-theme",
-				"flake-parts": "flake-parts_3",
-				"gnome-shell": "gnome-shell",
-				"nixpkgs": "nixpkgs_7",
-				"nur": "nur_2",
-				"systems": "systems_5",
-				"tinted-kitty": "tinted-kitty",
-				"tinted-schemes": "tinted-schemes",
-				"tinted-tmux": "tinted-tmux",
-				"tinted-zed": "tinted-zed"
-			},
-			"locked": {
-				"lastModified": 1775429060,
-				"narHash": "sha256-wbFF5cRxQOCzL/wHOKYm21t5AHPH2Lfp0mVPCOAvEoc=",
-				"owner": "danth",
-				"repo": "stylix",
-				"rev": "d27951a6539951d87f75cf0a7cda8a3a24016019",
-				"type": "github"
-			},
-			"original": {
-				"owner": "danth",
-				"repo": "stylix",
-				"type": "github"
-			}
-		},
-		"systems": {
-			"locked": {
-				"lastModified": 1681028828,
-				"narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-				"owner": "nix-systems",
-				"repo": "default",
-				"rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-systems",
-				"repo": "default",
-				"type": "github"
-			}
-		},
-		"systems_2": {
-			"locked": {
-				"lastModified": 1681028828,
-				"narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-				"owner": "nix-systems",
-				"repo": "default",
-				"rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-systems",
-				"repo": "default",
-				"type": "github"
-			}
-		},
-		"systems_3": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1681028828,
-				"narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-				"owner": "nix-systems",
-				"repo": "default",
-				"rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-systems",
-				"repo": "default",
-				"type": "github"
-			}
-		},
-		"systems_4": {
-			"locked": {
-				"lastModified": 1681028828,
-				"narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-				"owner": "nix-systems",
-				"repo": "default",
-				"rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-systems",
-				"repo": "default",
-				"type": "github"
-			}
-		},
-		"systems_5": {
-			"locked": {
-				"lastModified": 1681028828,
-				"narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-				"owner": "nix-systems",
-				"repo": "default",
-				"rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-systems",
-				"repo": "default",
-				"type": "github"
-			}
-		},
-		"systems_6": {
-			"locked": {
-				"lastModified": 1681028828,
-				"narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-				"owner": "nix-systems",
-				"repo": "default",
-				"rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-				"type": "github"
-			},
-			"original": {
-				"owner": "nix-systems",
-				"repo": "default",
-				"type": "github"
-			}
-		},
-		"tinted-kitty": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1735730497,
-				"narHash": "sha256-4KtB+FiUzIeK/4aHCKce3V9HwRvYaxX+F1edUrfgzb8=",
-				"owner": "tinted-theming",
-				"repo": "tinted-kitty",
-				"rev": "de6f888497f2c6b2279361bfc790f164bfd0f3fa",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tinted-theming",
-				"repo": "tinted-kitty",
-				"type": "github"
-			}
-		},
-		"tinted-schemes": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1772661346,
-				"narHash": "sha256-4eu3LqB9tPqe0Vaqxd4wkZiBbthLbpb7llcoE/p5HT0=",
-				"owner": "tinted-theming",
-				"repo": "schemes",
-				"rev": "13b5b0c299982bb361039601e2d72587d6846294",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tinted-theming",
-				"repo": "schemes",
-				"type": "github"
-			}
-		},
-		"tinted-tmux": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1772934010,
-				"narHash": "sha256-x+6+4UvaG+RBRQ6UaX+o6DjEg28u4eqhVRM9kpgJGjQ=",
-				"owner": "tinted-theming",
-				"repo": "tinted-tmux",
-				"rev": "c3529673a5ab6e1b6830f618c45d9ce1bcdd829d",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tinted-theming",
-				"repo": "tinted-tmux",
-				"type": "github"
-			}
-		},
-		"tinted-zed": {
-			"flake": false,
-			"locked": {
-				"lastModified": 1772909925,
-				"narHash": "sha256-jx/5+pgYR0noHa3hk2esin18VMbnPSvWPL5bBjfTIAU=",
-				"owner": "tinted-theming",
-				"repo": "base16-zed",
-				"rev": "b4d3a1b3bcbd090937ef609a0a3b37237af974df",
-				"type": "github"
-			},
-			"original": {
-				"owner": "tinted-theming",
-				"repo": "base16-zed",
-				"type": "github"
-			}
-		}
-	},
-	"root": "root",
-	"version": 7
+  "nodes": {
+    "agenix": {
+      "inputs": {
+        "darwin": "darwin",
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1770165109,
+        "narHash": "sha256-9VnK6Oqai65puVJ4WYtCTvlJeXxMzAp/69HhQuTdl/I=",
+        "owner": "ryantm",
+        "repo": "agenix",
+        "rev": "b027ee29d959fda4b60b57566d64c98a202e0feb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ryantm",
+        "repo": "agenix",
+        "type": "github"
+      }
+    },
+    "base16": {
+      "inputs": {
+        "fromYaml": "fromYaml"
+      },
+      "locked": {
+        "lastModified": 1755819240,
+        "narHash": "sha256-qcMhnL7aGAuFuutH4rq9fvAhCpJWVHLcHVZLtPctPlo=",
+        "owner": "SenchoPens",
+        "repo": "base16.nix",
+        "rev": "75ed5e5e3fce37df22e49125181fa37899c3ccd6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SenchoPens",
+        "repo": "base16.nix",
+        "type": "github"
+      }
+    },
+    "base16-fish": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765809053,
+        "narHash": "sha256-XCUQLoLfBJ8saWms2HCIj4NEN+xNsWBlU1NrEPcQG4s=",
+        "owner": "tomyun",
+        "repo": "base16-fish",
+        "rev": "86cbea4dca62e08fb7fd83a70e96472f92574782",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tomyun",
+        "repo": "base16-fish",
+        "rev": "86cbea4dca62e08fb7fd83a70e96472f92574782",
+        "type": "github"
+      }
+    },
+    "base16-helix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1760703920,
+        "narHash": "sha256-m82fGUYns4uHd+ZTdoLX2vlHikzwzdu2s2rYM2bNwzw=",
+        "owner": "tinted-theming",
+        "repo": "base16-helix",
+        "rev": "d646af9b7d14bff08824538164af99d0c521b185",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-helix",
+        "type": "github"
+      }
+    },
+    "base16-vim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1732806396,
+        "narHash": "sha256-e0bpPySdJf0F68Ndanwm+KWHgQiZ0s7liLhvJSWDNsA=",
+        "owner": "tinted-theming",
+        "repo": "base16-vim",
+        "rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-vim",
+        "rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1765145449,
+        "narHash": "sha256-aBVHGWWRzSpfL++LubA0CwOOQ64WNLegrYHwsVuVN7A=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "69f538cdce5955fcd47abfed4395dc6d5194c1c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "agenix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744478979,
+        "narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
+        "owner": "lnl7",
+        "repo": "nix-darwin",
+        "rev": "43975d782b418ebf4969e9ccba82466728c2851b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lnl7",
+        "ref": "master",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "devour-flake": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1770055559,
+        "narHash": "sha256-peb6VlxIDoqaHkGPanQ35p8SXy9t54NIJ8XJHgMSuFg=",
+        "owner": "srid",
+        "repo": "devour-flake",
+        "rev": "e65d15fd4ef46dbde90ac59be581b2a286c35d0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "devour-flake",
+        "type": "github"
+      }
+    },
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "firefox-gnome-theme": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775176642,
+        "narHash": "sha256-2veEED0Fg7Fsh81tvVDNYR6SzjqQxa7hbi18Jv4LWpM=",
+        "owner": "rafaelmardojai",
+        "repo": "firefox-gnome-theme",
+        "rev": "179704030c5286c729b5b0522037d1d51341022c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rafaelmardojai",
+        "repo": "firefox-gnome-theme",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1746162366,
+        "narHash": "sha256-5SSSZ/oQkwfcAz/o/6TlejlVGqeK08wyREBQ5qFFPhM=",
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "rev": "0f158086a2ecdbb138cd0429410e44994f1b7e4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "stylix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "fromYaml": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1731966426,
+        "narHash": "sha256-lq95WydhbUTWig/JpqiB7oViTcHFP8Lv41IGtayokA8=",
+        "owner": "SenchoPens",
+        "repo": "fromYaml",
+        "rev": "106af9e2f715e2d828df706c386a685698f3223b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SenchoPens",
+        "repo": "fromYaml",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775585728,
+        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "lanzaboote",
+          "pre-commit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gnome-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767737596,
+        "narHash": "sha256-eFujfIUQDgWnSJBablOuG+32hCai192yRdrNHTv0a+s=",
+        "owner": "GNOME",
+        "repo": "gnome-shell",
+        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "GNOME",
+        "repo": "gnome-shell",
+        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776454077,
+        "narHash": "sha256-7zSUFWsU0+jlD7WB3YAxQ84Z/iJurA5hKPm8EfEyGJk=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "565e5349208fe7d0831ef959103c9bafbeac0681",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_2": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprpanel",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750798083,
+        "narHash": "sha256-DTCCcp6WCFaYXWKFRA6fiI2zlvOLCf5Vwx8+/0R8Wc4=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "ff31a4677c1a8ae506aa7e003a3dba08cb203f82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_3": {
+      "inputs": {
+        "nixpkgs": [
+          "impermanence",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768598210,
+        "narHash": "sha256-kkgA32s/f4jaa4UG+2f8C225Qvclxnqs76mf8zvTVPg=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "c47b2cc64a629f8e075de52e4742de688f930dc6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "hyprpanel": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "home-manager": "home-manager_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1774257081,
+        "narHash": "sha256-92ZbaBfsEXEE7VaWJjv9aRSk3l9nyoYYyMe2AwTqSZI=",
+        "owner": "Jas-SinghFSU",
+        "repo": "HyprPanel",
+        "rev": "e919b4a8a8ab5f2a0752f68576ab3eed6993cefd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Jas-SinghFSU",
+        "repo": "HyprPanel",
+        "type": "github"
+      }
+    },
+    "impermanence": {
+      "inputs": {
+        "home-manager": "home-manager_3",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1769548169,
+        "narHash": "sha256-03+JxvzmfwRu+5JafM0DLbxgHttOQZkUtDWBmeUkN8Y=",
+        "owner": "nix-community",
+        "repo": "impermanence",
+        "rev": "7b1d382faf603b6d264f58627330f9faa5cba149",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "impermanence",
+        "type": "github"
+      }
+    },
+    "lanzaboote": {
+      "inputs": {
+        "crane": "crane",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pre-commit": "pre-commit",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1765382359,
+        "narHash": "sha256-RJmgVDzjRI18BWVogG6wpsl1UCuV6ui8qr4DJ1LfWZ8=",
+        "owner": "nix-community",
+        "repo": "lanzaboote",
+        "rev": "e8c096ade12ec9130ff931b0f0e25d2f1bc63607",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v1.0.0",
+        "repo": "lanzaboote",
+        "type": "github"
+      }
+    },
+    "nix-flatpak": {
+      "locked": {
+        "lastModified": 1767983141,
+        "narHash": "sha256-7ZCulYUD9RmJIDULTRkGLSW1faMpDlPKcbWJLYHoXcs=",
+        "owner": "gmodena",
+        "repo": "nix-flatpak",
+        "rev": "440818969ac2cbd77bfe025e884d0aa528991374",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gmodena",
+        "ref": "latest",
+        "repo": "nix-flatpak",
+        "type": "github"
+      }
+    },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1775970782,
+        "narHash": "sha256-7jt9Vpm48Yy5yAWigYpde+HxtYEpEuyzIQJF4VYehhk=",
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "rev": "bedba5989b04614fc598af9633033b95a937933f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
+    "nix4vscode": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1776481363,
+        "narHash": "sha256-XvMCnshrWCwoNn1rxiBVD6Avf16nGwWKA3gtI3dEjHc=",
+        "owner": "nix-community",
+        "repo": "nix4vscode",
+        "rev": "b69acee4ba8dffcfa553c9a7ba19984db1a1c3a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix4vscode",
+        "type": "github"
+      }
+    },
+    "nixos-cosmic": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "nixpkgs": "nixpkgs_4",
+        "nixpkgs-stable": "nixpkgs-stable",
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1751591814,
+        "narHash": "sha256-A4lgvuj4v+Pr8MniXz1FBG0DXOygi8tTECR+j53FMhM=",
+        "owner": "lilyinstarlight",
+        "repo": "nixos-cosmic",
+        "rev": "fef2d0c78c4e4d6c600a88795af193131ff51bdc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lilyinstarlight",
+        "repo": "nixos-cosmic",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750776420,
+        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1751048012,
+        "narHash": "sha256-MYbotu4UjWpTsq01wglhN5xDRfZYLFtNk7SBY0BcjkU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a684c58d46ebbede49f280b653b9e56100aa3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1768564909,
+        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1751011381,
+        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nur": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_6"
+      },
+      "locked": {
+        "lastModified": 1776531480,
+        "narHash": "sha256-iDpiiJGGd5x50jNnB1auK18W+fcG2WZUZTkQxeFAux8=",
+        "owner": "nix-community",
+        "repo": "NUR",
+        "rev": "7663873ea0473ed21ea6a03d6939ecb188636fda",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NUR",
+        "type": "github"
+      }
+    },
+    "nur_2": {
+      "inputs": {
+        "flake-parts": [
+          "stylix",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "stylix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775228139,
+        "narHash": "sha256-ebbeHmg+V7w8050bwQOuhmQHoLOEOfqKzM1KgCTexK4=",
+        "owner": "nix-community",
+        "repo": "NUR",
+        "rev": "601971b9c89e0304561977f2c28fa25e73aa7132",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NUR",
+        "type": "github"
+      }
+    },
+    "plasma-manager": {
+      "inputs": {
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775856943,
+        "narHash": "sha256-b7Mp7P+q2Md5AGt4rjHfMcBykzMumFTen10ST++AuTU=",
+        "owner": "nix-community",
+        "repo": "plasma-manager",
+        "rev": "a524a6160e6df89f7673ba293cf7d78b559eb1a5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "plasma-manager",
+        "type": "github"
+      }
+    },
+    "pre-commit": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "lanzaboote",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765016596,
+        "narHash": "sha256-rhSqPNxDVow7OQKi4qS5H8Au0P4S3AYbawBSmJNUtBQ=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "548fc44fca28a5e81c5d6b846e555e6b9c2a5a3c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "agenix": "agenix",
+        "devour-flake": "devour-flake",
+        "devshell": "devshell",
+        "flake-parts": "flake-parts",
+        "git-hooks": "git-hooks",
+        "home-manager": "home-manager",
+        "hyprpanel": "hyprpanel",
+        "impermanence": "impermanence",
+        "lanzaboote": "lanzaboote",
+        "nix-flatpak": "nix-flatpak",
+        "nix-index-database": "nix-index-database",
+        "nix4vscode": "nix4vscode",
+        "nixos-cosmic": "nixos-cosmic",
+        "nixpkgs": "nixpkgs_5",
+        "nixpkgs-stable": "nixpkgs-stable_2",
+        "nur": "nur",
+        "plasma-manager": "plasma-manager",
+        "spicetify-nix": "spicetify-nix",
+        "stylix": "stylix",
+        "systems": "systems_6"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "lanzaboote",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765075567,
+        "narHash": "sha256-KFDCdQcHJ0hE3Nt5Gm5enRIhmtEifAjpxgUQ3mzSJpA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "769156779b41e8787a46ca3d7d76443aaf68be6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixos-cosmic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1751251399,
+        "narHash": "sha256-y+viCuy/eKKpkX1K2gDvXIJI/yzvy6zA3HObapz9XZ0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b22d5ee8c60ed1291521f2dde48784edd6bf695b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "spicetify-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1776126760,
+        "narHash": "sha256-Y/RrT7WdJe9B81ZSSRuSXktVyV5koWfcQIRHDqIIof4=",
+        "owner": "Gerg-L",
+        "repo": "spicetify-nix",
+        "rev": "8b00357d910c5281181c21fc3a0d071ceec80c06",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Gerg-L",
+        "repo": "spicetify-nix",
+        "type": "github"
+      }
+    },
+    "stylix": {
+      "inputs": {
+        "base16": "base16",
+        "base16-fish": "base16-fish",
+        "base16-helix": "base16-helix",
+        "base16-vim": "base16-vim",
+        "firefox-gnome-theme": "firefox-gnome-theme",
+        "flake-parts": "flake-parts_3",
+        "gnome-shell": "gnome-shell",
+        "nixpkgs": "nixpkgs_7",
+        "nur": "nur_2",
+        "systems": "systems_5",
+        "tinted-kitty": "tinted-kitty",
+        "tinted-schemes": "tinted-schemes",
+        "tinted-tmux": "tinted-tmux",
+        "tinted-zed": "tinted-zed"
+      },
+      "locked": {
+        "lastModified": 1776170745,
+        "narHash": "sha256-Tl1aZVP5EIlT+k0+iAKH018GLHJpLz3hhJ0LNQOWxCc=",
+        "owner": "danth",
+        "repo": "stylix",
+        "rev": "e3861617645a43c9bbefde1aa6ac54dd0a44bfa9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "danth",
+        "repo": "stylix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "tinted-kitty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1735730497,
+        "narHash": "sha256-4KtB+FiUzIeK/4aHCKce3V9HwRvYaxX+F1edUrfgzb8=",
+        "owner": "tinted-theming",
+        "repo": "tinted-kitty",
+        "rev": "de6f888497f2c6b2279361bfc790f164bfd0f3fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-kitty",
+        "type": "github"
+      }
+    },
+    "tinted-schemes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772661346,
+        "narHash": "sha256-4eu3LqB9tPqe0Vaqxd4wkZiBbthLbpb7llcoE/p5HT0=",
+        "owner": "tinted-theming",
+        "repo": "schemes",
+        "rev": "13b5b0c299982bb361039601e2d72587d6846294",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "schemes",
+        "type": "github"
+      }
+    },
+    "tinted-tmux": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772934010,
+        "narHash": "sha256-x+6+4UvaG+RBRQ6UaX+o6DjEg28u4eqhVRM9kpgJGjQ=",
+        "owner": "tinted-theming",
+        "repo": "tinted-tmux",
+        "rev": "c3529673a5ab6e1b6830f618c45d9ce1bcdd829d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-tmux",
+        "type": "github"
+      }
+    },
+    "tinted-zed": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772909925,
+        "narHash": "sha256-jx/5+pgYR0noHa3hk2esin18VMbnPSvWPL5bBjfTIAU=",
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
+        "rev": "b4d3a1b3bcbd090937ef609a0a3b37237af974df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
 }


### PR DESCRIPTION
Automated Pull Request for Week 16

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/b0569dc6ec1e6e7fefd8f6897184e4c191cd768e' (2026-04-11)
  → 'github:nix-community/home-manager/565e5349208fe7d0831ef959103c9bafbeac0681' (2026-04-17)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/cef5cf82671e749ac87d69aadecbb75967e6f6c3' (2026-04-05)
  → 'github:nix-community/nix-index-database/bedba5989b04614fc598af9633033b95a937933f' (2026-04-12)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/6201e203d09599479a3b3450ed24fa81537ebc4e' (2026-03-24)
  → 'github:NixOS/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa' (2026-04-09)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/98c5bbb8b5cd5f3fe1ce1de3dabf744dfa100c49' (2026-04-11)
  → 'github:nix-community/nix4vscode/b69acee4ba8dffcfa553c9a7ba19984db1a1c3a7' (2026-04-18)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa' (2026-04-09)
  → 'github:NixOS/nixpkgs/4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9' (2026-04-14)
• Updated input 'nur':
    'github:nix-community/NUR/6046e21406c4a6cac05b22c077e0f4ed5f2d7b8e' (2026-04-11)
  → 'github:nix-community/NUR/7663873ea0473ed21ea6a03d6939ecb188636fda' (2026-04-18)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa' (2026-04-09)
  → 'github:nixos/nixpkgs/4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9' (2026-04-14)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/ec8d73085fdf807d55765335dc8126e14e7b2096' (2026-04-05)
  → 'github:Gerg-L/spicetify-nix/8b00357d910c5281181c21fc3a0d071ceec80c06' (2026-04-14)
• Updated input 'stylix':
    'github:danth/stylix/d27951a6539951d87f75cf0a7cda8a3a24016019' (2026-04-05)
  → 'github:danth/stylix/e3861617645a43c9bbefde1aa6ac54dd0a44bfa9' (2026-04-14)
```

Sources Changelog:
```
nix-fast-build: 1030b0cfaca52f95769d0998ea366946144cd47c → 67df5acda0e22b97e17d5eed579b969ddb9ea06c
```
