### PR TITLE
chore: update flake.lock & sources (2026-07-04)

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-06-27",
+        "date": "2026-07-04",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "c632a8b5acec04c929d521cf1d0af5707e11b9e3",
-            "sha256": "sha256-Mwowugw1fYT10OPipRy9Xg7v4juvR/se5flIThpYU8A=",
+            "rev": "03b5e3d352f1c1439f5f4f50ae62b6c32c87a625",
+            "sha256": "sha256-lG05oSx3yY03MHB5ER0BRJF6yPe8g/ntCKQ0o1OaTjE=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "c632a8b5acec04c929d521cf1d0af5707e11b9e3"
+        "version": "03b5e3d352f1c1439f5f4f50ae62b6c32c87a625"
     },
     "obs_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "c632a8b5acec04c929d521cf1d0af5707e11b9e3";
+    version = "03b5e3d352f1c1439f5f4f50ae62b6c32c87a625";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "c632a8b5acec04c929d521cf1d0af5707e11b9e3";
+      rev = "03b5e3d352f1c1439f5f4f50ae62b6c32c87a625";
       fetchSubmodules = false;
-      sha256 = "sha256-Mwowugw1fYT10OPipRy9Xg7v4juvR/se5flIThpYU8A=";
+      sha256 = "sha256-lG05oSx3yY03MHB5ER0BRJF6yPe8g/ntCKQ0o1OaTjE=";
     };
-    date = "2026-06-27";
+    date = "2026-07-04";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -235,11 +235,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -327,17 +327,16 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
@@ -347,27 +346,6 @@
       }
     },
     "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_2": {
       "inputs": {
         "nixpkgs": [
           "lanzaboote",
@@ -413,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782522538,
-        "narHash": "sha256-CvOaUvJ+mXlxU3m2cPWKcOAhtKETsPUYhq+Xa5ewBp4=",
+        "lastModified": 1783134515,
+        "narHash": "sha256-qMoZazubXlXUD9k/syJ/aiWC4X4g73mwVmZ7Z4+rdpM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8d8a6cc50ddc60748791a14ee1163c865ec57635",
+        "rev": "b885baad531fa3d3beae2ba9a0712d22974d8016",
         "type": "github"
       },
       "original": {
@@ -552,11 +530,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1782030356,
-        "narHash": "sha256-h4WpMr455AfRub0FXBaon6Vcpe0waUyJ4GivIW6oyd4=",
+        "lastModified": 1783023993,
+        "narHash": "sha256-gaOvvY/lL1eWoSmSRO17pWry8R49AuPMrF4nzu47K5o=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "3017088b49efd404f78e3b104f553b97e4af786b",
+        "rev": "f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074",
         "type": "github"
       },
       "original": {
@@ -573,11 +551,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1782533316,
-        "narHash": "sha256-8ms94YUo0yADGNNqns2KJTwW3nYvmWjHeaUJ/Cqm2X4=",
+        "lastModified": 1783136999,
+        "narHash": "sha256-RplSaIR6vI/Oycf8/y+c/5gj7DBA2YdBgSoMlhm8jVY=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "2a10a2edad74b9eae5048231726f0b22bccdaffa",
+        "rev": "520498e2dbf8e1a13fd1df84ffcbdc54dc1acf17",
         "type": "github"
       },
       "original": {
@@ -625,11 +603,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -688,11 +666,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
@@ -720,11 +698,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
         "type": "github"
       },
       "original": {
@@ -736,11 +714,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
         "type": "github"
       },
       "original": {
@@ -772,11 +750,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1782580988,
-        "narHash": "sha256-ep3Sq+flyyzKwliP86B4I++Uu1nyyBvFTZH/lPaes/4=",
+        "lastModified": 1783186157,
+        "narHash": "sha256-C4x+plPVSWjJNLA9RXfX6jO1JlTvrfrQENpu3ouAPzc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a8a5f7e6366c532790fdcbe761ae2bdee8b1ca4",
+        "rev": "08f0f43cf7510f3de5ab3a164a77a1587ce9be3a",
         "type": "github"
       },
       "original": {
@@ -836,7 +814,7 @@
     "pre-commit": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "gitignore": "gitignore_2",
+        "gitignore": "gitignore",
         "nixpkgs": [
           "lanzaboote",
           "nixpkgs"
@@ -930,11 +908,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1782031037,
-        "narHash": "sha256-a7oWSyS7SN81UOqVt481yIEMDsMpaJ7GNdV6Eaz5Yqg=",
+        "lastModified": 1782898510,
+        "narHash": "sha256-7QVN7ijsXbIBRrI9LdXfeoFktTS0I6HZya9tu6+STrs=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "9cb27462cfd20edac174353f1e95bc03aa888863",
+        "rev": "9cabea6f5973ec01f60080ea50f54f8f6d74dc95",
         "type": "github"
       },
       "original": {
@@ -961,11 +939,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1782310521,
-        "narHash": "sha256-vsxcG0i8e4EPfdnhMTKMVzD1825H2vG1BBslzom9wxg=",
+        "lastModified": 1783101802,
+        "narHash": "sha256-/Ti+wDco0f3C9s94RxyBKJyc0BklwYh0a/jFWKeHNYw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e084d011e7ee9302aceaaf6c1fc28a9ace09e16a",
+        "rev": "718c14e8ecba215a65ff955c187fadb9732ddd01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated Pull Request for Week 27

Flakes Changelog:
```
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb' (2026-05-13)
  → 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e' (2026-07-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/f5901329dade4a6ea039af1433fb087bd9c1fe14' (2026-04-26)
  → 'github:nix-community/nixpkgs.lib/db3f255737b94216eb71cce308e2912cf6bc2d7c' (2026-06-28)
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/3bbec39bc90eadfa031e6f3b77272f3f60803e39' (2026-06-17)
  → 'github:cachix/git-hooks.nix/bca82caa46d5ec0f5d422c61fb1e30bc51313cbe' (2026-07-02)
• Updated input 'home-manager':
    'github:nix-community/home-manager/8d8a6cc50ddc60748791a14ee1163c865ec57635' (2026-06-27)
  → 'github:nix-community/home-manager/b885baad531fa3d3beae2ba9a0712d22974d8016' (2026-07-04)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/3017088b49efd404f78e3b104f553b97e4af786b' (2026-06-21)
  → 'github:nix-community/nix-index-database/f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074' (2026-07-02)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f' (2026-06-16)
  → 'github:NixOS/nixpkgs/b5aa0fbd538984f6e3d201be0005b4463d8b09f8' (2026-06-29)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/2a10a2edad74b9eae5048231726f0b22bccdaffa' (2026-06-27)
  → 'github:nix-community/nix4vscode/520498e2dbf8e1a13fd1df84ffcbdc54dc1acf17' (2026-07-04)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/e73de5be04e0eff4190a1432b946d469c794e7b4' (2026-06-26)
  → 'github:NixOS/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0' (2026-07-02)
• Updated input 'nur':
    'github:nix-community/NUR/2a8a5f7e6366c532790fdcbe761ae2bdee8b1ca4' (2026-06-27)
  → 'github:nix-community/NUR/08f0f43cf7510f3de5ab3a164a77a1587ce9be3a' (2026-07-04)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/e73de5be04e0eff4190a1432b946d469c794e7b4' (2026-06-26)
  → 'github:nixos/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0' (2026-07-02)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/9cb27462cfd20edac174353f1e95bc03aa888863' (2026-06-21)
  → 'github:Gerg-L/spicetify-nix/9cabea6f5973ec01f60080ea50f54f8f6d74dc95' (2026-07-01)
• Updated input 'stylix':
    'github:danth/stylix/e084d011e7ee9302aceaaf6c1fc28a9ace09e16a' (2026-06-24)
  → 'github:danth/stylix/718c14e8ecba215a65ff955c187fadb9732ddd01' (2026-07-03)
```

Sources Changelog:
```
nix-fast-build: c632a8b5acec04c929d521cf1d0af5707e11b9e3 → 03b5e3d352f1c1439f5f4f50ae62b6c32c87a625
```
