### PR TITLE
chore: update flake.lock & sources (2026-06-27)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,6 @@ jobs:
         nix develop .#ci --command bash -euo pipefail <<'OUTER'
         nix-build-all --systems x86_64-linux --override-input flake . --out-link newFlake --cachix-cache spearman4157
         nix-build-all --systems x86_64-linux --override-input flake github:${{ github.repository }} --out-link oldFlake
-        ls
         mv newFlake- newFlake
         mv oldFlake- oldFlake
         OUTER

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,11 +40,11 @@ jobs:
       id: build
       run: |
         nix develop .#ci --command bash -euo pipefail <<'OUTER'
-        nix-build-all --systems x86_64-linux --override-input flake . --out-link newFlake
+        nix-build-all --systems x86_64-linux --override-input flake . --out-link newFlake --cachix-cache spearman4157
         nix-build-all --systems x86_64-linux --override-input flake github:${{ github.repository }} --out-link oldFlake
+        ls
         mv newFlake- newFlake
         mv oldFlake- oldFlake
-        realpath newFlake | cachix push
         OUTER
 
     - name: "Diff Profile Closures"

--- a/Shells/ci.nix
+++ b/Shells/ci.nix
@@ -17,7 +17,6 @@
         name = "nix-build-all";
         text = ''
           nix-fast-build \
-            --skip-cached \
             --flake ${inputs.devour-flake}#packages.${pkgs.stdenv.hostPlatform.system}.default \
             --no-nom \
             "$@"

--- a/Users/WickedWizard/Programs/Shell/fastfetch.nix
+++ b/Users/WickedWizard/Programs/Shell/fastfetch.nix
@@ -11,5 +11,6 @@
     fastfetch
   '';
 
-  xdg.configFile."fastfetch/config.jsonc".source = "${pkgs.fastfetch.src}/presets/examples/7.jsonc";
+  xdg.configFile."fastfetch/config.jsonc".source =
+    "${pkgs.fastfetch-unwrapped.src}/presets/examples/7.jsonc";
 }

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-06-18",
+        "date": "2026-06-27",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,16 +118,16 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "1a6fda534f88e82420cbbaa781b9db9f9fc66c6d",
-            "sha256": "sha256-8iwszBEigYqIU4jIZ8gB31SRLnQ/OBZ5CNiVq/Q3wgY=",
+            "rev": "c632a8b5acec04c929d521cf1d0af5707e11b9e3",
+            "sha256": "sha256-Mwowugw1fYT10OPipRy9Xg7v4juvR/se5flIThpYU8A=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "1a6fda534f88e82420cbbaa781b9db9f9fc66c6d"
+        "version": "c632a8b5acec04c929d521cf1d0af5707e11b9e3"
     },
     "obs_catppuccin": {
         "cargoLock": null,
-        "date": "2026-06-18",
+        "date": "2026-06-20",
         "extract": null,
         "name": "obs_catppuccin",
         "passthru": null,
@@ -139,12 +139,12 @@
             "name": null,
             "owner": "catppuccin",
             "repo": "obs",
-            "rev": "d70e36b0074d535e82c3e8f09a9fe0db662bc056",
-            "sha256": "sha256-jUXdfXXKjxgN7XDkIqCLWigjcyiwnoZJCF69d9s1PRs=",
+            "rev": "054a297d303a5bac4f1652a13b17d78a13201c0e",
+            "sha256": "sha256-zFg7dgxLIK3K1KpLdEgphH2JpdMwVTovr+oKiAqdLEE=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "d70e36b0074d535e82c3e8f09a9fe0db662bc056"
+        "version": "054a297d303a5bac4f1652a13b17d78a13201c0e"
     },
     "prismlauncher_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,27 +67,27 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "1a6fda534f88e82420cbbaa781b9db9f9fc66c6d";
+    version = "c632a8b5acec04c929d521cf1d0af5707e11b9e3";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "1a6fda534f88e82420cbbaa781b9db9f9fc66c6d";
+      rev = "c632a8b5acec04c929d521cf1d0af5707e11b9e3";
       fetchSubmodules = false;
-      sha256 = "sha256-8iwszBEigYqIU4jIZ8gB31SRLnQ/OBZ5CNiVq/Q3wgY=";
+      sha256 = "sha256-Mwowugw1fYT10OPipRy9Xg7v4juvR/se5flIThpYU8A=";
     };
-    date = "2026-06-18";
+    date = "2026-06-27";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";
-    version = "d70e36b0074d535e82c3e8f09a9fe0db662bc056";
+    version = "054a297d303a5bac4f1652a13b17d78a13201c0e";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "obs";
-      rev = "d70e36b0074d535e82c3e8f09a9fe0db662bc056";
+      rev = "054a297d303a5bac4f1652a13b17d78a13201c0e";
       fetchSubmodules = false;
-      sha256 = "sha256-jUXdfXXKjxgN7XDkIqCLWigjcyiwnoZJCF69d9s1PRs=";
+      sha256 = "sha256-zFg7dgxLIK3K1KpLdEgphH2JpdMwVTovr+oKiAqdLEE=";
     };
-    date = "2026-06-18";
+    date = "2026-06-20";
   };
   prismlauncher_catppuccin = {
     pname = "prismlauncher_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781977139,
-        "narHash": "sha256-ClDkeNbPMZdWMHDt8hEyONNcXCTwMYuwf+DKOMPpCsg=",
+        "lastModified": 1782522538,
+        "narHash": "sha256-CvOaUvJ+mXlxU3m2cPWKcOAhtKETsPUYhq+Xa5ewBp4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a4ee5403cafbc708ad0f0d585965f1931ec340a8",
+        "rev": "8d8a6cc50ddc60748791a14ee1163c865ec57635",
         "type": "github"
       },
       "original": {
@@ -552,11 +552,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1781422160,
-        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
+        "lastModified": 1782030356,
+        "narHash": "sha256-h4WpMr455AfRub0FXBaon6Vcpe0waUyJ4GivIW6oyd4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
+        "rev": "3017088b49efd404f78e3b104f553b97e4af786b",
         "type": "github"
       },
       "original": {
@@ -573,11 +573,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1781929357,
-        "narHash": "sha256-M1j+Ma/6flPHhGkgM5O4BqEvzmBeCcGldbQlVUDFwwI=",
+        "lastModified": 1782533316,
+        "narHash": "sha256-8ms94YUo0yADGNNqns2KJTwW3nYvmWjHeaUJ/Cqm2X4=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "031868e8376184830b736763879ef377609bf099",
+        "rev": "2a10a2edad74b9eae5048231726f0b22bccdaffa",
         "type": "github"
       },
       "original": {
@@ -688,11 +688,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -720,11 +720,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {
@@ -736,11 +736,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {
@@ -772,11 +772,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1781977526,
-        "narHash": "sha256-vykAfcGYiARNvhi5hj0vJNhUWvzhTOFBMI9edLVV3pk=",
+        "lastModified": 1782580988,
+        "narHash": "sha256-ep3Sq+flyyzKwliP86B4I++Uu1nyyBvFTZH/lPaes/4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "10ef8169586f79788662c8a75b8f8b0cf667a4b7",
+        "rev": "2a8a5f7e6366c532790fdcbe761ae2bdee8b1ca4",
         "type": "github"
       },
       "original": {
@@ -930,11 +930,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1781425310,
-        "narHash": "sha256-GTBka4Df/ZOacmisI/DI2LICyNChEqn/giah83LucdM=",
+        "lastModified": 1782031037,
+        "narHash": "sha256-a7oWSyS7SN81UOqVt481yIEMDsMpaJ7GNdV6Eaz5Yqg=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "aeaf7c81a45d3761da61cb05bfc370ac6d1b0441",
+        "rev": "9cb27462cfd20edac174353f1e95bc03aa888863",
         "type": "github"
       },
       "original": {
@@ -961,11 +961,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1781018772,
-        "narHash": "sha256-C+cGIUaC6dqfwTbI+BwCd572PbESGA3WYxR1sLTqxkY=",
+        "lastModified": 1782310521,
+        "narHash": "sha256-vsxcG0i8e4EPfdnhMTKMVzD1825H2vG1BBslzom9wxg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a378e4c09031fb15a4d65da88aa628f71fc52f6b",
+        "rev": "e084d011e7ee9302aceaaf6c1fc28a9ace09e16a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 26

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/a4ee5403cafbc708ad0f0d585965f1931ec340a8' (2026-06-20)
  → 'github:nix-community/home-manager/8d8a6cc50ddc60748791a14ee1163c865ec57635' (2026-06-27)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/854d04e2368fb2e9c328a36b3c0a04cd713bfae1' (2026-06-14)
  → 'github:nix-community/nix-index-database/3017088b49efd404f78e3b104f553b97e4af786b' (2026-06-21)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca' (2026-06-10)
  → 'github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f' (2026-06-16)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/031868e8376184830b736763879ef377609bf099' (2026-06-20)
  → 'github:nix-community/nix4vscode/2a10a2edad74b9eae5048231726f0b22bccdaffa' (2026-06-27)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f' (2026-06-16)
  → 'github:NixOS/nixpkgs/e73de5be04e0eff4190a1432b946d469c794e7b4' (2026-06-26)
• Updated input 'nur':
    'github:nix-community/NUR/10ef8169586f79788662c8a75b8f8b0cf667a4b7' (2026-06-20)
  → 'github:nix-community/NUR/2a8a5f7e6366c532790fdcbe761ae2bdee8b1ca4' (2026-06-27)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f' (2026-06-16)
  → 'github:nixos/nixpkgs/e73de5be04e0eff4190a1432b946d469c794e7b4' (2026-06-26)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/aeaf7c81a45d3761da61cb05bfc370ac6d1b0441' (2026-06-14)
  → 'github:Gerg-L/spicetify-nix/9cb27462cfd20edac174353f1e95bc03aa888863' (2026-06-21)
• Updated input 'stylix':
    'github:danth/stylix/a378e4c09031fb15a4d65da88aa628f71fc52f6b' (2026-06-09)
  → 'github:danth/stylix/e084d011e7ee9302aceaaf6c1fc28a9ace09e16a' (2026-06-24)
```

Sources Changelog:
```
nix-fast-build: 1a6fda534f88e82420cbbaa781b9db9f9fc66c6d → c632a8b5acec04c929d521cf1d0af5707e11b9e3
obs_catppuccin: d70e36b0074d535e82c3e8f09a9fe0db662bc056 → 054a297d303a5bac4f1652a13b17d78a13201c0e
```
