### PR TITLE
chore: update flake.lock & sources (2026-05-02)

### DIFF
--- a/Packages/tlpui.nix
+++ b/Packages/tlpui.nix
@@ -31,7 +31,7 @@ python3Packages.buildPythonPackage rec {
   ];
 
   # ignore test/test_tlp_settings.py asit relies on opening a gui which is non-trivial
-  pytestFlagsArray = [ "--ignore=test/test_tlp_settings.py" ];
+  pytestFlags = [ "--ignore=test/test_tlp_settings.py" ];
   nativeCheckInputs = [
     gobject-introspection
     python3Packages.pytestCheckHook

--- a/System/Common/Services/networking.nix
+++ b/System/Common/Services/networking.nix
@@ -14,6 +14,8 @@
       enable = true;
       dns = "none";
     };
+    # Set below, not necessary.
+    resolvconf.enable = false;
   };
 
   environment.etc."resolv.conf".text = lib.concatMapStringsSep "\n" (

--- a/flake.lock
+++ b/flake.lock
@@ -235,11 +235,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1777678872,
+        "narHash": "sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT+IPhcsukVbgk=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "5250617bffd85403b14dbf43c3870e7f255d2c16",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777086106,
-        "narHash": "sha256-hlNpIN18pw3xo34Lsrp6vAMUPn0aB/zFBqL0QXI1Pmk=",
+        "lastModified": 1777733408,
+        "narHash": "sha256-lyKV2GtkMPS1Mp8bKJ8sBr7LPCzL4GnVnQQYa4e7UsQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5826802354a74af18540aef0b01bc1320f82cc17",
+        "rev": "9ce9f7f128c5834bb71a4f5c62232187371379b6",
         "type": "github"
       },
       "original": {
@@ -552,11 +552,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1776829403,
-        "narHash": "sha256-oHVcvP2Ahhj1KUsEzp+2BQF55/r5VSa3QxdPdwE1p00=",
+        "lastModified": 1777181277,
+        "narHash": "sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "c43246d4e9e506178b69baed075d797ec2d873e2",
+        "rev": "b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa",
         "type": "github"
       },
       "original": {
@@ -573,11 +573,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1777084019,
-        "narHash": "sha256-zsjoybecLjWTA0xPhTahh8G9aMNSmawrIdSEecaGTHk=",
+        "lastModified": 1777730827,
+        "narHash": "sha256-NJ5BGdeEVSfzCjNIGWJahgBsg8y7XUNHSJo8zWD2emk=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "aeaa8983f0abd865c2363bd634a03db27b8b3857",
+        "rev": "add1b8d6026aedc59c4105e4c6d232feb9e38abf",
         "type": "github"
       },
       "original": {
@@ -625,11 +625,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
@@ -688,11 +688,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {
@@ -720,11 +720,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {
@@ -736,11 +736,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {
@@ -772,11 +772,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1777136441,
-        "narHash": "sha256-dOPaSxaqbaeNYO8rVcWymveu1WNE4pjUMzBWYJEtQ/0=",
+        "lastModified": 1777741218,
+        "narHash": "sha256-reHbEDfcF0hly2Uvrs+Ub9kg2ArzbbwN6ZjpoGEXNvA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05030429b1bbb7a41ec51e479a9d8cd0695c3e9b",
+        "rev": "e45ee2e0defd299181f87eec923a5a9246fc7366",
         "type": "github"
       },
       "original": {
@@ -930,11 +930,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1777043003,
-        "narHash": "sha256-lEKiNXDssCjM5bM6v1rltaYRsBRrXrozD4ryctlnZo0=",
+        "lastModified": 1777183994,
+        "narHash": "sha256-zahis/vVFOsWv/HeyHbU13jxnrCC+ppIg49xG+viWxg=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "8486e82fd1b2bab54868139ac2263de54c9c85c7",
+        "rev": "501256c3e670ca1679501ce3839ea805df00d8ba",
         "type": "github"
       },
       "original": {
@@ -961,11 +961,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1776893932,
-        "narHash": "sha256-AFD5cf9eNqXq1brHS63xeZy2xKZMgG9J86XJ9I2eLn8=",
+        "lastModified": 1777580129,
+        "narHash": "sha256-6buSTzDtHYCJP1JNAIZCmgNcOs76oN03j+21CxdijVo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "84971726c7ef0bb3669a5443e151cc226e65c518",
+        "rev": "20ff51f523e2dd67e5f31a321719d30708c1b771",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 18

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/3107b77cd68437b9a76194f0f7f9c55f2329ca5b' (2026-04-01)
  → 'github:hercules-ci/flake-parts/5250617bffd85403b14dbf43c3870e7f255d2c16' (2026-05-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/333c4e0545a6da976206c74db8773a1645b5870a' (2026-03-29)
  → 'github:nix-community/nixpkgs.lib/f5901329dade4a6ea039af1433fb087bd9c1fe14' (2026-04-26)
• Updated input 'home-manager':
    'github:nix-community/home-manager/5826802354a74af18540aef0b01bc1320f82cc17' (2026-04-25)
  → 'github:nix-community/home-manager/9ce9f7f128c5834bb71a4f5c62232187371379b6' (2026-05-02)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/c43246d4e9e506178b69baed075d797ec2d873e2' (2026-04-22)
  → 'github:nix-community/nix-index-database/b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa' (2026-04-26)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9' (2026-04-14)
  → 'github:NixOS/nixpkgs/0726a0ecb6d4e08f6adced58726b95db924cef57' (2026-04-22)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/aeaa8983f0abd865c2363bd634a03db27b8b3857' (2026-04-25)
  → 'github:nix-community/nix4vscode/add1b8d6026aedc59c4105e4c6d232feb9e38abf' (2026-05-02)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/0726a0ecb6d4e08f6adced58726b95db924cef57' (2026-04-22)
  → 'github:NixOS/nixpkgs/15f4ee454b1dce334612fa6843b3e05cf546efab' (2026-04-30)
• Updated input 'nur':
    'github:nix-community/NUR/05030429b1bbb7a41ec51e479a9d8cd0695c3e9b' (2026-04-25)
  → 'github:nix-community/NUR/e45ee2e0defd299181f87eec923a5a9246fc7366' (2026-05-02)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/0726a0ecb6d4e08f6adced58726b95db924cef57' (2026-04-22)
  → 'github:nixos/nixpkgs/15f4ee454b1dce334612fa6843b3e05cf546efab' (2026-04-30)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/8486e82fd1b2bab54868139ac2263de54c9c85c7' (2026-04-24)
  → 'github:Gerg-L/spicetify-nix/501256c3e670ca1679501ce3839ea805df00d8ba' (2026-04-26)
• Updated input 'stylix':
    'github:danth/stylix/84971726c7ef0bb3669a5443e151cc226e65c518' (2026-04-22)
  → 'github:danth/stylix/20ff51f523e2dd67e5f31a321719d30708c1b771' (2026-04-30)
```

Sources Changelog:
```
No changes!
```
