### PR TITLE
chore: update flake.lock & sources (2026-07-11)

### DIFF
--- a/Users/WickedWizard/Programs/Desktop/Theming/cursors.nix
+++ b/Users/WickedWizard/Programs/Desktop/Theming/cursors.nix
@@ -9,6 +9,7 @@
     size = 32;
   };
 
+  home.pointerCursor.enable = true;
   # Should be done by stylix itself. danth/stylix#478
   home.pointerCursor.hyprcursor.enable = true;
 

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -106,7 +106,7 @@
     },
     "nix-fast-build": {
         "cargoLock": null,
-        "date": "2026-07-04",
+        "date": "2026-07-05",
         "extract": null,
         "name": "nix-fast-build",
         "passthru": null,
@@ -118,12 +118,12 @@
             "name": null,
             "owner": "Mic92",
             "repo": "nix-fast-build",
-            "rev": "03b5e3d352f1c1439f5f4f50ae62b6c32c87a625",
-            "sha256": "sha256-lG05oSx3yY03MHB5ER0BRJF6yPe8g/ntCKQ0o1OaTjE=",
+            "rev": "561be51b96d376c9c6c49a063cfdc83af81f4929",
+            "sha256": "sha256-9Fs2vjIdTaQQYPUsvU99X5f9cl8qkzT1dUgIC4A8A1M=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "03b5e3d352f1c1439f5f4f50ae62b6c32c87a625"
+        "version": "561be51b96d376c9c6c49a063cfdc83af81f4929"
     },
     "obs_catppuccin": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -67,15 +67,15 @@
   };
   nix-fast-build = {
     pname = "nix-fast-build";
-    version = "03b5e3d352f1c1439f5f4f50ae62b6c32c87a625";
+    version = "561be51b96d376c9c6c49a063cfdc83af81f4929";
     src = fetchFromGitHub {
       owner = "Mic92";
       repo = "nix-fast-build";
-      rev = "03b5e3d352f1c1439f5f4f50ae62b6c32c87a625";
+      rev = "561be51b96d376c9c6c49a063cfdc83af81f4929";
       fetchSubmodules = false;
-      sha256 = "sha256-lG05oSx3yY03MHB5ER0BRJF6yPe8g/ntCKQ0o1OaTjE=";
+      sha256 = "sha256-9Fs2vjIdTaQQYPUsvU99X5f9cl8qkzT1dUgIC4A8A1M=";
     };
-    date = "2026-07-04";
+    date = "2026-07-05";
   };
   obs_catppuccin = {
     pname = "obs_catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783134515,
-        "narHash": "sha256-qMoZazubXlXUD9k/syJ/aiWC4X4g73mwVmZ7Z4+rdpM=",
+        "lastModified": 1783744526,
+        "narHash": "sha256-yYVxW+uIbCx0Nt870fbErQbz+b2+3Gwpppe+JbIU+Co=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b885baad531fa3d3beae2ba9a0712d22974d8016",
+        "rev": "2afec152df4e284d264f8489d16004c264aebf4c",
         "type": "github"
       },
       "original": {
@@ -530,11 +530,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1783023993,
-        "narHash": "sha256-gaOvvY/lL1eWoSmSRO17pWry8R49AuPMrF4nzu47K5o=",
+        "lastModified": 1783414108,
+        "narHash": "sha256-RY8e+gR2/DhXsYDxGDL6Hhe9+POD9u4+llwxMBqMQDs=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074",
+        "rev": "96d6de10eb281b98f5cfcd1841394c03da5df77c",
         "type": "github"
       },
       "original": {
@@ -551,11 +551,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1783136999,
-        "narHash": "sha256-RplSaIR6vI/Oycf8/y+c/5gj7DBA2YdBgSoMlhm8jVY=",
+        "lastModified": 1783739523,
+        "narHash": "sha256-/oZUJj/USVYEIVh0b4vizFXjaeEJXF5P2srlleya6n4=",
         "owner": "nix-community",
         "repo": "nix4vscode",
-        "rev": "520498e2dbf8e1a13fd1df84ffcbdc54dc1acf17",
+        "rev": "6c615cdf2b78d17ce097a5258a3caa5187d78a62",
         "type": "github"
       },
       "original": {
@@ -666,11 +666,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
         "type": "github"
       },
       "original": {
@@ -698,11 +698,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1782959384,
-        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
         "type": "github"
       },
       "original": {
@@ -714,11 +714,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1782959384,
-        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
         "type": "github"
       },
       "original": {
@@ -750,11 +750,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1783186157,
-        "narHash": "sha256-C4x+plPVSWjJNLA9RXfX6jO1JlTvrfrQENpu3ouAPzc=",
+        "lastModified": 1783790618,
+        "narHash": "sha256-02qMdDNjt39vvoeWL+pjxaGU22gFY72s18QvDezFQgs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08f0f43cf7510f3de5ab3a164a77a1587ce9be3a",
+        "rev": "0352662c18ef8c811cdf5093a27ab17e28af96aa",
         "type": "github"
       },
       "original": {
@@ -798,11 +798,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775856943,
-        "narHash": "sha256-b7Mp7P+q2Md5AGt4rjHfMcBykzMumFTen10ST++AuTU=",
+        "lastModified": 1783574839,
+        "narHash": "sha256-ICof1tV4/9XheBLBGf7dhMhfMq4dOs1zwTHrr7zGFlA=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "a524a6160e6df89f7673ba293cf7d78b559eb1a5",
+        "rev": "c551f0687658e4bb699cfff6015436ad7ee57a0d",
         "type": "github"
       },
       "original": {
@@ -908,11 +908,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1782898510,
-        "narHash": "sha256-7QVN7ijsXbIBRrI9LdXfeoFktTS0I6HZya9tu6+STrs=",
+        "lastModified": 1783713280,
+        "narHash": "sha256-TcDlq7je/KLuwDVpCWBp6hoBqxuhWvatekq8pqPjY60=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "9cabea6f5973ec01f60080ea50f54f8f6d74dc95",
+        "rev": "3fdc209a45ff9b4e95596feb3be1684d9da51735",
         "type": "github"
       },
       "original": {
@@ -939,11 +939,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1783101802,
-        "narHash": "sha256-/Ti+wDco0f3C9s94RxyBKJyc0BklwYh0a/jFWKeHNYw=",
+        "lastModified": 1783358511,
+        "narHash": "sha256-/F85cBWvU8b2hpawuCog464065ZTJtdMgVPWwJ9yHjE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "718c14e8ecba215a65ff955c187fadb9732ddd01",
+        "rev": "14814ef555d8148ab82eba5054e654cd9eae3a1f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -153,7 +153,30 @@
           # Installation hooks need to setup manually in each devshell.
           pre-commit.check.enable = true;
           pre-commit.settings.hooks = {
-            commitizen.enable = true;
+            commitizen = {
+              enable = true;
+              # Fixes commitizen-tools/commitizen#1864
+              # Waiting for NixOS/nixpkgs#539725. Patch taken from there.
+              package = pkgs.commitizen.overrideAttrs (oldAttrs: rec {
+                version = "4.16.4";
+                src = pkgs.fetchFromGitHub {
+                  owner = "commitizen-tools";
+                  repo = "commitizen";
+                  tag = "v${version}";
+                  hash = "sha256-lVc1Kdy/IWRa8uoPZfOSSa379bDDknE3dpm0U7DVv0s=";
+                };
+                postPatch = ''
+                  substituteInPlace pyproject.toml \
+                    --replace-fail "uv_build >= 0.9.17, <0.12" "uv-build"
+                '';
+                makeWrapperArgs = [
+                  "--prefix"
+                  "PATH"
+                  ":"
+                  (lib.makeBinPath [ pkgs.gitMinimal ])
+                ];
+              });
+            };
             nixfmt-rfc-style = {
               enable = true;
               package = pkgs.nixfmt;


### PR DESCRIPTION
Automated Pull Request for Week 28

Flakes Changelog:
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/b885baad531fa3d3beae2ba9a0712d22974d8016' (2026-07-04)
  → 'github:nix-community/home-manager/2afec152df4e284d264f8489d16004c264aebf4c' (2026-07-11)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074' (2026-07-02)
  → 'github:nix-community/nix-index-database/96d6de10eb281b98f5cfcd1841394c03da5df77c' (2026-07-07)
• Updated input 'nix-index-database/nixpkgs':
    'github:NixOS/nixpkgs/b5aa0fbd538984f6e3d201be0005b4463d8b09f8' (2026-06-29)
  → 'github:NixOS/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0' (2026-07-02)
• Updated input 'nix4vscode':
    'github:nix-community/nix4vscode/520498e2dbf8e1a13fd1df84ffcbdc54dc1acf17' (2026-07-04)
  → 'github:nix-community/nix4vscode/6c615cdf2b78d17ce097a5258a3caa5187d78a62' (2026-07-11)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0' (2026-07-02)
  → 'github:NixOS/nixpkgs/0bb7ec54c8483066ec9d7720e780a5caa71f8612' (2026-07-08)
• Updated input 'nur':
    'github:nix-community/NUR/08f0f43cf7510f3de5ab3a164a77a1587ce9be3a' (2026-07-04)
  → 'github:nix-community/NUR/0352662c18ef8c811cdf5093a27ab17e28af96aa' (2026-07-11)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0' (2026-07-02)
  → 'github:nixos/nixpkgs/0bb7ec54c8483066ec9d7720e780a5caa71f8612' (2026-07-08)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/a524a6160e6df89f7673ba293cf7d78b559eb1a5' (2026-04-10)
  → 'github:nix-community/plasma-manager/c551f0687658e4bb699cfff6015436ad7ee57a0d' (2026-07-09)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/9cabea6f5973ec01f60080ea50f54f8f6d74dc95' (2026-07-01)
  → 'github:Gerg-L/spicetify-nix/3fdc209a45ff9b4e95596feb3be1684d9da51735' (2026-07-10)
• Updated input 'stylix':
    'github:danth/stylix/718c14e8ecba215a65ff955c187fadb9732ddd01' (2026-07-03)
  → 'github:danth/stylix/14814ef555d8148ab82eba5054e654cd9eae3a1f' (2026-07-06)
```

Sources Changelog:
```
nix-fast-build: 03b5e3d352f1c1439f5f4f50ae62b6c32c87a625 → 561be51b96d376c9c6c49a063cfdc83af81f4929
```
