### PR TITLE
chore: update flake.lock & sources (2026-05-23)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-05-10",
+        "date": "2026-05-17",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "5874ab8d0ef2f7b00dbc8644232c18cadee7b3dc",
-            "sha256": "sha256-T/stWCwxHnD059O4ZyLo5Tc66gBCogUMkN1FBsMAjOQ=",
+            "rev": "ab8dadc27c73855a958198c6f994398f0e84d2ab",
+            "sha256": "sha256-EL66LU1TCXIava+cBhG/tBIm6Izxkdb4P9ZLZl/wtTk=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "5874ab8d0ef2f7b00dbc8644232c18cadee7b3dc"
+        "version": "ab8dadc27c73855a958198c6f994398f0e84d2ab"
     },
     "obs_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "5874ab8d0ef2f7b00dbc8644232c18cadee7b3dc";
+    version = "ab8dadc27c73855a958198c6f994398f0e84d2ab";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "5874ab8d0ef2f7b00dbc8644232c18cadee7b3dc";
+      rev = "ab8dadc27c73855a958198c6f994398f0e84d2ab";
       fetchSubmodules = false;
-      sha256 = "sha256-T/stWCwxHnD059O4ZyLo5Tc66gBCogUMkN1FBsMAjOQ=";
+      sha256 = "sha256-EL66LU1TCXIava+cBhG/tBIm6Izxkdb4P9ZLZl/wtTk=";
     };
-    date = "2026-05-10";
+    date = "2026-05-17";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778937626,
-        "narHash": "sha256-OzLAT0G96WlT/WWaNdkTvQ7E9ohq9h0xQTdL1oe3gm0=",
+        "lastModified": 1779507042,
+        "narHash": "sha256-7wOwi8B6D0BYsieZCnHZZj2sNUzgJhLoIVSfkwB7lxQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5ece85b6d3d6b5ab5a514b2785fb952b629bfea",
+        "rev": "509ed3c603349a9d43de9e2ae6613baea6bd5b34",
         "type": "github"
       },
       "original": {
@@ -552,11 +552,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1778393439,
-        "narHash": "sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc=",
+        "lastModified": 1778999127,
+        "narHash": "sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "01466c414c7357ae2ce32be4a272a7c69e94ab5f",
+        "rev": "f680e0d3c1dbefe298c423691662e238496890f2",
         "type": "github"
       },
       "original": {
@@ -573,11 +573,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1778903319,
-        "narHash": "sha256-wdHPI1dNC/VEy3n2ILe9pjNCnIuaNWl7+dMeXuPwkC8=",
+        "lastModified": 1779508413,
+        "narHash": "sha256-Sic0ApcD3mb53kvBYtuJjf7vJuM4eklt60Kmxtt+fq0=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "22183203918032416508545bf0053be7c313f686",
+        "rev": "5940ddf31cba9c2d3b01eaad8d1dcbad4312e892",
         "type": "github"
       },
       "original": {
@@ -688,11 +688,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -720,11 +720,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779357205,
+        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
         "type": "github"
       },
       "original": {
@@ -736,11 +736,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779357205,
+        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
         "type": "github"
       },
       "original": {
@@ -752,11 +752,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -772,11 +772,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1778951636,
-        "narHash": "sha256-2vN5nS2Rnm1kbsB8DEw+02Bgu7a0K6ArWWHzzVVOMNc=",
+        "lastModified": 1779551213,
+        "narHash": "sha256-CBWXFb//njiA2vB5CFuknX6HVhPGKMxLQ2w9K1fWQsI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f6077b9dedfb6921e7ed8e539ee3bf43e753aea",
+        "rev": "7f189705ebb1497af89b57c479f602fa69501f95",
         "type": "github"
       },
       "original": {
@@ -930,11 +930,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1778793632,
-        "narHash": "sha256-HYHD6J64bAWB2iT00lyyTn0wWcb0POtV+nPshYvq6Uc=",
+        "lastModified": 1779000518,
+        "narHash": "sha256-wdtytSnzMe85J/qeXJALMzSLRFTZ1gBHwn81l1PtT8k=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "e175a8b634e06a1b0635ec3d4db2c72cdc41fd15",
+        "rev": "5dde76b38418892ccb3d99e99bed7f8a43ac294c",
         "type": "github"
       },
       "original": {
@@ -961,11 +961,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1778776709,
-        "narHash": "sha256-YhnEcpiY6+l3RFA+cPmdTaeODGvNRuqE8B7VBjPVIxo=",
+        "lastModified": 1779378391,
+        "narHash": "sha256-IsDb9erotvx9npI94UDosvMeYQK17p7/vmU2v9batrY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e8ea85b4f7dddda9603e0f1ac86cd92cee3b2819",
+        "rev": "c1456cc4ba3c9485e7b4158c909eeca5a752cd59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 21

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/d5ece85b6d3d6b5ab5a514b2785fb952b629bfea' (2026-05-16)
  → 'github:nix-community/home-manager/509ed3c603349a9d43de9e2ae6613baea6bd5b34' (2026-05-23)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/01466c414c7357ae2ce32be4a272a7c69e94ab5f' (2026-05-10)
  → 'github:nix-community/nix-index-database/f680e0d3c1dbefe298c423691662e238496890f2' (2026-05-17)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/549bd84d6279f9852cae6225e372cc67fb91a4c1' (2026-05-05)
  → 'github:NixOS/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb' (2026-05-15)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/22183203918032416508545bf0053be7c313f686' (2026-05-16)
  → 'github:nix-community/nix4vscode/5940ddf31cba9c2d3b01eaad8d1dcbad4312e892' (2026-05-23)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb' (2026-05-15)
  → 'github:NixOS/nixpkgs/f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1' (2026-05-21)
• Updated input 'nur':
    'github:nix-community/NUR/9f6077b9dedfb6921e7ed8e539ee3bf43e753aea' (2026-05-16)
  → 'github:nix-community/NUR/7f189705ebb1497af89b57c479f602fa69501f95' (2026-05-23)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb' (2026-05-15)
  → 'github:nixos/nixpkgs/f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1' (2026-05-21)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/e175a8b634e06a1b0635ec3d4db2c72cdc41fd15' (2026-05-14)
  → 'github:Gerg-L/spicetify-nix/5dde76b38418892ccb3d99e99bed7f8a43ac294c' (2026-05-17)
• Updated input 'stylix':
    'github:danth/stylix/e8ea85b4f7dddda9603e0f1ac86cd92cee3b2819' (2026-05-14)
  → 'github:danth/stylix/c1456cc4ba3c9485e7b4158c909eeca5a752cd59' (2026-05-21)
• Updated input 'stylix/nixpkgs':
    'github:NixOS/nixpkgs/1c3fe55ad329cbcb28471bb30f05c9827f724c76' (2026-04-27)
  → 'github:NixOS/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb' (2026-05-15)
```

Sources Changelog:
```
nix-fast-build: 5874ab8d0ef2f7b00dbc8644232c18cadee7b3dc → ab8dadc27c73855a958198c6f994398f0e84d2ab
```
