### PR TITLE
chore: update flake.lock & sources (2026-04-25)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-04-12",
+        "date": "2026-04-24",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "67df5acda0e22b97e17d5eed579b969ddb9ea06c",
-            "sha256": "sha256-fVTG9Uw7wfKmjYSu0CuB+kdvs9p4MrPimjtUtgWOPJE=",
+            "rev": "7f185e0ec37b65b4730f892e0de9a831b0610f3a",
+            "sha256": "sha256-8csvAFJtFzA/9hX3C784sMlaQME40LQmWI2V+YzCNhc=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "67df5acda0e22b97e17d5eed579b969ddb9ea06c"
+        "version": "7f185e0ec37b65b4730f892e0de9a831b0610f3a"
     },
     "obs_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "67df5acda0e22b97e17d5eed579b969ddb9ea06c";
+    version = "7f185e0ec37b65b4730f892e0de9a831b0610f3a";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "67df5acda0e22b97e17d5eed579b969ddb9ea06c";
+      rev = "7f185e0ec37b65b4730f892e0de9a831b0610f3a";
       fetchSubmodules = false;
-      sha256 = "sha256-fVTG9Uw7wfKmjYSu0CuB+kdvs9p4MrPimjtUtgWOPJE=";
+      sha256 = "sha256-8csvAFJtFzA/9hX3C784sMlaQME40LQmWI2V+YzCNhc=";
     };
-    date = "2026-04-12";
+    date = "2026-04-24";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -333,11 +333,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775585728,
-        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776454077,
-        "narHash": "sha256-7zSUFWsU0+jlD7WB3YAxQ84Z/iJurA5hKPm8EfEyGJk=",
+        "lastModified": 1777086106,
+        "narHash": "sha256-hlNpIN18pw3xo34Lsrp6vAMUPn0aB/zFBqL0QXI1Pmk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "565e5349208fe7d0831ef959103c9bafbeac0681",
+        "rev": "5826802354a74af18540aef0b01bc1320f82cc17",
         "type": "github"
       },
       "original": {
@@ -475,11 +475,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1774257081,
-        "narHash": "sha256-92ZbaBfsEXEE7VaWJjv9aRSk3l9nyoYYyMe2AwTqSZI=",
+        "lastModified": 1776923321,
+        "narHash": "sha256-QowlCOrE4jGOTDCUCEx/E8gHjqSx3r25y7v4dEBpBhk=",
         "owner": "Jas-SinghFSU",
         "repo": "HyprPanel",
-        "rev": "e919b4a8a8ab5f2a0752f68576ab3eed6993cefd",
+        "rev": "1961ba86ad5ab880beb639e5454054b2b5037e0d",
         "type": "github"
       },
       "original": {
@@ -552,11 +552,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1775970782,
-        "narHash": "sha256-7jt9Vpm48Yy5yAWigYpde+HxtYEpEuyzIQJF4VYehhk=",
+        "lastModified": 1776829403,
+        "narHash": "sha256-oHVcvP2Ahhj1KUsEzp+2BQF55/r5VSa3QxdPdwE1p00=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "bedba5989b04614fc598af9633033b95a937933f",
+        "rev": "c43246d4e9e506178b69baed075d797ec2d873e2",
         "type": "github"
       },
       "original": {
@@ -573,11 +573,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1776481363,
-        "narHash": "sha256-XvMCnshrWCwoNn1rxiBVD6Avf16nGwWKA3gtI3dEjHc=",
+        "lastModified": 1777084019,
+        "narHash": "sha256-zsjoybecLjWTA0xPhTahh8G9aMNSmawrIdSEecaGTHk=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "b69acee4ba8dffcfa553c9a7ba19984db1a1c3a7",
+        "rev": "aeaa8983f0abd865c2363bd634a03db27b8b3857",
         "type": "github"
       },
       "original": {
@@ -688,11 +688,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {
@@ -720,11 +720,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {
@@ -736,11 +736,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {
@@ -772,11 +772,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1776531480,
-        "narHash": "sha256-iDpiiJGGd5x50jNnB1auK18W+fcG2WZUZTkQxeFAux8=",
+        "lastModified": 1777136441,
+        "narHash": "sha256-dOPaSxaqbaeNYO8rVcWymveu1WNE4pjUMzBWYJEtQ/0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7663873ea0473ed21ea6a03d6939ecb188636fda",
+        "rev": "05030429b1bbb7a41ec51e479a9d8cd0695c3e9b",
         "type": "github"
       },
       "original": {
@@ -930,11 +930,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1776126760,
-        "narHash": "sha256-Y/RrT7WdJe9B81ZSSRuSXktVyV5koWfcQIRHDqIIof4=",
+        "lastModified": 1777043003,
+        "narHash": "sha256-lEKiNXDssCjM5bM6v1rltaYRsBRrXrozD4ryctlnZo0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "8b00357d910c5281181c21fc3a0d071ceec80c06",
+        "rev": "8486e82fd1b2bab54868139ac2263de54c9c85c7",
         "type": "github"
       },
       "original": {
@@ -961,11 +961,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1776170745,
-        "narHash": "sha256-Tl1aZVP5EIlT+k0+iAKH018GLHJpLz3hhJ0LNQOWxCc=",
+        "lastModified": 1776893932,
+        "narHash": "sha256-AFD5cf9eNqXq1brHS63xeZy2xKZMgG9J86XJ9I2eLn8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e3861617645a43c9bbefde1aa6ac54dd0a44bfa9",
+        "rev": "84971726c7ef0bb3669a5443e151cc226e65c518",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 17

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/580633fa3fe5fc0379905986543fd7495481913d' (2026-04-07)
  → 'github:cachix/git-hooks.nix/3cfd774b0a530725a077e17354fbdb87ea1c4aad' (2026-04-21)
• Updated input 'home-manager':
    'github:nix-community/home-manager/565e5349208fe7d0831ef959103c9bafbeac0681' (2026-04-17)
  → 'github:nix-community/home-manager/5826802354a74af18540aef0b01bc1320f82cc17' (2026-04-25)
• Updated input 'hyprpanel':
    'github:Jas-SinghFSU/HyprPanel/e919b4a8a8ab5f2a0752f68576ab3eed6993cefd' (2026-03-23)
  → 'github:Jas-SinghFSU/HyprPanel/1961ba86ad5ab880beb639e5454054b2b5037e0d' (2026-04-23)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/bedba5989b04614fc598af9633033b95a937933f' (2026-04-12)
  → 'github:nix-community/nix-index-database/c43246d4e9e506178b69baed075d797ec2d873e2' (2026-04-22)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa' (2026-04-09)
  → 'github:NixOS/nixpkgs/4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9' (2026-04-14)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/b69acee4ba8dffcfa553c9a7ba19984db1a1c3a7' (2026-04-18)
  → 'github:nix-community/nix4vscode/aeaa8983f0abd865c2363bd634a03db27b8b3857' (2026-04-25)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9' (2026-04-14)
  → 'github:NixOS/nixpkgs/0726a0ecb6d4e08f6adced58726b95db924cef57' (2026-04-22)
• Updated input 'nur':
    'github:nix-community/NUR/7663873ea0473ed21ea6a03d6939ecb188636fda' (2026-04-18)
  → 'github:nix-community/NUR/05030429b1bbb7a41ec51e479a9d8cd0695c3e9b' (2026-04-25)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9' (2026-04-14)
  → 'github:nixos/nixpkgs/0726a0ecb6d4e08f6adced58726b95db924cef57' (2026-04-22)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/8b00357d910c5281181c21fc3a0d071ceec80c06' (2026-04-14)
  → 'github:Gerg-L/spicetify-nix/8486e82fd1b2bab54868139ac2263de54c9c85c7' (2026-04-24)
• Updated input 'stylix':
    'github:danth/stylix/e3861617645a43c9bbefde1aa6ac54dd0a44bfa9' (2026-04-14)
  → 'github:danth/stylix/84971726c7ef0bb3669a5443e151cc226e65c518' (2026-04-22)
```

Sources Changelog:
```
nix-fast-build: 67df5acda0e22b97e17d5eed579b969ddb9ea06c → 7f185e0ec37b65b4730f892e0de9a831b0610f3a
```
