### PR TITLE
chore: update flake.lock & sources (2026-05-16)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -235,11 +235,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1777988971,
-        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778594112,
-        "narHash": "sha256-VA9z90SZviIvOcA4QyatA48FIyqb8mmsmH/EsXXWAG4=",
+        "lastModified": 1778937626,
+        "narHash": "sha256-OzLAT0G96WlT/WWaNdkTvQ7E9ohq9h0xQTdL1oe3gm0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1768d4e49860b86cb7652ee738de0e6b3050dd40",
+        "rev": "d5ece85b6d3d6b5ab5a514b2785fb952b629bfea",
         "type": "github"
       },
       "original": {
@@ -573,11 +573,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1778558030,
-        "narHash": "sha256-CLfwFIbLXAw61Xn1liFmb02g8Chi+EkUwCrRIPMsP6Q=",
+        "lastModified": 1778903319,
+        "narHash": "sha256-wdHPI1dNC/VEy3n2ILe9pjNCnIuaNWl7+dMeXuPwkC8=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "d0091f2b3b8177552006367707b3d88cb4322651",
+        "rev": "22183203918032416508545bf0053be7c313f686",
         "type": "github"
       },
       "original": {
@@ -720,11 +720,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -736,11 +736,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -772,11 +772,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1778596776,
-        "narHash": "sha256-RJUNWMlBnW6sYrG8V4AFFk09Xi9FU1qgx1UPw0Kzl7k=",
+        "lastModified": 1778951636,
+        "narHash": "sha256-2vN5nS2Rnm1kbsB8DEw+02Bgu7a0K6ArWWHzzVVOMNc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "02bac1e4ecfa398f3e3fc9469c507bb9aee6ca7f",
+        "rev": "9f6077b9dedfb6921e7ed8e539ee3bf43e753aea",
         "type": "github"
       },
       "original": {
@@ -930,11 +930,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1778540809,
-        "narHash": "sha256-FNXls2QZTcxY0Dem3QtSewnr8vUKMDsTw9m8pLOnhTc=",
+        "lastModified": 1778793632,
+        "narHash": "sha256-HYHD6J64bAWB2iT00lyyTn0wWcb0POtV+nPshYvq6Uc=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "83939d7df4c0f1b8ee88cabde112223280a48554",
+        "rev": "e175a8b634e06a1b0635ec3d4db2c72cdc41fd15",
         "type": "github"
       },
       "original": {
@@ -961,11 +961,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1778104276,
-        "narHash": "sha256-/DSSnU0LLmOTG/OCgGwYpxP6+5YvxRx2g/GhI4x6aCU=",
+        "lastModified": 1778776709,
+        "narHash": "sha256-YhnEcpiY6+l3RFA+cPmdTaeODGvNRuqE8B7VBjPVIxo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "18ed8d270231e067fe2739998479ed5d7c659c2c",
+        "rev": "e8ea85b4f7dddda9603e0f1ac86cd92cee3b2819",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 20

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/0678d8986be1661af6bb555f3489f2fdfc31f6ff' (2026-05-05)
  → 'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb' (2026-05-13)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1768d4e49860b86cb7652ee738de0e6b3050dd40' (2026-05-12)
  → 'github:nix-community/home-manager/d5ece85b6d3d6b5ab5a514b2785fb952b629bfea' (2026-05-16)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/d0091f2b3b8177552006367707b3d88cb4322651' (2026-05-12)
  → 'github:nix-community/nix4vscode/22183203918032416508545bf0053be7c313f686' (2026-05-16)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/da5ad661ba4e5ef59ba743f0d112cbc30e474f32' (2026-05-10)
  → 'github:NixOS/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb' (2026-05-15)
• Updated input 'nur':
    'github:nix-community/NUR/02bac1e4ecfa398f3e3fc9469c507bb9aee6ca7f' (2026-05-12)
  → 'github:nix-community/NUR/9f6077b9dedfb6921e7ed8e539ee3bf43e753aea' (2026-05-16)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/549bd84d6279f9852cae6225e372cc67fb91a4c1' (2026-05-05)
  → 'github:nixos/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb' (2026-05-15)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/83939d7df4c0f1b8ee88cabde112223280a48554' (2026-05-11)
  → 'github:Gerg-L/spicetify-nix/e175a8b634e06a1b0635ec3d4db2c72cdc41fd15' (2026-05-14)
• Updated input 'stylix':
    'github:danth/stylix/18ed8d270231e067fe2739998479ed5d7c659c2c' (2026-05-06)
  → 'github:danth/stylix/e8ea85b4f7dddda9603e0f1ac86cd92cee3b2819' (2026-05-14)
```

Sources Changelog:
```
No changes!
```
