### PR TITLE
chore: update flake.lock & sources (2026-06-20)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,11 +40,11 @@ jobs:
       id: build
       run: |
         nix develop .#ci --command bash -euo pipefail <<'OUTER'
-        nix-build-all --systems x86_64-linux --override-input flake . --out-link newFlake --cachix-cache spearman4157
+        nix-build-all --systems x86_64-linux --override-input flake . --out-link newFlake
         nix-build-all --systems x86_64-linux --override-input flake github:${{ github.repository }} --out-link oldFlake
-        ls
         mv newFlake- newFlake
         mv oldFlake- oldFlake
+        realpath newFlake | cachix push
         OUTER
 
     - name: "Diff Profile Closures"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,6 +42,7 @@ jobs:
         nix develop .#ci --command bash -euo pipefail <<'OUTER'
         nix-build-all --systems x86_64-linux --override-input flake . --out-link newFlake --cachix-cache spearman4157
         nix-build-all --systems x86_64-linux --override-input flake github:${{ github.repository }} --out-link oldFlake
+        ls
         mv newFlake- newFlake
         mv oldFlake- oldFlake
         OUTER

--- a/Users/WickedWizard/Programs/Browsers/librewolf.nix
+++ b/Users/WickedWizard/Programs/Browsers/librewolf.nix
@@ -1,21 +1,12 @@
 {
-  config,
   config',
   lib,
   ...
 }:
 {
-  programs.librewolf = {
-    enable = true;
-    settings = {
-      "privacy.resistFingerprinting.letterboxing" = true;
-      "network.http.referer.XOriginPolicy" = 2;
-      "privacy.clearOnShutdown.history" = false;
-      "privacy.clearOnShutdown.downloads" = false;
-    };
-  };
+  services.flatpak.packages = [ "io.gitlab.librewolf-community" ];
 
-  home.file.".librewolf/profiles.ini".text = ''
+  home.file.".var/app/io.gitlab.librewolf-community/profiles.ini".text = ''
     [Profile0]
     Name=Default
     IsRelative=0
@@ -26,7 +17,7 @@
     Version=2
   '';
 
-  programs.autostart.packages = [ config.programs.librewolf.package ];
+  programs.autostart.flatpaks = [ "io.gitlab.librewolf-community" ];
 
   wayland.windowManager.hyprland.settings = {
     bind = [

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-06-12",
+        "date": "2026-06-18",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,16 +118,16 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "bdb2e9b84f9146dadb1556dd6a6ffcfabce66d19",
-            "sha256": "sha256-g65WwClvsi3wNtp5U4cIt5Mf38zyZeaVo+QTGau+o18=",
+            "rev": "1a6fda534f88e82420cbbaa781b9db9f9fc66c6d",
+            "sha256": "sha256-8iwszBEigYqIU4jIZ8gB31SRLnQ/OBZ5CNiVq/Q3wgY=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "bdb2e9b84f9146dadb1556dd6a6ffcfabce66d19"
+        "version": "1a6fda534f88e82420cbbaa781b9db9f9fc66c6d"
     },
     "obs_catppuccin": {
         "cargoLock": null,
-        "date": "2026-04-05",
+        "date": "2026-06-18",
         "extract": null,
         "name": "obs_catppuccin",
         "passthru": null,
@@ -139,12 +139,12 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "obs",
-            "rev": "94d317949c0f4c3e55b8ccc7f16890ce7ba3fc37",
-            "sha256": "sha256-Eb9P4ZWRHy0KjysWgL4F6jOq21yCl8E/hT+eZhTO/pA=",
+            "rev": "d70e36b0074d535e82c3e8f09a9fe0db662bc056",
+            "sha256": "sha256-jUXdfXXKjxgN7XDkIqCLWigjcyiwnoZJCF69d9s1PRs=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "94d317949c0f4c3e55b8ccc7f16890ce7ba3fc37"
+        "version": "d70e36b0074d535e82c3e8f09a9fe0db662bc056"
     },
     "prismlauncher_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,27 +67,27 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "bdb2e9b84f9146dadb1556dd6a6ffcfabce66d19";
+    version = "1a6fda534f88e82420cbbaa781b9db9f9fc66c6d";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "bdb2e9b84f9146dadb1556dd6a6ffcfabce66d19";
+      rev = "1a6fda534f88e82420cbbaa781b9db9f9fc66c6d";
       fetchSubmodules = false;
-      sha256 = "sha256-g65WwClvsi3wNtp5U4cIt5Mf38zyZeaVo+QTGau+o18=";
+      sha256 = "sha256-8iwszBEigYqIU4jIZ8gB31SRLnQ/OBZ5CNiVq/Q3wgY=";
     };
-    date = "2026-06-12";
+    date = "2026-06-18";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";
-    version = "94d317949c0f4c3e55b8ccc7f16890ce7ba3fc37";
+    version = "d70e36b0074d535e82c3e8f09a9fe0db662bc056";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "obs";
-      rev = "94d317949c0f4c3e55b8ccc7f16890ce7ba3fc37";
+      rev = "d70e36b0074d535e82c3e8f09a9fe0db662bc056";
       fetchSubmodules = false;
-      sha256 = "sha256-Eb9P4ZWRHy0KjysWgL4F6jOq21yCl8E/hT+eZhTO/pA=";
+      sha256 = "sha256-jUXdfXXKjxgN7XDkIqCLWigjcyiwnoZJCF69d9s1PRs=";
     };
-    date = "2026-04-05";
+    date = "2026-06-18";
   };
   prismlauncher_catppuccin = {
     pname = "prismlauncher_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -333,11 +333,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781365335,
-        "narHash": "sha256-zqDBhXMzfbdlO7F2bGHe7MOtB3xngd/+4ieMHDC+ZXo=",
+        "lastModified": 1781977139,
+        "narHash": "sha256-ClDkeNbPMZdWMHDt8hEyONNcXCTwMYuwf+DKOMPpCsg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c",
+        "rev": "a4ee5403cafbc708ad0f0d585965f1931ec340a8",
         "type": "github"
       },
       "original": {
@@ -552,11 +552,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1780816331,
-        "narHash": "sha256-0BYqs8yKWkOz2Q7+SP18N5E5gmDKSo6LSxIVIa0wWes=",
+        "lastModified": 1781422160,
+        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "1a2ea89c917781e88508d9fd2b507f2d2a0e173c",
+        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
         "type": "github"
       },
       "original": {
@@ -573,11 +573,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1781263587,
-        "narHash": "sha256-OEolpy/XeA/AL96vsHn024N06qQZJRicscWUu02YWWc=",
+        "lastModified": 1781929357,
+        "narHash": "sha256-M1j+Ma/6flPHhGkgM5O4BqEvzmBeCcGldbQlVUDFwwI=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "b3ca1861ed232b6ec732d63307e986f90334eb9b",
+        "rev": "031868e8376184830b736763879ef377609bf099",
         "type": "github"
       },
       "original": {
@@ -688,11 +688,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {
@@ -720,11 +720,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -736,11 +736,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -772,11 +772,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1781372494,
-        "narHash": "sha256-PoTZ0y0CQFtjcmzrbTCSMeg+pN7d+EXpLvOyjVS61OA=",
+        "lastModified": 1781977526,
+        "narHash": "sha256-vykAfcGYiARNvhi5hj0vJNhUWvzhTOFBMI9edLVV3pk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "340c1c2882342248ae7111706aca7a9bc305ff85",
+        "rev": "10ef8169586f79788662c8a75b8f8b0cf667a4b7",
         "type": "github"
       },
       "original": {
@@ -930,11 +930,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1781101834,
-        "narHash": "sha256-gNVY6SYglFe37FpD+NnOjTipsqvVMM2vh/uc22KDEsA=",
+        "lastModified": 1781425310,
+        "narHash": "sha256-GTBka4Df/ZOacmisI/DI2LICyNChEqn/giah83LucdM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "0243dd6707c969fc8440216c811b3f2e4a4cceb7",
+        "rev": "aeaf7c81a45d3761da61cb05bfc370ac6d1b0441",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -95,11 +95,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1765145449,
-        "narHash": "sha256-aBVHGWWRzSpfL++LubA0CwOOQ64WNLegrYHwsVuVN7A=",
+        "lastModified": 1781825982,
+        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "69f538cdce5955fcd47abfed4395dc6d5194c1c5",
+        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
         "type": "github"
       },
       "original": {
@@ -201,15 +201,15 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1761588595,
-        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -517,16 +517,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1765382359,
-        "narHash": "sha256-RJmgVDzjRI18BWVogG6wpsl1UCuV6ui8qr4DJ1LfWZ8=",
+        "lastModified": 1782141370,
+        "narHash": "sha256-hqijVSEETttmo8Okql9/LG0Ua34hdciKW1a5zzlj8mU=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e8c096ade12ec9130ff931b0f0e25d2f1bc63607",
+        "rev": "7c9a54a7f87b4539ddbd8bda09a8a5f5f9361aa9",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "v1.0.0",
+        "ref": "v1.1.0",
         "repo": "lanzaboote",
         "type": "github"
       }
@@ -843,11 +843,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765016596,
-        "narHash": "sha256-rhSqPNxDVow7OQKi4qS5H8Au0P4S3AYbawBSmJNUtBQ=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "548fc44fca28a5e81c5d6b846e555e6b9c2a5a3c",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -888,11 +888,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765075567,
-        "narHash": "sha256-KFDCdQcHJ0hE3Nt5Gm5enRIhmtEifAjpxgUQ3mzSJpA=",
+        "lastModified": 1782012058,
+        "narHash": "sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "769156779b41e8787a46ca3d7d76443aaf68be6f",
+        "rev": "8534567325bd8a8d2928e6afd81e0a87d19efd3c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@
     # Require manual updates, nix flake update will not work.
     # We don't really want it to work either.
     lanzaboote = {
-      url = "github:nix-community/lanzaboote/v1.0.0";
+      url = "github:nix-community/lanzaboote/v1.1.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
Automated Pull Request for Week 25

Flakes Changelog:
```
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a' (2026-05-11)
  → 'github:cachix/git-hooks.nix/3bbec39bc90eadfa031e6f3b77272f3f60803e39' (2026-06-17)
• Updated input 'home-manager':
    'github:nix-community/home-manager/5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c' (2026-06-13)
  → 'github:nix-community/home-manager/a4ee5403cafbc708ad0f0d585965f1931ec340a8' (2026-06-20)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/1a2ea89c917781e88508d9fd2b507f2d2a0e173c' (2026-06-07)
  → 'github:nix-community/nix-index-database/854d04e2368fb2e9c328a36b3c0a04cd713bfae1' (2026-06-14)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/331800de5053fcebacf6813adb5db9c9dca22a0c' (2026-05-31)
  → 'github:NixOS/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca' (2026-06-10)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/b3ca1861ed232b6ec732d63307e986f90334eb9b' (2026-06-12)
  → 'github:nix-community/nix4vscode/031868e8376184830b736763879ef377609bf099' (2026-06-20)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca' (2026-06-10)
  → 'github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f' (2026-06-16)
• Updated input 'nur':
    'github:nix-community/NUR/340c1c2882342248ae7111706aca7a9bc305ff85' (2026-06-13)
  → 'github:nix-community/NUR/10ef8169586f79788662c8a75b8f8b0cf667a4b7' (2026-06-20)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca' (2026-06-10)
  → 'github:nixos/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f' (2026-06-16)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/0243dd6707c969fc8440216c811b3f2e4a4cceb7' (2026-06-10)
  → 'github:Gerg-L/spicetify-nix/aeaf7c81a45d3761da61cb05bfc370ac6d1b0441' (2026-06-14)
```

Sources Changelog:
```
obs_catppuccin: 94d317949c0f4c3e55b8ccc7f16890ce7ba3fc37 → d70e36b0074d535e82c3e8f09a9fe0db662bc056
nix-fast-build: bdb2e9b84f9146dadb1556dd6a6ffcfabce66d19 → 1a6fda534f88e82420cbbaa781b9db9f9fc66c6d
```
