### PR TITLE
chore: update flake.lock & sources (2026-06-13)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-06-06",
+        "date": "2026-06-12",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "eda392e4b8cf82f7f9b55f9e9f923c9dd70d2677",
-            "sha256": "sha256-/Hs3gz05EpiR6FE+ZxCbBTBaCZvfGYpqNGnGHWhkIxs=",
+            "rev": "bdb2e9b84f9146dadb1556dd6a6ffcfabce66d19",
+            "sha256": "sha256-g65WwClvsi3wNtp5U4cIt5Mf38zyZeaVo+QTGau+o18=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "eda392e4b8cf82f7f9b55f9e9f923c9dd70d2677"
+        "version": "bdb2e9b84f9146dadb1556dd6a6ffcfabce66d19"
     },
     "obs_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "eda392e4b8cf82f7f9b55f9e9f923c9dd70d2677";
+    version = "bdb2e9b84f9146dadb1556dd6a6ffcfabce66d19";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "eda392e4b8cf82f7f9b55f9e9f923c9dd70d2677";
+      rev = "bdb2e9b84f9146dadb1556dd6a6ffcfabce66d19";
       fetchSubmodules = false;
-      sha256 = "sha256-/Hs3gz05EpiR6FE+ZxCbBTBaCZvfGYpqNGnGHWhkIxs=";
+      sha256 = "sha256-g65WwClvsi3wNtp5U4cIt5Mf38zyZeaVo+QTGau+o18=";
     };
-    date = "2026-06-06";
+    date = "2026-06-12";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780679734,
-        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
+        "lastModified": 1781365335,
+        "narHash": "sha256-zqDBhXMzfbdlO7F2bGHe7MOtB3xngd/+4ieMHDC+ZXo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
+        "rev": "5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c",
         "type": "github"
       },
       "original": {
@@ -552,11 +552,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1780210899,
-        "narHash": "sha256-4axz3OBPTKa6LIkXV8n0lc63MQU+et2CB5DGobEAi6k=",
+        "lastModified": 1780816331,
+        "narHash": "sha256-0BYqs8yKWkOz2Q7+SP18N5E5gmDKSo6LSxIVIa0wWes=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "97df9dc0b7c924344b793a15c1e8e4522ebb854e",
+        "rev": "1a2ea89c917781e88508d9fd2b507f2d2a0e173c",
         "type": "github"
       },
       "original": {
@@ -573,11 +573,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1780719019,
-        "narHash": "sha256-DZCJn3xaUSztvxw8xtbRSBxRQRzAoWvzGFAc0NLZdjw=",
+        "lastModified": 1781263587,
+        "narHash": "sha256-OEolpy/XeA/AL96vsHn024N06qQZJRicscWUu02YWWc=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "efe7a04bb221089e7ecb0b663441afc2a40eb02d",
+        "rev": "b3ca1861ed232b6ec732d63307e986f90334eb9b",
         "type": "github"
       },
       "original": {
@@ -688,11 +688,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -720,11 +720,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {
@@ -736,11 +736,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {
@@ -772,11 +772,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1780766476,
-        "narHash": "sha256-BlI1qrW7wqI+pniqRebMttqN/w0H6XHqITGB9JPSQNQ=",
+        "lastModified": 1781372494,
+        "narHash": "sha256-PoTZ0y0CQFtjcmzrbTCSMeg+pN7d+EXpLvOyjVS61OA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "050c04c7c01ad5de7e60f32b66ce0599e3c17d8e",
+        "rev": "340c1c2882342248ae7111706aca7a9bc305ff85",
         "type": "github"
       },
       "original": {
@@ -930,11 +930,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1780422259,
-        "narHash": "sha256-dWGk4SEdI189kQW5cE4Uo1Mc+P+kQEdgMcyMgTtmQOA=",
+        "lastModified": 1781101834,
+        "narHash": "sha256-gNVY6SYglFe37FpD+NnOjTipsqvVMM2vh/uc22KDEsA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "8414bbf2fcc7bc0a22c675e498e3c7365c1aec0a",
+        "rev": "0243dd6707c969fc8440216c811b3f2e4a4cceb7",
         "type": "github"
       },
       "original": {
@@ -961,11 +961,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1780701809,
-        "narHash": "sha256-u7AUNs6U6eD1os4+ghbr1gH4QjPWzOdKvpeM+E+XRKM=",
+        "lastModified": 1781018772,
+        "narHash": "sha256-C+cGIUaC6dqfwTbI+BwCd572PbESGA3WYxR1sLTqxkY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3a02d9f73608641b28e08b26acb0b0b47c05f14b",
+        "rev": "a378e4c09031fb15a4d65da88aa628f71fc52f6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 24

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/b2b7db486e06e098711dc291bb25db82850e1d16' (2026-06-05)
  → 'github:nix-community/home-manager/5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c' (2026-06-13)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/97df9dc0b7c924344b793a15c1e8e4522ebb854e' (2026-05-31)
  → 'github:nix-community/nix-index-database/1a2ea89c917781e88508d9fd2b507f2d2a0e173c' (2026-06-07)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786' (2026-05-23)
  → 'github:NixOS/nixpkgs/331800de5053fcebacf6813adb5db9c9dca22a0c' (2026-05-31)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/efe7a04bb221089e7ecb0b663441afc2a40eb02d' (2026-06-06)
  → 'github:nix-community/nix4vscode/b3ca1861ed232b6ec732d63307e986f90334eb9b' (2026-06-12)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/331800de5053fcebacf6813adb5db9c9dca22a0c' (2026-05-31)
  → 'github:NixOS/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca' (2026-06-10)
• Updated input 'nur':
    'github:nix-community/NUR/050c04c7c01ad5de7e60f32b66ce0599e3c17d8e' (2026-06-06)
  → 'github:nix-community/NUR/340c1c2882342248ae7111706aca7a9bc305ff85' (2026-06-13)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/331800de5053fcebacf6813adb5db9c9dca22a0c' (2026-05-31)
  → 'github:nixos/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca' (2026-06-10)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/8414bbf2fcc7bc0a22c675e498e3c7365c1aec0a' (2026-06-02)
  → 'github:Gerg-L/spicetify-nix/0243dd6707c969fc8440216c811b3f2e4a4cceb7' (2026-06-10)
• Updated input 'stylix':
    'github:danth/stylix/3a02d9f73608641b28e08b26acb0b0b47c05f14b' (2026-06-05)
  → 'github:danth/stylix/a378e4c09031fb15a4d65da88aa628f71fc52f6b' (2026-06-09)
```

Sources Changelog:
```
nix-fast-build: eda392e4b8cf82f7f9b55f9e9f923c9dd70d2677 → bdb2e9b84f9146dadb1556dd6a6ffcfabce66d19
```
